### PR TITLE
Increased memory allocation to EXTRACT_VIRAL_HITS_TO_FASTQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v2.8.1.2-dev
 - Made Cutadapt mismatch rate parameter configurable
 - Fixed issues with BLAST bitscore filtering
+- Increased memory allocation for EXTRACT_VIRAL_HITS_TO_FASTQ
 
 # v2.8.1.1
 - Modified Kraken2 DB handling in index workflow to avoid staging

--- a/modules/local/extractViralHitsToFastq/main.nf
+++ b/modules/local/extractViralHitsToFastq/main.nf
@@ -1,7 +1,7 @@
 // Given a gzipped TSV of viral hits, extract the seq_ids and use them to subseq an interleaved FASTQ file
 process EXTRACT_VIRAL_HITS_TO_FASTQ {
     label "seqtk"
-    label "single"
+    label "single_cpu_16GB_memory"
     input:
         path(hits_tsv)
         path(fastq)


### PR DESCRIPTION
See #233 for discussion.

Module and workflow local tests pass.