### PR TITLE
Bug fix in subset reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v2.3.2
+- Fixed subsetReads to run on all reads when the number of reads per sample is below the set threshold.
+
 # v2.3.1
 
 - Clarifications to documentation (in README and elsewhere)


### PR DESCRIPTION
Updated subset reads so that it uses all reads if the number of reads is below the subset threshold set in the nextflow.config file. Solution was copied from @willbradshaw.