### PR TITLE
Fixing an issue in count-viral-taxa.R that leads to a loss of HV reads when going from hv_hits_putative_collapsed.tsv to hv_clade_counts.tsv

### DIFF
--- a/bin/count-viral-taxa.R
+++ b/bin/count-viral-taxa.R
@@ -102,7 +102,7 @@ count_hits <- function(read_db, taxid_tree, group_var){
 #============#
 
 # Import data
-read_db <- read_tsv(read_db_path, show_col_types = FALSE) %>% mutate(taxid = as.integer(taxid))
+read_db <- read_tsv(read_db_path, show_col_types = FALSE) %>% mutate(taxid = as.integer(taxid_best))
 taxa_db <- read_tsv(taxa_db_path, show_col_types = FALSE) %>% mutate(taxid = as.integer(taxid))
 
 if (nrow(read_db) > 0){

--- a/bin/count-viral-taxa.R
+++ b/bin/count-viral-taxa.R
@@ -36,12 +36,11 @@ count_children <- function(taxid_tree){
 count_hits_direct <- function(read_db, taxid_tree, group_var){
     # Count number of reads directly assigned to each taxid in a tree
     taxids <- count_children(taxid_tree)
-    direct_hits_setup <- read_db %>% group_by(taxid, .data[[group_var]]) %>%
+    direct_hits_setup <- read_db %>% group_by(taxid_best, .data[[group_var]]) %>%
         count(name="n_reads_direct", .drop=FALSE) %>%
         pivot_wider(names_from=any_of(group_var), values_from=n_reads_direct,
                     values_fill = 0)
-    direct_hits_joined <- taxids %>% left_join(direct_hits_setup, by="taxid")
-    direct_hits <- taxids %>% left_join(direct_hits_setup, by="taxid") %>%
+    direct_hits <- taxids %>% left_join(direct_hits_setup, by=c("taxid" = "taxid_best")) %>%
         pivot_longer(cols=-(taxid:n_children), names_to=group_var,
                      values_to="n_reads_direct") %>%
         mutate(n_reads_direct = replace_na(n_reads_direct, 0))
@@ -102,7 +101,7 @@ count_hits <- function(read_db, taxid_tree, group_var){
 #============#
 
 # Import data
-read_db <- read_tsv(read_db_path, show_col_types = FALSE) %>% mutate(taxid = as.integer(taxid_best))
+read_db <- read_tsv(read_db_path, show_col_types = FALSE) %>% mutate(taxid_best = as.integer(taxid_best))
 taxa_db <- read_tsv(taxa_db_path, show_col_types = FALSE) %>% mutate(taxid = as.integer(taxid))
 
 if (nrow(read_db) > 0){


### PR DESCRIPTION
When reading in `hv_hits_putative_collapsed.tsv` `count-viral-taxa.R`  tries to coerce the column `taxid` to become integer type.

```
read_db <- read_tsv(read_db_path, show_col_types = FALSE) %>% mutate(taxid = as.integer(taxid))
```
This gives a warning:

```
Warning message:
There was 1 warning in `mutate()`.
ℹ In argument: `taxid = as.integer(taxid)`.
Caused by warning:
! NAs introduced by coercion 
```
Rows in `hv_hits_putative_collapsed.tsv`  where this warning is triggered look like the following. The important bit is the value for `taxid`, which contains a “/” character: `166124/627439`.

```
seq_id	sample	genome_id	taxid_best	taxid	best_alignment_score_fwd	best_alignment_score_rev	query_len_fwd	query_seq_fwd	query_len_rev	query_seq_rev	classified	assigned_name	assigned_taxid_best	assigned_taxid	assigned_hv	hit_hv	encoded_hits	adj_score_fwd	adj_score_rev	adj_score_max
SRR14530735.2040293	SRR14530735	FJ415324.1/FJ938067.1	166124	166124/627439	236	255	132	AGACAGTTTTAGGTGAATATGTTTTTGATAAGAGTGAGTTGACTAATGGTGTGTATTATCGCGCCAAAACCACTTACAATATATCTGTAGGAGATGTTTTTGTTTTAACATCTCATTCAGTAGCTAATTTAA	137	TGGTAAGACAGTTTTAGGTGAATATGTTTTTGATAAGAGTGATTTGACTAATGGTGTGTATTATCGCGCCACAACCACTTACAAGCTATCTGTAGGAGATGTTTTTGTTTTAACCTCTCATTCAGTAGCTAATTTAA	0	unclassified	0	0	0	0	0:3 A:34 0:4 2509481:1 0:4 A:52	48.33290470136319	51.8294692284968	51.8294692284968
```
The variable that should likely be used is `taxid_best`, which gets created in [collapseHV](https://github.com/naobservatory/mgs-workflow/blob/master/modules/local/collapseHV/main.nf#L22):
```
taxid_best = taxid[1], taxid = collapse(as.character(taxid)),
```

Ultimately, the inadvertent creation of NAs in the `read_db` dataframe gets propagated to the creation of `direct_hits_setup` in `count-viral-taxa.R`. Once `direct_hits_setup` is left-joined with `taxids`, the NA counts get lost (because there is no NA taxid in taxids).

```
    direct_hits_setup <- read_db %>% group_by(taxid, .data[[group_var]]) %>%
        count(name="n_reads_direct", .drop=FALSE) %>%
        pivot_wider(names_from=any_of(group_var), values_from=n_reads_direct,
                    values_fill = 0)
    sum_direct_hits_setup <- sum(direct_hits_setup[[2]], na.rm = TRUE)
    print(paste("Sum of direct_hits_setup counts:", sum_direct_hits_setup))
    direct_hits <- taxids %>%
        left_join(direct_hits_setup, by = "taxid") %>%
        pivot_longer(
            cols = -(taxid:n_children), names_to = group_var,
            values_to = "n_reads_direct"
        ) %>%
        mutate(n_reads_direct = replace_na(n_reads_direct, 0))
    sum_direct_hits <- sum(direct_hits$n_reads_direct, na.rm = TRUE)
    print(paste("Sum of direct_hits counts:", sum_direct_hits))
```
This leads to the following output (a loss of 25 reads for this sample)
```
[1] "Sum of direct_hits_setup counts: 3487"
[1] "Sum of direct_hits counts: 3462"
```