### PR TITLE
Add column name customization features to LCA_TSV

### DIFF
--- a/modules/local/lcaTsv/main.nf
+++ b/modules/local/lcaTsv/main.nf
@@ -10,6 +10,7 @@ process LCA_TSV {
         val(taxid_field) // Column header for taxid field
         val(score_field) // Column header for score field
         val(taxid_artificial) // Parent taxid for artificial sequences
+        val(prefix) // Prefix for output columns
     output:
         tuple val(sample), path("lca_${tsv}"), emit: output // LCA-summarized TSV
         tuple val(sample), path("input_${tsv}"), path("input_${nodes_db}"), path("input_${names_db}"), emit: input // Input files for testing
@@ -17,7 +18,7 @@ process LCA_TSV {
         '''
         # Set up and run Python script
         io="-i !{tsv} -o lca_!{tsv} -d !{nodes_db} -n !{names_db}"
-        par="-g !{group_field} -t !{taxid_field} -s !{score_field} -a !{taxid_artificial}"
+        par="-g !{group_field} -t !{taxid_field} -s !{score_field} -a !{taxid_artificial} -p !{prefix}"
         lca_tsv.py ${io} ${par}
         # Link input files to output for testing
         ln -s !{tsv} input_!{tsv}

--- a/tests/modules/local/lcaTsv/main.nf.test
+++ b/tests/modules/local/lcaTsv/main.nf.test
@@ -13,6 +13,7 @@ nextflow_process {
 
     test("Should run without errors and produce expected output when run on valid natural input"){
         tag "expect_success"
+        tag "natural"
         when {
             params {
                 input_path = "${projectDir}/test-data/toy-data/lca-taxonomy/test-input.tsv"
@@ -22,6 +23,7 @@ nextflow_process {
                 taxid_field = "taxid"
                 score_field = "test_score"
                 artificial_taxid = 8000
+                prefix = "test"
             }
             process {
                 '''
@@ -33,6 +35,7 @@ nextflow_process {
                 input[4] = params.taxid_field
                 input[5] = params.score_field
                 input[6] = params.artificial_taxid
+                input[7] = params.prefix
                 '''
             }
         }
@@ -45,17 +48,21 @@ nextflow_process {
             def groups = tab_in.columns[params.group_field].unique()
             assert tab_out.rowCount == groups.size()
             // Output should have expected column names
-            def exp_headers_base = ["lca", "n_entries", "n_classified", "top_taxid",
-                "top_taxid_classified", "min_score", "max_score", "mean_score"]
-            def exp_headers_all = exp_headers_base.collect { it + "_all" }
-            def exp_headers_natural = exp_headers_base.collect { it + "_natural" }
-            def exp_headers_artificial = exp_headers_base.collect { it + "_artificial" }
-            def exp_headers = ["group_id"] + exp_headers_all + exp_headers_natural + exp_headers_artificial
+            def exp_headers_base = [params.taxid_field + "_lca",
+                "n_assignments_total", "n_assignments_classified",
+                params.taxid_field + "_top", params.taxid_field + "_top_classified",
+                params.score_field + "_min", params.score_field + "_max",
+                params.score_field + "_mean"]
+            def exp_headers_prefixed = exp_headers_base.collect { params.prefix + "_" + it }
+            def exp_headers_all = exp_headers_prefixed.collect { it + "_all" }
+            def exp_headers_natural = exp_headers_prefixed.collect { it + "_natural" }
+            def exp_headers_artificial = exp_headers_prefixed.collect { it + "_artificial" }
+            def exp_headers = [params.group_field] + exp_headers_all + exp_headers_natural + exp_headers_artificial
             assert tab_out.columnNames == exp_headers
             // Output should have expected column values
             for (group in groups) {
                 def tab_in_filtered = filter_tab(tab_in, params.group_field, group)
-                def tab_out_filtered = filter_tab(tab_out, "group_id", group)
+                def tab_out_filtered = filter_tab(tab_out, params.group_field, group)
                 assert tab_out_filtered.rowCount == 1
                 def exp_lca = tab_in_filtered.columns["exp_lca"][0]
                 def exp_top_taxid = tab_in_filtered.columns["exp_top_taxid"][0]
@@ -63,24 +70,25 @@ nextflow_process {
                 def exp_min_score = tab_in_filtered.columns[params.score_field].min()
                 def exp_max_score = tab_in_filtered.columns[params.score_field].max()
                 def exp_mean_score = tab_in_filtered.columns[params.score_field].sum() / exp_n_entries
-                assert tab_out_filtered.columns["group_id"][0] == group
-                assert tab_out_filtered.columns["lca_all"][0] == exp_lca
-                assert tab_out_filtered.columns["n_entries_all"][0] == exp_n_entries
-                assert tab_out_filtered.columns["min_score_all"][0] == exp_min_score
-                assert tab_out_filtered.columns["max_score_all"][0] == exp_max_score
-                assert tab_out_filtered.columns["mean_score_all"][0] == exp_mean_score
-                assert tab_out_filtered.columns["top_taxid_all"][0] == exp_top_taxid
+                assert tab_out_filtered.columns[params.group_field][0] == group
+                assert tab_out_filtered.columns[params.prefix + "_" + params.taxid_field + "_lca_all"][0] == exp_lca
+                assert tab_out_filtered.columns[params.prefix + "_n_assignments_total_all"][0] == exp_n_entries
+                assert tab_out_filtered.columns[params.prefix + "_" + params.score_field + "_min_all"][0] == exp_min_score
+                assert tab_out_filtered.columns[params.prefix + "_" + params.score_field + "_max_all"][0] == exp_max_score
+                assert tab_out_filtered.columns[params.prefix + "_" + params.score_field + "_mean_all"][0] == exp_mean_score
+                assert tab_out_filtered.columns[params.prefix + "_" + params.taxid_field + "_top_all"][0] == exp_top_taxid
                 // All entries should be natural
-                assert tab_out_filtered.columns["n_entries_natural"][0] == exp_n_entries
-                assert tab_out_filtered.columns["n_entries_artificial"][0] == 0
-                assert tab_out_filtered.columns["lca_natural"][0] == exp_lca
-                assert tab_out_filtered.columns["lca_artificial"][0] == "None"
+                assert tab_out_filtered.columns[params.prefix + "_n_assignments_total_natural"][0] == exp_n_entries
+                assert tab_out_filtered.columns[params.prefix + "_n_assignments_total_artificial"][0] == 0
+                assert tab_out_filtered.columns[params.prefix + "_" + params.taxid_field + "_lca_natural"][0] == exp_lca
+                assert tab_out_filtered.columns[params.prefix + "_" + params.taxid_field + "_top_natural"][0] == exp_top_taxid
             }
         }
     }
 
     test("Should run without errors and produce expected output when run on mixed natural and artificial input"){
         tag "expect_success"
+        tag "artificial"
         when {
             params {
                 input_path = "${projectDir}/test-data/toy-data/lca-taxonomy/test-input-artificial.tsv"
@@ -90,6 +98,7 @@ nextflow_process {
                 taxid_field = "taxid"
                 score_field = "test_score"
                 artificial_taxid = 8000
+                prefix = "test"
             }
             process {
                 '''
@@ -101,6 +110,7 @@ nextflow_process {
                 input[4] = params.taxid_field
                 input[5] = params.score_field
                 input[6] = params.artificial_taxid
+                input[7] = params.prefix
                 '''
             }
         }
@@ -113,25 +123,29 @@ nextflow_process {
             def groups = tab_in.columns[params.group_field].unique()
             assert tab_out.rowCount == groups.size()
             // Output should have expected column names
-            def exp_headers_base = ["lca", "n_entries", "n_classified", "top_taxid",
-                "top_taxid_classified", "min_score", "max_score", "mean_score"]
-            def exp_headers_all = exp_headers_base.collect { it + "_all" }
-            def exp_headers_natural = exp_headers_base.collect { it + "_natural" }
-            def exp_headers_artificial = exp_headers_base.collect { it + "_artificial" }
-            def exp_headers = ["group_id"] + exp_headers_all + exp_headers_natural + exp_headers_artificial
+            def exp_headers_base = [params.taxid_field + "_lca",
+                "n_assignments_total", "n_assignments_classified",
+                params.taxid_field + "_top", params.taxid_field + "_top_classified",
+                params.score_field + "_min", params.score_field + "_max",
+                params.score_field + "_mean"]
+            def exp_headers_prefixed = exp_headers_base.collect { params.prefix + "_" + it }
+            def exp_headers_all = exp_headers_prefixed.collect { it + "_all" }
+            def exp_headers_natural = exp_headers_prefixed.collect { it + "_natural" }
+            def exp_headers_artificial = exp_headers_prefixed.collect { it + "_artificial" }
+            def exp_headers = [params.group_field] + exp_headers_all + exp_headers_natural + exp_headers_artificial
             assert tab_out.columnNames == exp_headers
             // Output should have expected column values
             for (group in groups) {
                 def tab_in_filtered = filter_tab(tab_in, params.group_field, group)
-                def tab_out_filtered = filter_tab(tab_out, "group_id", group)
+                def tab_out_filtered = filter_tab(tab_out, params.group_field, group)
                 assert tab_out_filtered.rowCount == 1
                 def exp_lca_all = tab_in_filtered.columns["exp_lca_all"][0]
                 def exp_lca_natural = tab_in_filtered.columns["exp_lca_natural"][0]
                 def exp_lca_artificial = tab_in_filtered.columns["exp_lca_artificial"][0]
-                assert tab_out_filtered.columns["group_id"][0] == group
-                assert tab_out_filtered.columns["lca_all"][0] == exp_lca_all
-                assert tab_out_filtered.columns["lca_natural"][0] == exp_lca_natural
-                assert tab_out_filtered.columns["lca_artificial"][0] == exp_lca_artificial
+                assert tab_out_filtered.columns[params.group_field][0] == group
+                assert tab_out_filtered.columns[params.prefix + "_" + params.taxid_field + "_lca_all"][0] == exp_lca_all
+                assert tab_out_filtered.columns[params.prefix + "_" + params.taxid_field + "_lca_natural"][0] == exp_lca_natural
+                assert tab_out_filtered.columns[params.prefix + "_" + params.taxid_field + "_lca_artificial"][0] == exp_lca_artificial
             }
         }
     }
@@ -148,6 +162,7 @@ nextflow_process {
                 taxid_field = "taxid"
                 score_field = "test_score"
                 artificial_taxid = 8000
+                prefix = "test"
             }
             process {
                 '''
@@ -159,6 +174,7 @@ nextflow_process {
                 input[4] = params.taxid_field
                 input[5] = params.score_field
                 input[6] = params.artificial_taxid
+                input[7] = params.prefix
                 '''
             }
         }
@@ -171,17 +187,21 @@ nextflow_process {
             def groups = tab_in.columns[params.group_field].unique()
             assert tab_out.rowCount == groups.size()
             // Output should have expected column names
-            def exp_headers_base = ["lca", "n_entries", "n_classified", "top_taxid",
-                "top_taxid_classified", "min_score", "max_score", "mean_score"]
-            def exp_headers_all = exp_headers_base.collect { it + "_all" }
-            def exp_headers_natural = exp_headers_base.collect { it + "_natural" }
-            def exp_headers_artificial = exp_headers_base.collect { it + "_artificial" }
-            def exp_headers = ["group_id"] + exp_headers_all + exp_headers_natural + exp_headers_artificial
+            def exp_headers_base = [params.taxid_field + "_lca",
+                "n_assignments_total", "n_assignments_classified",
+                params.taxid_field + "_top", params.taxid_field + "_top_classified",
+                params.score_field + "_min", params.score_field + "_max",
+                params.score_field + "_mean"]
+            def exp_headers_prefixed = exp_headers_base.collect { params.prefix + "_" + it }
+            def exp_headers_all = exp_headers_prefixed.collect { it + "_all" }
+            def exp_headers_natural = exp_headers_prefixed.collect { it + "_natural" }
+            def exp_headers_artificial = exp_headers_prefixed.collect { it + "_artificial" }
+            def exp_headers = [params.group_field] + exp_headers_all + exp_headers_natural + exp_headers_artificial
             assert tab_out.columnNames == exp_headers
             // Output should have expected column values
             for (group in groups) {
                 def tab_in_filtered = filter_tab(tab_in, params.group_field, group)
-                def tab_out_filtered = filter_tab(tab_out, "group_id", group)
+                def tab_out_filtered = filter_tab(tab_out, params.group_field, group)
                 assert tab_out_filtered.rowCount == 1
                 def exp_lca = tab_in_filtered.columns["exp_lca"][0]
                 def exp_top_taxid = tab_in_filtered.columns["exp_top_taxid"][0]
@@ -190,14 +210,14 @@ nextflow_process {
                 def exp_min_score = tab_in_filtered.columns[params.score_field].min()
                 def exp_max_score = tab_in_filtered.columns[params.score_field].max()
                 def exp_mean_score = tab_in_filtered.columns[params.score_field].sum() / exp_n_entries
-                assert tab_out_filtered.columns["group_id"][0] == group
-                assert tab_out_filtered.columns["lca_all"][0] == exp_lca
-                assert tab_out_filtered.columns["n_entries_all"][0] == exp_n_entries
-                assert tab_out_filtered.columns["min_score_all"][0] == exp_min_score
-                assert tab_out_filtered.columns["max_score_all"][0] == exp_max_score
-                assert tab_out_filtered.columns["mean_score_all"][0] == exp_mean_score
-                assert tab_out_filtered.columns["top_taxid_all"][0] == exp_top_taxid
-                assert tab_out_filtered.columns["top_taxid_classified_all"][0] == exp_top_taxid_classified
+                assert tab_out_filtered.columns[params.group_field][0] == group
+                assert tab_out_filtered.columns[params.prefix + "_" + params.taxid_field + "_lca_all"][0] == exp_lca
+                assert tab_out_filtered.columns[params.prefix + "_n_assignments_total_all"][0] == exp_n_entries
+                assert tab_out_filtered.columns[params.prefix + "_" + params.score_field + "_min_all"][0] == exp_min_score
+                assert tab_out_filtered.columns[params.prefix + "_" + params.score_field + "_max_all"][0] == exp_max_score
+                assert tab_out_filtered.columns[params.prefix + "_" + params.score_field + "_mean_all"][0] == exp_mean_score
+                assert tab_out_filtered.columns[params.prefix + "_" + params.taxid_field + "_top_all"][0] == exp_top_taxid
+                assert tab_out_filtered.columns[params.prefix + "_" + params.taxid_field + "_top_classified_all"][0] == exp_top_taxid_classified
             }
         }
     }
@@ -213,6 +233,7 @@ nextflow_process {
                 taxid_field = "taxid"
                 score_field = "test_score"
                 artificial_taxid = 8000
+                prefix = "test"
             }
             process {
                 '''
@@ -224,6 +245,7 @@ nextflow_process {
                 input[4] = params.taxid_field
                 input[5] = params.score_field
                 input[6] = params.artificial_taxid
+                input[7] = params.prefix
                 '''
             }
         }
@@ -246,6 +268,7 @@ nextflow_process {
                 taxid_field = "missing"
                 score_field = "test_score"
                 artificial_taxid = 8000
+                prefix = "test"
             }
             process {
                 '''
@@ -257,6 +280,7 @@ nextflow_process {
                 input[4] = params.taxid_field
                 input[5] = params.score_field
                 input[6] = params.artificial_taxid
+                input[7] = params.prefix
                 '''
             }
         }
@@ -279,6 +303,7 @@ nextflow_process {
                 taxid_field = "taxid"
                 score_field = "missing"
                 artificial_taxid = 8000
+                prefix = "test"
             }
             process {
                 '''
@@ -290,6 +315,7 @@ nextflow_process {
                 input[4] = params.taxid_field
                 input[5] = params.score_field
                 input[6] = params.artificial_taxid
+                input[7] = params.prefix
                 '''
             }
         }
@@ -312,6 +338,7 @@ nextflow_process {
                 taxid_field = "taxid"
                 score_field = "test_score"
                 artificial_taxid = 8000
+                prefix = "test"
             }
             process {
                 '''
@@ -323,6 +350,7 @@ nextflow_process {
                 input[4] = params.taxid_field
                 input[5] = params.score_field
                 input[6] = params.artificial_taxid
+                input[7] = params.prefix
                 '''
             }
         }
@@ -345,6 +373,7 @@ nextflow_process {
                 taxid_field = "taxid"
                 score_field = "test_score"
                 artificial_taxid = 8000
+                prefix = "test"
             }
             process {
                 '''
@@ -356,6 +385,7 @@ nextflow_process {
                 input[4] = params.taxid_field
                 input[5] = params.score_field
                 input[6] = params.artificial_taxid
+                input[7] = params.prefix
                 '''
             }
         }


### PR DESCRIPTION
This small PR modifies LCA_TSV to change the output column names:

1. It adds a "prefix" argument that allows all columns to receive a common prefix (e.g. "blast" for BLAST validation); this is important to distinguish e.g. Bowtie2 LCA from BLAST LCA.
2. It modifies the output column names to preserve input information -- e.g. if the input groups column name is "seq_id" then the corresponding output column will now also be "seq_id".