### PR TITLE
Katherine ont empty

### DIFF
--- a/modules/local/processViralMinimap2Sam/resources/usr/bin/process_viral_minimap2_sam.py
+++ b/modules/local/processViralMinimap2Sam/resources/usr/bin/process_viral_minimap2_sam.py
@@ -109,7 +109,9 @@ def process_sam(sam_file, out_file, genbank_metadata, viral_taxids, clean_read_d
         out_fh.write(header)
         try:
             with pysam.AlignmentFile(sam_file, "r") as sam_file:
+                num_reads = 0
                 for read in sam_file:
+                    num_reads += 1
                     print_log(f"Processing read: {read.query_name}")
                     if read.is_unmapped or read.is_secondary or read.is_supplementary:
                         continue
@@ -124,6 +126,8 @@ def process_sam(sam_file, out_file, genbank_metadata, viral_taxids, clean_read_d
                     assert test_key_line == header
 
                     out_fh.write(join_line(line.values()))
+                if num_reads == 0:
+                    print_log("Warning: Input SAM file is empty. Creating empty output with header only.")
 
         except Exception as e:
             import traceback

--- a/tests/subworkflows/local/extractViralReadsONT/main.nf.test
+++ b/tests/subworkflows/local/extractViralReadsONT/main.nf.test
@@ -88,16 +88,16 @@ nextflow_workflow {
             assert workflow.success
 
             // FASTQ and SAM output files should be empty
-            def fastq_and_sam_files = [
-                path(workflow.out.hits_fastq[0][1]),
+            def fastq_files = [
+                path(workflow.out.hits_fastq[0]),
                 path(workflow.out.test_fastq_filtered_human[0][1]),
-                path(workflow.out.test_fastq_filtered_contam[0][1]),
-                path(workflow.out.test_minimap2_virus[0][1])
+                path(workflow.out.test_fastq_filtered_contam[0][1])
             ]
             def fastqs = fastq_files.collect{ it.fastq }
             def read_counts = fastqs.collect{ it.getNumberOfRecords() }
             assert read_counts.every{ it == 0 }
-
+            def samlines = sam(workflow.out.test_minimap2_virus[0][1]).getSamLines()
+	    assert samlines.size() == 0
             // Tabular output files should have only header lines
             def tabular_files = [
                 path(workflow.out.hits_final[0]),

--- a/tests/subworkflows/local/extractViralReadsONT/main.nf.test
+++ b/tests/subworkflows/local/extractViralReadsONT/main.nf.test
@@ -58,4 +58,52 @@ nextflow_workflow {
             assert virus_filter_num > 0
         }
     }
+
+    test("Should handle empty input file") {
+        tag "empty_file"
+        tag "expect_success"
+        tag "ont"
+        setup {
+            run("GZIP_FILE", alias: "GZIP_EMPTY_FORWARD") {
+                script "modules/local/gzipFile/main.nf"
+                process {
+                    '''
+                    input[0] = Channel.of("empty")
+                        | combine(Channel.of("${projectDir}/test-data/toy-data/empty_file.txt"))
+                    '''
+                }
+            }
+        }
+        when {
+            
+            workflow {
+                '''
+                input[0] = GZIP_EMPTY_FORWARD.out
+                input[1] = params.ref_dir
+                '''
+            }
+        }
+        then {
+            // Should run without failures
+            assert workflow.success
+
+            // FASTQ and SAM output files should be empty
+            def fastq_and_sam_files = [
+                path(workflow.out.hits_fastq[0][1]),
+                path(workflow.out.test_fastq_filtered_human[0][1]),
+                path(workflow.out.test_fastq_filtered_contam[0][1]),
+                path(workflow.out.test_minimap2_virus[0][1])
+            ]
+            def fastqs = fastq_files.collect{ it.fastq }
+            def read_counts = fastqs.collect{ it.getNumberOfRecords() }
+            assert read_counts.every{ it == 0 }
+
+            // Tabular output files should have only header lines
+            def tabular_files = [
+                path(workflow.out.hits_final[0]),
+            ]
+            def tabular_lines = tabular_files.collect{ it.linesGzip.toList() }
+            assert tabular_lines.every{ it.size() == 1 }
+        }
+    }
 }


### PR DESCRIPTION
This may have substantially more work, but I wanted to get your first-pass review before I go further.

Without any changes, the end-to-end empty file test of extractViralReadsONT ran fine! So I'm not sure I actually have any work to do.
MINIMAP2, MINIMAP2_NON_STREAMED, FILTLONG, PROCESS_VIRAL_MINIMAP2_SAM, MASK_FASTQ_READS, EXTRACT_SHARED_FASTQ_READS were the ONT-specific processes I identified.
I added a warning message about empty files to PROCESS_VIRAL_MINIMAP2_SAM because you'd done something similar for PROCESS_VIRAL_BOWTIE2_SAM; the others are command-line utilities (and it didn't look like you'd added empty file warnings for similar processes like BOWTIE2) so I left them unchanged
Should I be adding empty file tests for all of these? None of these? just PROCESS_VIRAL_MINIMAP2_SAM? Unsure how you're thinking about this.
Anything else I need to do that I've missed?
(Will update changelog once you've given me this initial feedback)