### PR TITLE
Implement basic BLAST LCA functionality in BLAST_VIRAL and VALIDATE_VIRAL_ASSIGNMENTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     - Split out core of BLAST_VIRAL subworkflow into a new BLAST_FASTA subworkflow that is called by both BLAST_VIRAL and VALIDATE_VIRAL_ASSIGNMENTS
     - Added tests for BLAST_FASTA and updated tests for VALIDATE_VIRAL_ASSIGNMENTS
     - Implemented basic algorithm for computing the lowest common ancestor of sets of taxids in tabular TSV data (LCA_TSV), including special handling of artificial and unclassified taxids
+    - Integrated LCA_TSV into BLAST_FASTA subworkflow and updated tests
 
 # v2.9.0.0
 - Implemented ONT analysis in the RUN workflow

--- a/configs/run.config
+++ b/configs/run.config
@@ -35,6 +35,7 @@ params {
                        // Recommended setting: 60 for short-read, 0 for ONT
     blast_qcov_hsp_perc = 30 // Query coverage threshold for BLAST hits
                              // Recommended setting: 30 for short-read, 0 for ONT
+    taxid_artificial = "81077" // Parent taxid for artificial sequences in NCBI taxonomy
 }
 
 includeConfig "${projectDir}/configs/logging.config"

--- a/configs/run_validation.config
+++ b/configs/run_validation.config
@@ -20,6 +20,7 @@ params {
     blast_max_rank = 5 // Keep BLAST hits whose dense bitscore rank for that query is at most this value
     blast_perc_id = 60 // Percent identity threshold for BLAST hits
     blast_qcov_hsp_perc = 30 // Query coverage threshold for BLAST hits
+    taxid_artificial = "81077" // Parent taxid for artificial sequences in NCBI taxonomy
 
     // Other
     drop_unpaired = false // Whether to drop reads from TSV that lack a pair sequence (otherwise replace with "N")

--- a/modules/local/lcaTsv/main.nf
+++ b/modules/local/lcaTsv/main.nf
@@ -2,6 +2,8 @@
 // return a TSV with a single row per group containing the lowest common ancestor
 // taxid across all taxids in the group.
 process LCA_TSV {
+    label "python"
+    label "single"
     input:
         tuple val(sample), path(tsv) // Sorted TSV with group, taxid, and score columns
         path(nodes_db) // TSV containing taxonomic structure (mapping taxids to parent taxids)

--- a/modules/local/lcaTsv/resources/usr/bin/lca_tsv.py
+++ b/modules/local/lcaTsv/resources/usr/bin/lca_tsv.py
@@ -768,7 +768,7 @@ def get_unclassified_taxids(names_db: dict[int, set[str]]) -> set[int]:
     for taxid, names in names_db.items():
         for name in names:
             name_lower = name.lower()
-            if "unclassified" in name_lower or "sp." in name_lower:
+            if "unclassified" in name_lower or " sp." in name_lower:
                 unclassified_taxids.add(taxid)
                 break
     # Return set of unclassified taxids

--- a/modules/local/lcaTsv/resources/usr/bin/lca_tsv.py
+++ b/modules/local/lcaTsv/resources/usr/bin/lca_tsv.py
@@ -617,19 +617,27 @@ def parse_input_tsv(
         prefix (str): Prefix for output columns.
     """
     with open_by_suffix(input_path) as inf, open_by_suffix(output_path, "w") as outf:
+        # Read header from input file
+        header = inf.readline().strip().split("\t")
+        logger.debug(f"Header: {header}")
+        if len(header) == 1 and header[0] == "":
+            logger.warning("Input file is empty (header only). Returning header only.")
+            return
         # Write header to output file
         output_header = get_output_header(prefix, group_field, taxid_field, score_field)
         write_output_line(output_header, output_header, outf)
-        # Read header from input file
-        header = inf.readline().strip().split("\t")
         # Get indices of fields
         group_idx, taxid_idx, score_idx = parse_input_header(
             header, group_field, taxid_field, score_field)
         def parse_line(fields: list[str], group_info: Group | None) -> tuple[Group, dict[int, list[int]]]:
             return process_input_line(fields, group_idx, taxid_idx, score_idx, group_info,
                                       artificial_taxids, unclassified_taxids)
-        # Process first line
+        # Check for empty file
         fields = inf.readline().strip().split("\t")
+        if len(fields) == 1 and fields[0] == "":
+            logger.warning("Input file is empty (header only). Returning header only.")
+            return
+        # Process first line
         group_id = fields[group_idx]
         group_info = parse_line(fields, None)
         # Iterate over input file

--- a/subworkflows/local/blastFasta/main.nf
+++ b/subworkflows/local/blastFasta/main.nf
@@ -14,6 +14,7 @@ include { SORT_FILE as SORT_BLAST_1 } from "../../../modules/local/sortFile"
 include { SORT_FILE as SORT_BLAST_2 } from "../../../modules/local/sortFile"
 include { FILTER_TSV } from "../../../modules/local/filterTsv"
 include { FILTER_BLAST } from "../../../modules/local/filterBlast"
+include { LCA_TSV } from "../../../modules/local/lcaTsv"
 
 /***********
 | WORKFLOW |
@@ -22,13 +23,18 @@ include { FILTER_BLAST } from "../../../modules/local/filterBlast"
 workflow BLAST_FASTA {
     take:
         query_fasta // Fasta of sequences to align
-        blast_db_dir // Path to BLAST reference DB
+        ref_dir // Path to reference directory containing BLAST DB
         blast_db_prefix // Prefix for BLAST reference DB files (e.g. "nt")
         perc_id // Minimum %ID required for BLAST to return an alignment
         qcov_hsp_perc // Minimum query coverage required for BLAST to return an alignment
         blast_max_rank // Only keep alignments that are in the top-N for that query by bitscore
         blast_min_frac // Only keep alignments that have at least this fraction of the best bitscore for that query
+        taxid_artificial // Parent taxid for artificial sequences in NCBI taxonomy
     main:
+        // 0. Get reference paths
+        blast_db_dir = "${ref_dir}/results/${blast_db_prefix}"
+        nodes_db = "${ref_dir}/results/taxonomy-nodes.dmp"
+        names_db = "${ref_dir}/results/taxonomy-names.dmp"
         // 1. Run BLAST
         blast_ch = BLAST(query_fasta, blast_db_dir, blast_db_prefix,
             perc_id, qcov_hsp_perc)
@@ -40,7 +46,12 @@ workflow BLAST_FASTA {
         sort_str_2 = "-t\$\'\\t\' -k1,1 -k7,7nr" // Sort by query and bitscore only
         sort_ch_2 = SORT_BLAST_2(filter_ch_1.output, sort_str_2, "blast")
         filter_ch_2 = FILTER_BLAST(sort_ch_2.output, blast_max_rank, blast_min_frac).output // Filter on relative bitscores
+        // 4. Apply LCA to BLAST output
+        lca_ch = LCA_TSV(filter_ch_2, nodes_db, names_db,
+            "qseqid", "staxid", "bitscore", taxid_artificial,
+            "blast").output
     emit:
+        lca = lca_ch
         blast = filter_ch_2
         query = query_fasta
 }

--- a/subworkflows/local/blastViral/main.nf
+++ b/subworkflows/local/blastViral/main.nf
@@ -15,14 +15,15 @@ include { COPY_FILE } from "../../../modules/local/copyFile"
 workflow BLAST_VIRAL {
     take:
         viral_fastq // Interleaved or single-end
-        blast_db_dir
-        blast_db_prefix
+        ref_dir // Path to reference directory containing BLAST DB
+        blast_db_prefix // Prefix for BLAST reference DB files (e.g. "nt")
         read_fraction
         blast_max_rank
         blast_min_frac
         random_seed
         perc_id
         qcov_hsp_perc
+        taxid_artificial // Parent taxid for artificial sequences in NCBI taxonomy
     main:
         // 1. Subset viral reads for BLAST
         reads_in = Channel.of("merged")
@@ -34,8 +35,9 @@ workflow BLAST_VIRAL {
         // 2. Convert to FASTA
         fasta_ch = CONVERT_FASTQ_FASTA(subset_sorted_ch).output
         // 3. Run BLAST and process output
-        blast_ch = BLAST_FASTA(fasta_ch, blast_db_dir, blast_db_prefix,
-            perc_id, qcov_hsp_perc, blast_max_rank, blast_min_frac)
+        blast_ch = BLAST_FASTA(fasta_ch, ref_dir, blast_db_prefix,
+            perc_id, qcov_hsp_perc, blast_max_rank, blast_min_frac,
+            taxid_artificial)
         // 4. Rename subset FASTA file for output
         copy_ch = COPY_FILE(fasta_ch, "blast_input_subset.fasta.gz")
     emit:

--- a/subworkflows/local/validateViralAssignments/main.nf
+++ b/subworkflows/local/validateViralAssignments/main.nf
@@ -30,12 +30,13 @@ workflow VALIDATE_VIRAL_ASSIGNMENTS {
         cluster_identity // Identity threshold for VSEARCH clustering
         cluster_min_len // Minimum sequence length for VSEARCH clustering
         n_clusters // Number of cluster representatives to validate for each specie
-        blast_db_dir // Path to BLAST reference DB
+        ref_dir // Path to reference directory containing BLAST DB
         blast_db_prefix // Prefix for BLAST reference DB files (e.g. "nt")
         perc_id // Minimum %ID required for BLAST to return an alignment
         qcov_hsp_perc // Minimum query coverage required for BLAST to return an alignment
         blast_max_rank // Only keep alignments that are in the top-N for that query by bitscore
         blast_min_frac // Only keep alignments that have at least this fraction of the best bitscore for that query
+        taxid_artificial // Parent taxid for artificial sequences in NCBI taxonomy
     main:
         // 1. Split viral hits TSV by species
         split_ch = SPLIT_VIRAL_TSV_BY_SPECIES(groups, db)
@@ -43,8 +44,8 @@ workflow VALIDATE_VIRAL_ASSIGNMENTS {
         cluster_ch = CLUSTER_VIRAL_ASSIGNMENTS(split_ch.fastq, cluster_identity,
             cluster_min_len, n_clusters, Channel.of(false))
         // 3. BLAST cluster representatives
-        blast_ch = BLAST_FASTA(cluster_ch.fasta, blast_db_dir, blast_db_prefix,
-            perc_id, qcov_hsp_perc, blast_max_rank, blast_min_frac)
+        blast_ch = BLAST_FASTA(cluster_ch.fasta, ref_dir, blast_db_prefix,
+            perc_id, qcov_hsp_perc, blast_max_rank, blast_min_frac, taxid_artificial)
         // 4. Concatenate clustering information across species to regenerate per-group information
         // NB: This concatenation stage will move down as more steps are added, but will need to happen eventually
         // and is useful for testing, so I'm implementing it now. It should probably get moved into its own

--- a/subworkflows/local/validateViralAssignments/main.nf
+++ b/subworkflows/local/validateViralAssignments/main.nf
@@ -80,5 +80,6 @@ workflow VALIDATE_VIRAL_ASSIGNMENTS {
         test_reps_fasta = cluster_ch.fasta
         test_blast_db = blast_ch.blast
         test_blast_query = blast_ch.query
+        test_blast_lca = blast_ch.lca
         test_regrouped = regrouped_ch
 }

--- a/test-data/toy-data/lca-taxonomy/test-input-empty.tsv
+++ b/test-data/toy-data/lca-taxonomy/test-input-empty.tsv
@@ -1,0 +1,1 @@
+seq_id	taxid	test_score

--- a/tests/configs/run.config
+++ b/tests/configs/run.config
@@ -34,6 +34,7 @@ params {
     blast_max_rank = 10 // Keep BLAST hits whose dense bitscore rank for that query is at most this value
     blast_perc_id = 60 // Percent identity threshold for BLAST hits
     blast_qcov_hsp_perc = 30 // Query coverage threshold for BLAST hits
+    taxid_artificial = "81077" // Parent taxid for artificial sequences in NCBI taxonomy
 }
 
 includeConfig "${projectDir}/configs/containers.config"

--- a/tests/configs/run_ont.config
+++ b/tests/configs/run_ont.config
@@ -32,6 +32,7 @@ params {
     blast_max_rank = 5 // Keep BLAST hits whose dense bitscore rank for that query is at most this value
     blast_perc_id = 0 // Percent identity threshold for BLAST hits
     blast_qcov_hsp_perc = 0 // Query coverage threshold for BLAST hits
+    taxid_artificial = "81077" // Parent taxid for artificial sequences in NCBI taxonomy
 }
 
 includeConfig "${projectDir}/configs/containers.config"

--- a/tests/configs/run_validation.config
+++ b/tests/configs/run_validation.config
@@ -20,6 +20,7 @@ params {
     blast_max_rank = 5 // Keep BLAST hits whose dense bitscore rank for that query is at most this value
     blast_perc_id = 60 // Percent identity threshold for BLAST hits
     blast_qcov_hsp_perc = 30 // Query coverage threshold for BLAST hits
+    taxid_artificial = "81077" // Parent taxid for artificial sequences in NCBI taxonomy
 
     // Other
     drop_unpaired = false // Whether to drop reads from TSV that lack a pair sequence (otherwise replace with "N")

--- a/tests/modules/local/lcaTsv/main.nf.test
+++ b/tests/modules/local/lcaTsv/main.nf.test
@@ -397,4 +397,92 @@ nextflow_process {
         }
     }
 
+    test("Should correctly handle fully empty input (no header)"){
+        tag "expect_success"
+        tag "empty_input"
+        when {
+            params {
+                input_path = "${projectDir}/test-data/toy-data/empty_file.txt"
+                nodes_db_path = "${projectDir}/test-data/toy-data/lca-taxonomy/test-nodes.dmp"
+                names_db_path = "${projectDir}/test-data/toy-data/lca-taxonomy/test-names.dmp"
+                group_field = "seq_id"
+                taxid_field = "taxid"
+                score_field = "test_score"
+                artificial_taxid = 8000
+                prefix = "test"
+            }
+            process {
+                '''
+                input[0] = Channel.of("test")
+                    | combine(Channel.of(params.input_path))
+                input[1] = params.nodes_db_path
+                input[2] = params.names_db_path
+                input[3] = params.group_field
+                input[4] = params.taxid_field
+                input[5] = params.score_field
+                input[6] = params.artificial_taxid
+                input[7] = params.prefix
+                '''
+            }
+        }
+        then {
+            // Should run without errors
+            assert process.success
+            // Output should be empty
+            def output_file = path(process.out.output[0][1])
+            assert output_file.exists()
+            assert output_file.size() == 0
+        }
+    }
+
+    test("Should correctly handle empty input (header only)"){
+        tag "expect_success"
+        tag "empty_input"
+        when {
+            params {
+                input_path = "${projectDir}/test-data/toy-data/lca-taxonomy/test-input-empty.tsv"
+                nodes_db_path = "${projectDir}/test-data/toy-data/lca-taxonomy/test-nodes.dmp"
+                names_db_path = "${projectDir}/test-data/toy-data/lca-taxonomy/test-names.dmp"
+                group_field = "seq_id"
+                taxid_field = "taxid"
+                score_field = "test_score"
+                artificial_taxid = 8000
+                prefix = "test"
+            }
+            process {
+                '''
+                input[0] = Channel.of("test")
+                    | combine(Channel.of(params.input_path))
+                input[1] = params.nodes_db_path
+                input[2] = params.names_db_path
+                input[3] = params.group_field
+                input[4] = params.taxid_field
+                input[5] = params.score_field
+                input[6] = params.artificial_taxid
+                input[7] = params.prefix
+                '''
+            }
+        }
+        then {
+            // Should run without errors
+            assert process.success
+            // Output should be empty
+            def output_file = path(process.out.output[0][1])
+            assert output_file.exists()
+            assert output_file.readLines().size() == 1
+            // Output should have expected column names
+            def exp_headers_base = [params.taxid_field + "_lca",
+                "n_assignments_total", "n_assignments_classified",
+                params.taxid_field + "_top", params.taxid_field + "_top_classified",
+                params.score_field + "_min", params.score_field + "_max",
+                params.score_field + "_mean"]
+            def exp_headers_prefixed = exp_headers_base.collect { params.prefix + "_" + it }
+            def exp_headers_all = exp_headers_prefixed.collect { it + "_all" }
+            def exp_headers_natural = exp_headers_prefixed.collect { it + "_natural" }
+            def exp_headers_artificial = exp_headers_prefixed.collect { it + "_artificial" }
+            def exp_headers = [params.group_field] + exp_headers_all + exp_headers_natural + exp_headers_artificial
+            def exp_headers_joined = exp_headers.join("\t")
+            assert output_file.readLines()[0] == exp_headers_joined
+        }
+    }
 }

--- a/tests/subworkflows/local/blastFasta/main.nf.test
+++ b/tests/subworkflows/local/blastFasta/main.nf.test
@@ -46,16 +46,18 @@ nextflow_workflow {
                 min_frac = 0.9
                 perc_id = 60
                 qcov_hsp_perc = 30
+                taxid_artificial = 81077
             }
             workflow {
                 '''
                 input[0] = CONVERT_FASTQ_FASTA.out.output
-                input[1] = "${params.ref_dir}/results/${params.blast_db_prefix}"
+                input[1] = params.ref_dir
                 input[2] = params.blast_db_prefix
                 input[3] = params.perc_id
                 input[4] = params.qcov_hsp_perc
                 input[5] = params.max_rank
                 input[6] = params.min_frac
+                input[7] = params.taxid_artificial
                 '''
             }
         }
@@ -134,16 +136,18 @@ nextflow_workflow {
                 min_frac = 0.9
                 perc_id = 60
                 qcov_hsp_perc = 30
+                taxid_artificial = 81077
             }
             workflow {
                 '''
                 input[0] = CONVERT_FASTQ_FASTA.out.output
-                input[1] = "${params.ref_dir}/results/${params.blast_db_prefix}"
+                input[1] = params.ref_dir
                 input[2] = params.blast_db_prefix
                 input[3] = params.perc_id
                 input[4] = params.qcov_hsp_perc
                 input[5] = params.max_rank
                 input[6] = params.min_frac
+                input[7] = params.taxid_artificial
                 '''
             }
         }
@@ -222,16 +226,18 @@ nextflow_workflow {
                 min_frac = 0.9
                 perc_id = 0
                 qcov_hsp_perc = 0
+                taxid_artificial = 81077
             }
             workflow {
                 '''
                 input[0] = CONVERT_FASTQ_FASTA.out.output
-                input[1] = "${params.ref_dir}/results/${params.blast_db_prefix}"
+                input[1] = params.ref_dir
                 input[2] = params.blast_db_prefix
                 input[3] = params.perc_id
                 input[4] = params.qcov_hsp_perc
                 input[5] = params.max_rank
                 input[6] = params.min_frac
+                input[7] = params.taxid_artificial
                 '''
             }
         }
@@ -268,6 +274,56 @@ nextflow_workflow {
             def ids_in = fasta_in.keySet().collect{ it.tokenize(" ")[0] }.toSet()
             def ids_out = tab_out.columns["qseqid"].toSet()
             assert ids_in.containsAll(ids_out)
+        }
+    } 
+
+    test("Should handle empty input files properly") {
+        tag "expect_success"
+        tag "empty_input"
+        config "tests/configs/run.config"
+        setup {
+            run("GZIP_FILE") {
+                script "modules/local/gzipFile/main.nf"
+                process {
+                    """
+                    input[0] = Channel.of("empty_sample").combine(Channel.of("${projectDir}/test-data/toy-data/empty_file.txt"))
+                    """
+                }
+            }
+        }
+        when {
+            params {
+                max_rank = 5
+                min_frac = 0.9
+                perc_id = 60
+                qcov_hsp_perc = 30
+                taxid_artificial = 81077
+            }
+            workflow {
+                '''
+                input[0] = GZIP_FILE.out
+                input[1] = params.ref_dir
+                input[2] = params.blast_db_prefix
+                input[3] = params.perc_id
+                input[4] = params.qcov_hsp_perc
+                input[5] = params.max_rank
+                input[6] = params.min_frac
+                input[7] = params.taxid_artificial
+                '''
+            }
+        }
+        then {
+            // Should run without failures
+            assert workflow.success
+            // Tabular output should have header row only
+            def tab_out = path(workflow.out.blast[0][1]).linesGzip
+            assert tab_out.size() == 1
+            def cols_out_exp = ["qseqid", "sseqid", "sgi", "staxid", "qlen", "evalue",
+                         "bitscore", "qcovs", "length", "pident", "mismatch",
+                         "gapopen", "sstrand", "qstart", "qend", "sstart", "send",
+                         "bitscore_rank_dense", "bitscore_fraction"]
+            def cols_out = tab_out[0].split("\t")
+            assert cols_out == cols_out_exp
         }
     }
 

--- a/tests/subworkflows/local/blastFasta/main.nf.test
+++ b/tests/subworkflows/local/blastFasta/main.nf.test
@@ -1,4 +1,11 @@
 def checkGzipSorted = { file,key -> ["bash", "-c", "zcat " + file + " | sort -C " + key + " && printf 1 || printf 0"].execute().text.trim() as Integer }
+def exp_lca_headers_base = ["staxid_lca", "n_assignments_total", "n_assignments_classified",
+    "staxid_top", "staxid_top_classified", "bitscore_min", "bitscore_max", "bitscore_mean"]
+def exp_lca_headers_prefixed = exp_lca_headers_base.collect{ "blast_${it}" }
+def exp_lca_headers_all = exp_lca_headers_prefixed.collect{ it + "_all" }
+def exp_lca_headers_natural = exp_lca_headers_prefixed.collect{ it + "_natural" }
+def exp_lca_headers_artificial = exp_lca_headers_prefixed.collect{ it + "_artificial" }
+def exp_lca_headers = ["qseqid"] + exp_lca_headers_all + exp_lca_headers_natural + exp_lca_headers_artificial
 
 nextflow_workflow {
 
@@ -94,6 +101,11 @@ nextflow_workflow {
             def ids_in = fasta_in.keySet().collect{ it.tokenize(" ")[0] }.toSet()
             def ids_out = tab_out.columns["qseqid"].toSet()
             assert ids_in.containsAll(ids_out)
+            // LCA output should have expected columns
+            def lca_out = path(workflow.out.lca[0][1]).csv(sep: "\t", decompress: true)
+            assert lca_out.columnNames == exp_lca_headers
+            // LCA output should have one row per sequence in BLAST output
+            assert lca_out.rowCount == tab_out.columns["qseqid"].toSet().size()
         }
     }
 
@@ -184,6 +196,11 @@ nextflow_workflow {
             def ids_in = fasta_in.keySet().collect{ it.tokenize(" ")[0] }.toSet()
             def ids_out = tab_out.columns["qseqid"].toSet()
             assert ids_in.containsAll(ids_out)
+            // LCA output should have expected columns
+            def lca_out = path(workflow.out.lca[0][1]).csv(sep: "\t", decompress: true)
+            assert lca_out.columnNames == exp_lca_headers
+            // LCA output should have one row per sequence in BLAST output
+            assert lca_out.rowCount == tab_out.columns["qseqid"].toSet().size()
         }
     }
 
@@ -274,6 +291,11 @@ nextflow_workflow {
             def ids_in = fasta_in.keySet().collect{ it.tokenize(" ")[0] }.toSet()
             def ids_out = tab_out.columns["qseqid"].toSet()
             assert ids_in.containsAll(ids_out)
+            // LCA output should have expected columns
+            def lca_out = path(workflow.out.lca[0][1]).csv(sep: "\t", decompress: true)
+            assert lca_out.columnNames == exp_lca_headers
+            // LCA output should have one row per sequence in BLAST output
+            assert lca_out.rowCount == tab_out.columns["qseqid"].toSet().size()
         }
     } 
 
@@ -324,7 +346,11 @@ nextflow_workflow {
                          "bitscore_rank_dense", "bitscore_fraction"]
             def cols_out = tab_out[0].split("\t")
             assert cols_out == cols_out_exp
+            // LCA output should have header row only
+            def lca_out = path(workflow.out.lca[0][1]).linesGzip
+            assert lca_out.size() == 1
+            def cols_lca_out = lca_out[0].split("\t")
+            assert cols_lca_out == exp_lca_headers
         }
     }
-
 }

--- a/tests/subworkflows/local/blastViral/main.nf.test
+++ b/tests/subworkflows/local/blastViral/main.nf.test
@@ -29,11 +29,12 @@ nextflow_workflow {
                 blast_frac = 0.9
                 perc_id = 60
                 qcov_hsp_perc = 30
+                taxid_artificial = 81077
             }
             workflow {
                 '''
                 input[0] = GZIP_FILE.out.collect{it[1]}
-                input[1] = "${params.ref_dir}/results/${params.blast_db_prefix}"
+                input[1] = params.ref_dir
                 input[2] = params.blast_db_prefix
                 input[3] = params.blast_frac
                 input[4] = params.max_rank
@@ -41,6 +42,7 @@ nextflow_workflow {
                 input[6] = ""
                 input[7] = params.perc_id
                 input[8] = params.qcov_hsp_perc
+                input[9] = params.taxid_artificial
                 '''
             }
         }
@@ -93,11 +95,12 @@ nextflow_workflow {
                 blast_frac = 0.9
                 perc_id = 60
                 qcov_hsp_perc = 30
+                taxid_artificial = 81077
             }
             workflow {
                 '''
                 input[0] = INTERLEAVE_FASTQ.out.output.collect{it[1]}
-                input[1] = "${params.ref_dir}/results/${params.blast_db_prefix}"
+                input[1] = params.ref_dir
                 input[2] = params.blast_db_prefix
                 input[3] = params.blast_frac
                 input[4] = params.max_rank
@@ -105,6 +108,7 @@ nextflow_workflow {
                 input[6] = ""
                 input[7] = params.perc_id
                 input[8] = params.qcov_hsp_perc
+                input[9] = params.taxid_artificial
                 '''
             }
         }
@@ -194,11 +198,12 @@ nextflow_workflow {
                 blast_frac = 0.9
                 perc_id = 60
                 qcov_hsp_perc = 30
+                taxid_artificial = 81077
             }
             workflow {
                 '''
                 input[0] = COPY_FILE.out.collect{it[1]}
-                input[1] = "${params.ref_dir}/results/${params.blast_db_prefix}"
+                input[1] = params.ref_dir
                 input[2] = params.blast_db_prefix
                 input[3] = params.blast_frac
                 input[4] = params.max_rank
@@ -206,6 +211,7 @@ nextflow_workflow {
                 input[6] = ""
                 input[7] = params.perc_id
                 input[8] = params.qcov_hsp_perc
+                input[9] = params.taxid_artificial
                 '''
             }
         }
@@ -295,11 +301,12 @@ nextflow_workflow {
                 blast_frac = 0.9
                 perc_id = 0
                 qcov_hsp_perc = 0
+                taxid_artificial = 81077
             }
             workflow {
                 '''
                 input[0] = COPY_FILE.out.collect{it[1]}
-                input[1] = "${params.ref_dir}/results/${params.blast_db_prefix}"
+                input[1] = params.ref_dir
                 input[2] = params.blast_db_prefix
                 input[3] = params.blast_frac
                 input[4] = params.max_rank
@@ -307,6 +314,7 @@ nextflow_workflow {
                 input[6] = ""
                 input[7] = params.perc_id
                 input[8] = params.qcov_hsp_perc
+                input[9] = params.taxid_artificial
                 '''
             }
         }

--- a/tests/subworkflows/local/validateViralAssignments/main.nf.test
+++ b/tests/subworkflows/local/validateViralAssignments/main.nf.test
@@ -81,6 +81,7 @@ nextflow_workflow {
             // Basic BLAST invocation should work as expected
             def blast_db = workflow.out.test_blast_db.collect{path(it[1]).csv(sep: "\t",decompress: true)}
             def blast_query = workflow.out.test_blast_query.collect{path(it[1]).fasta}
+            def blast_lca = workflow.out.test_blast_lca.collect{path(it[1]).csv(sep: "\t",decompress: true)}
             def cluster_fasta = workflow.out.test_reps_fasta.collect{path(it[1]).fasta}
             assert blast_query == cluster_fasta
             assert blast_db.size() == blast_query.size()
@@ -92,6 +93,8 @@ nextflow_workflow {
                 def ids_in = blast_query[i].keySet().collect{ it.tokenize(" ")[0] }.toSet()
                 def ids_out = blast_db[i].columns["qseqid"].toSet()
                 assert ids_in.containsAll(ids_out)
+                // LCA output should have one row per sequence in BLAST output
+                assert blast_lca[i].rowCount == blast_db[i].columns["qseqid"].toSet().size()
             }
         }
     }

--- a/tests/subworkflows/local/validateViralAssignments/main.nf.test
+++ b/tests/subworkflows/local/validateViralAssignments/main.nf.test
@@ -41,6 +41,7 @@ nextflow_workflow {
         when {
             params {
                 n_clusters = 10
+                taxid_artificial = 81077
             }
             workflow {
                 '''
@@ -49,12 +50,13 @@ nextflow_workflow {
                 input[2] = params.validation_cluster_identity // cluster_identity
                 input[3] = 15 // cluster_min_len
                 input[4] = params.n_clusters // n_clusters
-                input[5] = "${params.ref_dir}/results/${params.blast_db_prefix}" // blast_db_dir TODO
+                input[5] = params.ref_dir // ref_dir
                 input[6] = params.blast_db_prefix // blast_db_prefix
                 input[7] = params.blast_perc_id // perc_id
                 input[8] = params.blast_qcov_hsp_perc // qcov_hsp_perc
                 input[9] = params.blast_max_rank // blast_max_rank
                 input[10] = params.blast_min_frac // blast_min_frac
+                input[11] = params.taxid_artificial // taxid_artificial
                 '''
             }
         }

--- a/workflows/run.nf
+++ b/workflows/run.nf
@@ -66,9 +66,9 @@ workflow RUN {
     }
     // BLAST validation on host-viral reads (optional)
     if ( params.blast_viral_fraction > 0 ) {
-        BLAST_VIRAL(hits_fastq, blast_db_path, params.blast_db_prefix,
+        BLAST_VIRAL(hits_fastq, params.ref_dir, params.blast_db_prefix,
             params.blast_viral_fraction, params.blast_max_rank, params.blast_min_frac, params.random_seed,
-            params.blast_perc_id, params.blast_qcov_hsp_perc)
+            params.blast_perc_id, params.blast_qcov_hsp_perc, params.taxid_artificial)
         blast_subset_ch = BLAST_VIRAL.out.blast_subset
         blast_reads_ch = BLAST_VIRAL.out.subset_reads
     } else {

--- a/workflows/run_validation.nf
+++ b/workflows/run_validation.nf
@@ -35,10 +35,9 @@ workflow RUN_VALIDATION {
     }
 
     // BLAST validation on host-viral reads
-    blast_db_path = "${params.ref_dir}/results/${params.blast_db_prefix}"
-    BLAST_VIRAL(fastq_ch, blast_db_path, params.blast_db_prefix,
+    BLAST_VIRAL(fastq_ch, params.ref_dir, params.blast_db_prefix,
         params.blast_viral_fraction, params.blast_max_rank, params.blast_min_frac, params.random_seed,
-        params.blast_perc_id, params.blast_qcov_hsp_perc)
+        params.blast_perc_id, params.blast_qcov_hsp_perc, params.taxid_artificial)
 
     // Publish results (NB: BLAST workflow has its own publish directive)
     params_str = JsonOutput.prettyPrint(JsonOutput.toJson(params))


### PR DESCRIPTION
In recent PRs, I've implemented LCA on tabular data. In this PR, I apply that to filtered, tabular BLAST output in the BLAST_VIRAL subworkflow, propagate that change through parent workflows, and implement appropriate tests. In order to make all of these pass, I also needed to add explicit empty-file handling to LCA_TSV.