### PR TITLE
Add rank-raised taxids to viral taxonomy DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v2.8.3.2-dev
 - Made sure FASTQC could take advantage of its full memory allocation (to avoid OOM errors on long ONT reads)
-- Removed configurable resources for FASTQC_LABELED, and removed a couple of unused QC processes. Added test for FASTQC. 
+- Removed configurable resources for FASTQC_LABELED, and removed a couple of unused QC processes. Added test for FASTQC.
+- Added rank-raised taxids to viral taxonomy DB output by INDEX workflow.
 
 # v2.8.3.1
 - Added `expected-outputs-run.txt` file containing list of expected output files for the `RUN` workflow (excluding BLAST validation).

--- a/modules/local/annotateVirusInfection/resources/usr/bin/annotate-viral-hosts.py
+++ b/modules/local/annotateVirusInfection/resources/usr/bin/annotate-viral-hosts.py
@@ -535,7 +535,8 @@ def main():
                                   hard_exclude_taxids)
     # Write output
     logger.info("Writing output.")
-    output_db.to_csv(args.output_db, sep="\t", index=False)
+    output_db.to_csv(args.output_db, sep="\t", index=False,
+                     na_rep="NA", header=True)
     logger.info("Script complete.")
 
 if __name__ == "__main__":

--- a/modules/local/raiseTaxonomyRanks/main.nf
+++ b/modules/local/raiseTaxonomyRanks/main.nf
@@ -1,0 +1,14 @@
+// Annotate a taxonomic DB with taxids of higher ranks in the taxonomy tree (e.g. species, genus, family)
+process RAISE_TAXONOMY_RANKS {
+    label "single"
+    label "pandas"
+    input:
+        path(taxonomy_db)
+        val(target_ranks)
+    output:
+        path("taxonomy-db-raised.tsv.gz"), emit: db
+    shell:
+        '''
+        raise-taxonomy-ranks.py !{taxonomy_db} "!{target_ranks}" taxonomy-db-raised.tsv.gz
+        '''
+}

--- a/modules/local/raiseTaxonomyRanks/resources/usr/bin/raise-taxonomy-ranks.py
+++ b/modules/local/raiseTaxonomyRanks/resources/usr/bin/raise-taxonomy-ranks.py
@@ -161,7 +161,8 @@ def main():
     logger.info(f"Columns: {taxonomy_db.columns.tolist()}")
     # Write output
     logger.info("Writing output.")
-    taxonomy_db.to_csv(args.output_db, sep="\t", index=False)
+    taxonomy_db.to_csv(args.output_db, sep="\t", index=False,
+                       na_rep="NA", header=True)
     logger.info("Script complete.")
 
 if __name__ == "__main__":

--- a/modules/local/raiseTaxonomyRanks/resources/usr/bin/raise-taxonomy-ranks.py
+++ b/modules/local/raiseTaxonomyRanks/resources/usr/bin/raise-taxonomy-ranks.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python
+
+#=======================================================================
+# Preamble
+#=======================================================================
+
+# Import libraries
+import pandas as pd
+import subprocess
+from typing import Dict, Set, List
+import argparse
+from collections import defaultdict
+import logging
+from datetime import datetime, timezone
+
+# Configure logging
+class UTCFormatter(logging.Formatter):
+    def formatTime(self, record, datefmt=None):
+        dt = datetime.fromtimestamp(record.created, timezone.utc)
+        return dt.strftime('%Y-%m-%d %H:%M:%S UTC')
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger()
+handler = logging.StreamHandler()
+formatter = UTCFormatter('[%(asctime)s] %(message)s')
+handler.setFormatter(formatter)
+logger.handlers.clear()
+logger.addHandler(handler)
+
+# Define constants
+RANKS = ["subspecies", "species", "subgenus", "genus", "subfamily", "family",
+         "suborder", "order", "class", "subphylum", "phylum", "kingdom",
+         "superkingdom"]
+
+#=======================================================================
+# Auxiliary functions
+#=======================================================================
+
+def raise_rank_single(taxids: pd.Series, target_rank: str,
+                      db: pd.DataFrame) -> tuple[pd.Series, bool]:
+    """
+    Given a Series of taxids and a target rank, perform a single
+    rank-raise operation. Taxids below the target rank are replaced
+    with their parent taxid, while taxids above the target rank are
+    returned unchanged.
+    Args:
+        taxids (pd.Series): Series of taxids to raise.
+        target_rank (str): Target rank to raise to.
+        db (pd.DataFrame): DataFrame containing taxid hierarchy, with
+            taxids as the index and parent taxids as a column.
+    Returns:
+        tuple[pd.Series, bool]: Tuple containing a Series of taxids
+            raised to the target rank, and a boolean indicating whether
+            any taxids were raised.
+    """
+    # Get assigned ranks for each taxid
+    ranks = db.loc[taxids, "rank"]
+    # If all ranks are equal to or above target rank, return unmodified
+    ranks_above = RANKS[RANKS.index(target_rank):]
+    if ranks.isin(ranks_above).all():
+        return taxids, False
+    # Otherwise, return the parent taxid for each taxid below target
+    # rank, and the taxid itself for each taxid above target rank
+    parent_taxids = db.loc[taxids, "parent_taxid"]
+    taxids_out = taxids.where(ranks.isin(ranks_above), parent_taxids)
+    return taxids_out, True
+
+def raise_rank(taxids: pd.Series, target_rank: str,
+               db: pd.DataFrame) -> pd.Series:
+    """
+    Given a Series of taxids and a target rank, traverse the taxid
+    hierarchy to find the corresponding taxids at the target rank.
+    Args:
+        taxids (pd.Series): Series of taxids to raise.
+        target_rank (str): Target rank to raise to.
+        db (pd.DataFrame): DataFrame containing taxid hierarchy, with
+            taxids as the index and parent taxids as a column.
+    Returns:
+        pd.Series: Series of taxids raised to the target rank, or
+            pd.NA if the input taxid has no ancestor at that rank
+            (e.g. because it is already above that rank).
+    """
+    # Check that the target rank is valid
+    assert target_rank in RANKS, "Invalid target rank."
+    # Check that all taxids to raise are in the taxonomy db index
+    assert taxids.isin(db.index).all(), "Some taxids not in taxonomy db."
+    # Raise ranks until all taxids are at or above the target rank
+    iter_next = True
+    while iter_next:
+        taxids, iter_next = raise_rank_single(taxids, target_rank, db)
+    # Replace taxids above the target rank with pd.NA
+    ranks_high = RANKS[RANKS.index(target_rank)+1:]
+    ranks = db.loc[taxids, "rank"]
+    taxids_out = taxids.where(~ranks.isin(ranks_high), pd.NA)
+    return taxids_out
+
+def raise_rank_db(db: pd.DataFrame, target_rank: str) -> pd.DataFrame:
+    """
+    Given a DataFrame of taxids and their parent taxids, add a column
+    containing the corresponding taxids at the target taxonomic rank.
+    Args:
+        db (pd.DataFrame): DataFrame containing taxid hierarchy, with
+            taxids as the index and parent taxids as a column.
+        target_rank (str): Target rank to raise to.
+    Returns:
+        pd.DataFrame: DataFrame with an additional column "taxid_[RANK]"
+            containing the taxids at the target rank.
+    """
+    new_col_name = "taxid_" + target_rank
+    new_col_values = raise_rank(db.index, target_rank, db)
+    db[new_col_name] = new_col_values
+    return db
+
+def raise_ranks_db(db: pd.DataFrame, target_ranks: List[str]) -> pd.DataFrame:
+    """
+    Given a DataFrame of taxids and their parent taxids, add columns
+    containing the corresponding taxids at each target taxonomic rank.
+    Args:
+        db (pd.DataFrame): DataFrame containing taxid hierarchy, with
+            taxids as the index and parent taxids as a column.
+        target_ranks (List[str]): List of target ranks to raise to.
+    Returns:
+        pd.DataFrame: DataFrame with additional columns "taxid_[RANK]"
+            containing the taxids at each target rank.
+    """
+    for target_rank in target_ranks:
+        db = raise_rank_db(db, target_rank)
+    return db
+
+#=======================================================================
+# Main function
+#=======================================================================
+
+def main():
+    logger.info("Initializing script.")
+    # Define argument parsing
+    desc = "Given a TSV of taxids and their parent taxids, add columns " \
+           "containing the corresponding taxids at each target taxonomic rank."
+    parser = argparse.ArgumentParser(description=desc)
+    parser.add_argument("taxonomy_db", help="Path to TSV of taxids, parent taxids and ranks.")
+    parser.add_argument("target_ranks", help="Space-delimited list of target ranks to raise to.")
+    parser.add_argument("output_db", help="Path to output TSV.")
+    args = parser.parse_args()
+    # Import TSV and set taxids as index (while keeping taxid column)
+    logger.info("Importing input TSV.")
+    taxonomy_db = pd.read_csv(args.taxonomy_db, sep="\t", dtype=str)
+    taxonomy_db = taxonomy_db.set_index("taxid", drop=False)
+    logger.info(f"Imported {taxonomy_db.shape[0]} taxids.")
+    logger.info(f"Columns: {taxonomy_db.columns.tolist()}")
+    dims = taxonomy_db.shape
+    # Parse target ranks
+    target_ranks = args.target_ranks.split()
+    logger.info(f"Target ranks: {target_ranks}")
+    # Add columns for each target rank
+    logger.info("Raising ranks.")
+    for target_rank in target_ranks:
+        taxonomy_db = raise_rank_db(taxonomy_db, target_rank)
+    logger.info("Ranks raised.")
+    # New DB should have equal rows and extra columns
+    assert taxonomy_db.shape[0] == dims[0]
+    assert taxonomy_db.shape[1] == dims[1] + len(target_ranks)
+    logger.info(f"Columns: {taxonomy_db.columns.tolist()}")
+    # Write output
+    logger.info("Writing output.")
+    taxonomy_db.to_csv(args.output_db, sep="\t", index=False)
+    logger.info("Script complete.")
+
+if __name__ == "__main__":
+    main()

--- a/subworkflows/local/makeVirusTaxonomyDB/main.nf
+++ b/subworkflows/local/makeVirusTaxonomyDB/main.nf
@@ -6,6 +6,7 @@ include { DOWNLOAD_NCBI_TAXONOMY } from "../../../modules/local/downloadNcbiTaxo
 include { EXTRACT_NCBI_TAXONOMY } from "../../../modules/local/extractNcbiTaxonomy"
 include { DOWNLOAD_VIRUS_HOST_DB } from "../../../modules/local/downloadVirusHostDB"
 include { BUILD_VIRUS_TAXID_DB } from "../../../modules/local/buildVirusTaxidDB"
+include { RAISE_TAXONOMY_RANKS } from "../../../modules/local/raiseTaxonomyRanks"
 include { ANNOTATE_VIRUS_INFECTION } from "../../../modules/local/annotateVirusInfection"
 
 /***********
@@ -27,8 +28,10 @@ workflow MAKE_VIRUS_TAXONOMY_DB {
         vh_ch = DOWNLOAD_VIRUS_HOST_DB(virus_host_db_url)
         // Build virus taxid DB from NCBI taxonomy files
         virus_ch = BUILD_VIRUS_TAXID_DB(ext_ch.nodes, ext_ch.names, virus_taxid)
+        // Add rank-raised taxids
+        raised_ch = RAISE_TAXONOMY_RANKS(virus_ch, "species genus family order class phylum")
         // Annotate virus taxid DB with infection status for host taxa
-        annot_ch = ANNOTATE_VIRUS_INFECTION(virus_ch, host_taxon_db, vh_ch,
+        annot_ch = ANNOTATE_VIRUS_INFECTION(raised_ch, host_taxon_db, vh_ch,
             ext_ch.nodes, hard_exclude_taxids)
     emit:
         db = annot_ch

--- a/test-data/toy-data/test-taxonomy-ranked.tsv
+++ b/test-data/toy-data/test-taxonomy-ranked.tsv
@@ -1,0 +1,11 @@
+taxid	parent_taxid	rank	exp_species	exp_genus	exp_family
+1	0	kingdom	NA	NA	NA
+2	1	phylum	NA	NA	NA
+3	2	class	NA	NA	NA
+4	3	order	NA	NA	NA
+5	4	family	NA	NA	5
+6	5	genus	NA	6	5
+7	6	species	7	6	5
+8	7	subspecies	7	6	5
+9	5	none	NA	NA	5
+10	5	species	10	NA	5

--- a/tests/modules/local/raiseTaxonomyRanks/main.nf.test
+++ b/tests/modules/local/raiseTaxonomyRanks/main.nf.test
@@ -1,0 +1,49 @@
+nextflow_process {
+
+    name "Test process RAISE_TAXONOMY_RANKS"
+    script "modules/local/raiseTaxonomyRanks/main.nf"
+    process "RAISE_TAXONOMY_RANKS"
+    config "tests/configs/run.config"
+    tag "module"
+    tag "raise_taxonomy_ranks"
+
+    test("Should run without errors on test data and produce expected output"){
+        tag "expect_success"
+        when {
+            params {
+                taxonomy_db = "${projectDir}/test-data/toy-data/test-taxonomy-ranked.tsv"
+                target_ranks = "species genus family"
+            }
+            process {
+                '''
+                input[0] = params.taxonomy_db
+                input[1] = params.target_ranks
+                '''
+            }
+        }
+        then {
+            // Should run without errors
+            assert process.success
+            // Output should match input with one extra column per target rank
+            def tax_tab_out = path(process.out.db[0]).csv(sep: "\t", decompress: true)
+            def tax_tab_in = path(params.taxonomy_db).csv(sep: "\t")
+            def target_ranks = params.target_ranks.split(" ")
+            def new_cols = target_ranks.collect{ "taxid_${it}".toString() }
+            assert tax_tab_out.rowCount == tax_tab_in.rowCount
+            assert tax_tab_out.columnCount == tax_tab_in.columnCount + target_ranks.size()
+            for (c in tax_tab_in.columnNames){
+                assert tax_tab_out.columnNames.contains(c)
+                assert tax_tab_in.columns[c] == tax_tab_out.columns[c]
+            }
+            for (int i = 0; i < new_cols.size(); i++) {
+                assert tax_tab_out.columnNames.contains(new_cols[i])
+                assert !tax_tab_in.columnNames.contains(new_cols[i])
+            }
+            // New values should match expectations
+            def new_cols_exp = target_ranks.collect{ "exp_${it}" }
+            for (int r = 0; r < target_ranks.size(); r++) {
+                assert tax_tab_out.columns[new_cols[r]] == tax_tab_out.columns[new_cols_exp[r]]
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR modifies the MAKE_VIRUS_TAXONOMY_DB subworkflow to add rank-raised taxids to each entry in the viral taxonomy db (with column names `taxid_species`, `taxid_genus` etc).

These are currently not used directly in the pipeline itself, so index/pipeline backwards compatibility is preserved in both directions (though I intend to use them in the DOWNSTREAM workflow in an upcoming PR).

I ran tests for the following locally, all passing:
- INDEX
- MAKE_VIRUS_TAXONOMY_DB
- ANNOTATE_VIRUS_INFECTION
- RAISE_TAXONOMY_RANKS