### PR TITLE
Rework SORT_TSV to avoid memory overload (attempt 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Continued working on post-hoc validation of putative viral hits in the DOWNSTREAM workflow
     - Implemented VALIDATE_CLUSTER_REPRESENTATIVES subworkflow for comparing Bowtie2 and BLAST-LCA assignments, including new SELECT_TSV_COLUMNS and COMPUTE_TAXID_DISTANCE processes
+    - Implemented PROPAGATE_VALIDATION_INFORMATION subworkflow to merge cluster-representative validation information back into raw hits TSV
+    - Implemented CHECK_TSV_DUPLICATES process and added to SPLIT_VIRAL_TSV_BY_SPECIES to prevent many-to-many joins during post-hoc validation
+    - Implemented CONCATENATE_TSVS_ACROSS_SPECIES subworkflow for reconstructing grouped viral hits TSV from species-specific TSVs
+- Modified SORT_TSV behavior to avoid out-of-memory errors.
 
 # v2.9.0.1
 

--- a/modules/local/sortTsv/main.nf
+++ b/modules/local/sortTsv/main.nf
@@ -12,7 +12,7 @@ process SORT_TSV {
     shell:
         '''
         # Run the Python script to sort the TSV
-        sort_tsv.py !{tsv} !{sort_field} sorted_!{sort_field}_!{tsv}
+        sort_tsv.py -m !{task.memory.toGiga()} !{tsv} !{sort_field} sorted_!{sort_field}_!{tsv}
         
         # Link input to output for testing
         ln -s !{tsv} input_!{tsv}

--- a/modules/local/sortTsv/main.nf
+++ b/modules/local/sortTsv/main.nf
@@ -2,7 +2,7 @@
 // Uses Python script to handle empty files properly
 process SORT_TSV {
     label "python"
-    label "single"
+    label "single_cpu_16GB_memory"
     input:
         tuple val(sample), path(tsv)
         val(sort_field)

--- a/modules/local/sortTsv/resources/usr/bin/sort_tsv.py
+++ b/modules/local/sortTsv/resources/usr/bin/sort_tsv.py
@@ -69,7 +69,7 @@ def open_by_suffix(filename: str, mode: str = "r") -> io.TextIOWrapper:
     if filename.endswith('.gz'):
         return gzip.open(filename, mode + 't')
     elif filename.endswith('.bz2'):
-        return bz2.BZ2file(filename, mode)
+        return bz2.BZ2File(filename, mode)
     else:
         return open(filename, mode)
 
@@ -166,12 +166,23 @@ def run_sort(input_file: str,
         sort_index (int): The index of the column to sort by.
         temp_dir (str): The temporary directory for GNU sort to use.
     """
-    sort_cmd = ["sort", "-t", "\t", "-k", f"{sort_index+1},{sort_index+1}",
-                f"--temporary-directory={temp_dir}/sort",
-                "-o", output_file, input_file]
+    # Create the sort temporary directory
+    sort_temp_dir = os.path.join(temp_dir, "sort")
+    os.makedirs(sort_temp_dir, exist_ok=True)
+    logger.debug(f"Created sort temporary directory: {sort_temp_dir}")
+    # Build sort command with memory limits and proper temporary directory
+    sort_cmd = [
+        "sort", 
+        "-t", "\t",  # Tab delimiter
+        "-k", f"{sort_index+1},{sort_index+1}",  # Sort key
+        f"--temporary-directory={sort_temp_dir}",  # Temporary directory
+        "-o", output_file,  # Output file
+        input_file  # Input file
+    ]
     logger.debug(f"Running sort command: {sort_cmd}")
     try:
         subprocess.run(sort_cmd, check=True)
+        logger.debug("Sort command completed successfully")
     except subprocess.CalledProcessError as e:
         logger.error(f"Sort command failed: {e}")
         raise


### PR DESCRIPTION
My last attempt to address #298 (#318) was only partially successful; some runs still failed with OOM errors. This PR takes a more thorough approach, explicitly specifying GNU sort's memory allocation as well as using a custom temporary directory that's definitely writing to disk. I've tested it on one of the runs that was previously failing and it now succeeds, so I'm optimistic that this time will work.