### PR TITLE
Adding ability to test all subcomponents of a component recursively

### DIFF
--- a/bin/test_component_dependencies.py
+++ b/bin/test_component_dependencies.py
@@ -47,6 +47,7 @@ def identify_component_file(component):
         for hit in out:
             path, line_content = hit.split(":", 1)
             if line_content.lstrip().startswith("workflow "):
+                # TODO: This could pose a problem when there are multiple matches, and the first match is erroneous..
                 return path
     raise ValueError(f"Could not find workflow/subworkflow with name '{component}'.")
 


### PR DESCRIPTION
As discussed in #284 it would be useful to be able to test all the subcomponents that are used within a component. I.e., all the processes and subworkflows that are used by some subworkflow or workflow. I've now added the ability to do this.

Specifically, I:
- Introduced a function to get the file name of the component we want tested.
- Added code that parses the file to search for processes and subworkflows used in that component.
- Added code that recursively searches the components that are used by a component or its subcomponents.
- Added command-line argument that activates this entire process.

This code only works for workflows and subworkflows. @willbradshaw Can you provide an initial review?
