### PR TITLE
Changed repo to mgs-workflow in the definition of three paths in index.config to be consistent with the name the repo has.

### DIFF
--- a/configs/index.config
+++ b/configs/index.config
@@ -23,12 +23,12 @@ params {
     taxonomy_url = "https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump_archive/taxdmp_2022-12-01.zip"
 
     // Other reference files
-    contaminants = "${projectDir}/../repo/ref/contaminants.fasta.gz" // FASTA file containing additional "contaminant" sequences to screen out during viral identification
-    virus_db = "${projectDir}/../repo/ref/human-viruses.tsv" // TSV file containing a list of human-infecting virus names and taxids
+    contaminants = "${projectDir}/../mgs-workflow/ref/contaminants.fasta.gz" // FASTA file containing additional "contaminant" sequences to screen out during viral identification
+    virus_db = "${projectDir}/../mgs-workflow/ref/human-viruses.tsv" // TSV file containing a list of human-infecting virus names and taxids
     kraken_db = "s3://genome-idx/kraken/k2_standard_16gb_20221209.tar.gz" // Path to tarball containing Kraken reference DB
 
     // Paths to scripts
-    script_dir = "${projectDir}/../repo/scripts/"
+    script_dir = "${projectDir}/../mgs-workflow/scripts/"
     script_viral_taxa = "${params.script_dir}/make-viral-taxa-db.R"
 }
 
@@ -76,7 +76,7 @@ process{
     // Small multi-core processes
     withLabel: small {
         cpus = 7
-        memory = 15.GB 
+        memory = 15.GB
     }
 
     // Large multi-core processes


### PR DESCRIPTION
My index run choked on these file names. If there is a cleaner fix let me know. I'd assume it would be:
```
repo_dir = "mgs-workflow"
[...]

contaminants = "${projectDir}/../${repo_dir}/ref/contaminants.fasta.gz" // FASTA file containing additional "contaminant" sequences to screen out during viral identification.
```