### PR TITLE
Modify BLAST_FASTA to make LCA column prefix configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,9 @@ pipeline_report.txt
 .nf-test*
 **/Cargo.lock
 **/target
+
+.vscode/*
+*/__pycache__
+node_modules/*
+package-lock.json
+package.json

--- a/subworkflows/local/blastFasta/main.nf
+++ b/subworkflows/local/blastFasta/main.nf
@@ -30,6 +30,7 @@ workflow BLAST_FASTA {
         blast_max_rank // Only keep alignments that are in the top-N for that query by bitscore
         blast_min_frac // Only keep alignments that have at least this fraction of the best bitscore for that query
         taxid_artificial // Parent taxid for artificial sequences in NCBI taxonomy
+        lca_prefix // Prefix for LCA column names (e.g. "blast")
     main:
         // 0. Get reference paths
         blast_db_dir = "${ref_dir}/results/${blast_db_prefix}"
@@ -49,7 +50,7 @@ workflow BLAST_FASTA {
         // 4. Apply LCA to BLAST output
         lca_ch = LCA_TSV(filter_ch_2, nodes_db, names_db,
             "qseqid", "staxid", "bitscore", taxid_artificial,
-            "blast").output
+            lca_prefix).output
     emit:
         lca = lca_ch
         blast = filter_ch_2

--- a/subworkflows/local/blastViral/main.nf
+++ b/subworkflows/local/blastViral/main.nf
@@ -37,7 +37,7 @@ workflow BLAST_VIRAL {
         // 3. Run BLAST and process output
         blast_ch = BLAST_FASTA(fasta_ch, ref_dir, blast_db_prefix,
             perc_id, qcov_hsp_perc, blast_max_rank, blast_min_frac,
-            taxid_artificial)
+            taxid_artificial, "blast")
         // 4. Rename subset FASTA file for output
         copy_ch = COPY_FILE(fasta_ch, "blast_input_subset.fasta.gz")
     emit:

--- a/subworkflows/local/blastViral/main.nf
+++ b/subworkflows/local/blastViral/main.nf
@@ -37,7 +37,7 @@ workflow BLAST_VIRAL {
         // 3. Run BLAST and process output
         blast_ch = BLAST_FASTA(fasta_ch, ref_dir, blast_db_prefix,
             perc_id, qcov_hsp_perc, blast_max_rank, blast_min_frac,
-            taxid_artificial, "blast")
+            taxid_artificial, "validation")
         // 4. Rename subset FASTA file for output
         copy_ch = COPY_FILE(fasta_ch, "blast_input_subset.fasta.gz")
     emit:

--- a/subworkflows/local/validateViralAssignments/main.nf
+++ b/subworkflows/local/validateViralAssignments/main.nf
@@ -45,7 +45,12 @@ workflow VALIDATE_VIRAL_ASSIGNMENTS {
             cluster_min_len, n_clusters, Channel.of(false))
         // 3. BLAST cluster representatives
         blast_ch = BLAST_FASTA(cluster_ch.fasta, ref_dir, blast_db_prefix,
-            perc_id, qcov_hsp_perc, blast_max_rank, blast_min_frac, taxid_artificial)
+            perc_id, qcov_hsp_perc, blast_max_rank, blast_min_frac, taxid_artificial,
+            "validation")
+        // 4. Validate hit TSVs against BLAST results
+        validate_ch = VALIDATE_VIRAL_TAXIDS(split_ch.tsv, blast_ch.lca)
+        // 4. Merge hit TSV with validation information for representative sequences
+        merge_ch =
         // 4. Concatenate clustering information across species to regenerate per-group information
         // NB: This concatenation stage will move down as more steps are added, but will need to happen eventually
         // and is useful for testing, so I'm implementing it now. It should probably get moved into its own

--- a/subworkflows/local/validateViralAssignments/main.nf
+++ b/subworkflows/local/validateViralAssignments/main.nf
@@ -47,10 +47,6 @@ workflow VALIDATE_VIRAL_ASSIGNMENTS {
         blast_ch = BLAST_FASTA(cluster_ch.fasta, ref_dir, blast_db_prefix,
             perc_id, qcov_hsp_perc, blast_max_rank, blast_min_frac, taxid_artificial,
             "validation")
-        // 4. Validate hit TSVs against BLAST results
-        validate_ch = VALIDATE_VIRAL_TAXIDS(split_ch.tsv, blast_ch.lca)
-        // 4. Merge hit TSV with validation information for representative sequences
-        merge_ch =
         // 4. Concatenate clustering information across species to regenerate per-group information
         // NB: This concatenation stage will move down as more steps are added, but will need to happen eventually
         // and is useful for testing, so I'm implementing it now. It should probably get moved into its own

--- a/tests/subworkflows/local/blastFasta/main.nf.test
+++ b/tests/subworkflows/local/blastFasta/main.nf.test
@@ -1,7 +1,7 @@
 def checkGzipSorted = { file,key -> ["bash", "-c", "zcat " + file + " | sort -C " + key + " && printf 1 || printf 0"].execute().text.trim() as Integer }
 def exp_lca_headers_base = ["staxid_lca", "n_assignments_total", "n_assignments_classified",
     "staxid_top", "staxid_top_classified", "bitscore_min", "bitscore_max", "bitscore_mean"]
-def exp_lca_headers_prefixed = exp_lca_headers_base.collect{ "blast_${it}" }
+def exp_lca_headers_prefixed = exp_lca_headers_base.collect{ "testprefix_${it}" }
 def exp_lca_headers_all = exp_lca_headers_prefixed.collect{ it + "_all" }
 def exp_lca_headers_natural = exp_lca_headers_prefixed.collect{ it + "_natural" }
 def exp_lca_headers_artificial = exp_lca_headers_prefixed.collect{ it + "_artificial" }
@@ -54,6 +54,7 @@ nextflow_workflow {
                 perc_id = 60
                 qcov_hsp_perc = 30
                 taxid_artificial = 81077
+                lca_prefix = "testprefix"
             }
             workflow {
                 '''
@@ -65,6 +66,7 @@ nextflow_workflow {
                 input[5] = params.max_rank
                 input[6] = params.min_frac
                 input[7] = params.taxid_artificial
+                input[8] = params.lca_prefix
                 '''
             }
         }
@@ -149,6 +151,7 @@ nextflow_workflow {
                 perc_id = 60
                 qcov_hsp_perc = 30
                 taxid_artificial = 81077
+                lca_prefix = "testprefix"
             }
             workflow {
                 '''
@@ -160,6 +163,7 @@ nextflow_workflow {
                 input[5] = params.max_rank
                 input[6] = params.min_frac
                 input[7] = params.taxid_artificial
+                input[8] = params.lca_prefix
                 '''
             }
         }
@@ -244,6 +248,7 @@ nextflow_workflow {
                 perc_id = 0
                 qcov_hsp_perc = 0
                 taxid_artificial = 81077
+                lca_prefix = "testprefix"
             }
             workflow {
                 '''
@@ -255,6 +260,7 @@ nextflow_workflow {
                 input[5] = params.max_rank
                 input[6] = params.min_frac
                 input[7] = params.taxid_artificial
+                input[8] = params.lca_prefix
                 '''
             }
         }
@@ -320,6 +326,7 @@ nextflow_workflow {
                 perc_id = 60
                 qcov_hsp_perc = 30
                 taxid_artificial = 81077
+                lca_prefix = "testprefix"
             }
             workflow {
                 '''
@@ -331,6 +338,7 @@ nextflow_workflow {
                 input[5] = params.max_rank
                 input[6] = params.min_frac
                 input[7] = params.taxid_artificial
+                input[8] = params.lca_prefix
                 '''
             }
         }


### PR DESCRIPTION
Tiny PR to make LCA column prefix in BLAST_FASTA configurable, and to modify the default in VALIDATE_VIRAL_ASSIGNMENTS to "validation" instead of "blast". This means we can change the aligner used for post-hoc validation in future without needing to rename columns (and so hopefully avoid a schema update).

Local tests for BLAST_FASTA all pass.