### PR TITLE
Katherine contam bugfix

### DIFF
--- a/subworkflows/local/extractViralReadsONT/main.nf
+++ b/subworkflows/local/extractViralReadsONT/main.nf
@@ -45,7 +45,7 @@ workflow EXTRACT_VIRAL_READS_ONT {
         no_contam_ch = contam_minimap2_ch.reads_unmapped
 
         // Identify virus reads
-        virus_minimap2_ch = MINIMAP2_VIRUS(no_human_ch, minimap2_virus_index, "virus", false)
+        virus_minimap2_ch = MINIMAP2_VIRUS(no_contam_ch, minimap2_virus_index, "virus", false)
         virus_sam_ch = virus_minimap2_ch.sam
 
         // Group cleaned reads and sam files by sample


### PR DESCRIPTION
I realized we weren't actually passing the output of contaminant filtering into MINIMAP2_VIRUS, so we were effectively skipping the contaminant filtering. I talked with simon and confirmed it was a bug. Ran local test for extractViralReadsONT and it passed