### PR TITLE
change error rate

### DIFF
--- a/modules/local/cutadapt/main.nf
+++ b/modules/local/cutadapt/main.nf
@@ -13,14 +13,14 @@ process CUTADAPT {
         -b (-B for R2 read) to trim any adapter in the adapters file from either end of either read
         -j number of cpu cores
         -m to drop a read pair where either element of the pair is <20 bp after trimming
-        -e 0.33 To allow up to a 33% error rate in the matching region between an adapter
+        -e 0.125 To allow up to a 12.5% error rate in the matching region between an adapter
             and the read
         --action=trim to trim adapters and up/downstream sequence
         */
         '''
         output="!{sample}_cutadapt.fastq.gz"
         log="!{sample}_cutadapt_log.txt"
-        par="-b file:!{adapters} -B file:!{adapters} -j !{task.cpus} -m 20 -e 0.33 --action=trim --interleaved"
+        par="-b file:!{adapters} -B file:!{adapters} -j !{task.cpus} -m 20 -e 0.125 --action=trim --interleaved"
         zcat !{reads_interleaved} | cutadapt ${par} - 2> ${log} | gzip -c > ${output}
         ln -s !{reads_interleaved} !{sample}_cutadapt_in.fastq.gz
         '''


### PR DESCRIPTION
cutadapt allowed mismatch rate with adapters 33%->12.5%
note that CUTADAPT_MASK had a pre-existing error rate of 20%; I left this as this process isn't currently used anywhere in pipeline. 