### PR TITLE
Will post hoc distance

### DIFF
--- a/modules/local/computeTaxidDistance/main.nf
+++ b/modules/local/computeTaxidDistance/main.nf
@@ -12,7 +12,8 @@ process COMPUTE_TAXID_DISTANCE {
         tuple val(sample), path(tsv) // Sorted TSV with two taxid columns
         val(taxid_field_1) // Column header for first taxid field
         val(taxid_field_2) // Column header for second taxid field
-        val(distance_field) // Column header for new distance field
+        val(distance_field_1) // Column header for first new distance field
+        val(distance_field_2) // Column header for second new distance field
         path(nodes_db) // TSV containing taxonomic structure (mapping taxids to parent taxids)
     output:
         tuple val(sample), path("distance_${tsv}"), emit: output // Distance-computed TSV
@@ -21,7 +22,7 @@ process COMPUTE_TAXID_DISTANCE {
         '''
         # Set up and run Python script
         io="-i !{tsv} -o distance_!{tsv} -n !{nodes_db}"
-        par="-t1 !{taxid_field_1} -t2 !{taxid_field_2} -d !{distance_field}"
+        par="-t1 !{taxid_field_1} -t2 !{taxid_field_2} -d1 !{distance_field_1} -d2 !{distance_field_2}"
         compute_taxid_distance.py ${io} ${par}
         # Link input file to output for testing
         ln -s !{tsv} input_!{tsv}

--- a/subworkflows/local/validateClusterRepresentatives/main.nf
+++ b/subworkflows/local/validateClusterRepresentatives/main.nf
@@ -25,7 +25,8 @@ workflow VALIDATE_CLUSTER_REPRESENTATIVES {
         lca_tsv // LCA TSV from validation against core_nt
         hits_taxid_column // Column header for original taxid in hits TSV
         lca_taxid_column // Column header for LCA taxid in LCA TSV
-        tax_dist_column // Column header for taxonomic distance in hits TSV
+        tax_dist_column_1 // Column header for taxonomic distance in hits TSV
+        tax_dist_column_2 // Column header for taxonomic distance in hits TSV
         ref_dir // Path to reference directory containing taxonomy information
     main:
         // 0. Get reference paths
@@ -43,7 +44,7 @@ workflow VALIDATE_CLUSTER_REPRESENTATIVES {
         join_ch = JOIN_TSVS(combine_ch, "seq_id", "inner", "representative").output
         // 3. Compute taxonomic distance between original and validated taxids
         dist_ch = COMPUTE_TAXID_DISTANCE(join_ch, hits_taxid_column, lca_taxid_column,
-            tax_dist_column, nodes_db).output
+            tax_dist_column_1, tax_dist_column_2, nodes_db).output
         // NB: As implemented, this will produce a negative distance if the original
         // taxid is too high (ancestor of LCA taxid), and a positive distance if the
         // original taxid is too low (descendant of LCA taxid).

--- a/subworkflows/local/validateViralAssignments/main.nf
+++ b/subworkflows/local/validateViralAssignments/main.nf
@@ -59,7 +59,7 @@ workflow VALIDATE_VIRAL_ASSIGNMENTS {
         validate_ch = VALIDATE_CLUSTER_REPRESENTATIVES(groups, blast_ch.lca,
             "bowtie2_taxid_best", // Column header for original taxid in hits TSV
             "validation_staxid_lca_natural", // LCA taxid computed from BLAST results, excluding artificial sequences
-            "validation_distance", ref_dir)
+            "validation_distance_bowtie2", "validation_distance_validation", ref_dir)
         // 6. Propagate validation information back to individual hits
         propagate_ch = PROPAGATE_VALIDATION_INFORMATION(groups, concat_cluster_ch.output,
             validate_ch.output, "bowtie2_taxid_best")

--- a/test-data/toy-data/taxonomy-distance/test-input.tsv
+++ b/test-data/toy-data/taxonomy-distance/test-input.tsv
@@ -1,8 +1,9 @@
-taxid1	taxid2	exp_distance	comment
-9000	9000	0	Matching taxids
-9001	9000	1	Child/parent
-9000	9001	-1	Parent/child
-9004	9000	2	Grandchild/grandparent
-9000	9004	-2	Grandparent/grandchild
-9001	9002	NA	Unrelated
-None	9000	NA	Invalid taxid
+taxid1	taxid2	exp_distance_1	exp_distance_2	comment
+9000	9000	0	0	Matching taxids
+9001	9000	1	0	Child/parent
+9000	9001	0	1	Parent/child
+9004	9000	2	0	Grandchild/grandparent
+9000	9004	0	2	Grandparent/grandchild
+9001	9002	1	1	Siblings
+9007	9009	2	3	Distant cousins
+None	9000	NA	NA	Invalid taxid

--- a/test-data/toy-data/validate-cluster-reps/test-lca.tsv
+++ b/test-data/toy-data/validate-cluster-reps/test-lca.tsv
@@ -1,6 +1,6 @@
-qseqid	lca_taxid	exp_distance
-R1	9000	1
-R2	9000	2
-R3	9005	0
-R4	9009	-1
-R5	9002	NA
+qseqid	lca_taxid	exp_distance_1	exp_distance_2
+R1	9000	1	0
+R2	9000	2	0
+R3	9005	0	0
+R4	9009	0	1
+R5	9002	1	1

--- a/tests/modules/local/computeTaxidDistance/main.nf.test
+++ b/tests/modules/local/computeTaxidDistance/main.nf.test
@@ -14,7 +14,8 @@ nextflow_process {
                 input_path = "${projectDir}/test-data/toy-data/test_tab_sorted.tsv"
                 taxid_field_1 = "x"
                 taxid_field_2 = "a"
-                distance_field = "distance"
+                distance_field_1 = "distance_1"
+                distance_field_2 = "distance_2"
                 nodes_db_path = "${projectDir}/test-data/toy-data/taxonomy-distance/test-nodes.dmp"
             }
             process {
@@ -22,8 +23,9 @@ nextflow_process {
                 input[0] = Channel.of("test").combine(Channel.of(params.input_path))
                 input[1] = params.taxid_field_1
                 input[2] = params.taxid_field_2
-                input[3] = params.distance_field
-                input[4] = params.nodes_db_path
+                input[3] = params.distance_field_1
+                input[4] = params.distance_field_2
+                input[5] = params.nodes_db_path
                 '''
             }
         }
@@ -35,7 +37,7 @@ nextflow_process {
         }
     }
 
-    test("Should fail when distance field is already present"){
+    test("Should fail when distance field 1 is already present"){
         tag "expect_failed"
         tag "distance_field"
         when {
@@ -43,7 +45,8 @@ nextflow_process {
                 input_path = "${projectDir}/test-data/toy-data/test_tab_sorted.tsv"
                 taxid_field_1 = "x"
                 taxid_field_2 = "y"
-                distance_field = "z"
+                distance_field_1 = "z"
+                distance_field_2 = "w"
                 nodes_db_path = "${projectDir}/test-data/toy-data/taxonomy-distance/test-nodes.dmp"
             }
             process {
@@ -51,8 +54,40 @@ nextflow_process {
                 input[0] = Channel.of("test").combine(Channel.of(params.input_path))
                 input[1] = params.taxid_field_1
                 input[2] = params.taxid_field_2
-                input[3] = params.distance_field
-                input[4] = params.nodes_db_path
+                input[3] = params.distance_field_1
+                input[4] = params.distance_field_2
+                input[5] = params.nodes_db_path
+                '''
+            }
+        }
+        then {
+            assert process.failed
+            assert process.exitStatus == 1
+            assert process.errorReport.contains("ValueError: Distance field already present in input header")
+            assert !process.errorReport.contains("ValueError: Header line is empty")
+        }
+    }
+
+    test("Should fail when distance field 2 is already present"){
+        tag "expect_failed"
+        tag "distance_field"
+        when {
+            params {
+                input_path = "${projectDir}/test-data/toy-data/test_tab_sorted.tsv"
+                taxid_field_1 = "x"
+                taxid_field_2 = "y"
+                distance_field_1 = "w"
+                distance_field_2 = "z"
+                nodes_db_path = "${projectDir}/test-data/toy-data/taxonomy-distance/test-nodes.dmp"
+            }
+            process {
+                '''
+                input[0] = Channel.of("test").combine(Channel.of(params.input_path))
+                input[1] = params.taxid_field_1
+                input[2] = params.taxid_field_2
+                input[3] = params.distance_field_1
+                input[4] = params.distance_field_2
+                input[5] = params.nodes_db_path
                 '''
             }
         }
@@ -71,7 +106,8 @@ nextflow_process {
                 input_path = "${projectDir}/test-data/toy-data/test_tab_sorted.tsv"
                 taxid_field_1 = "x"
                 taxid_field_2 = "y"
-                distance_field = "distance"
+                distance_field_1 = "distance_1"
+                distance_field_2 = "distance_2"
                 nodes_db_path = "${projectDir}/test-data/toy-data/taxonomy-distance/test-nodes-truncated.dmp"
             }
             process {
@@ -79,8 +115,9 @@ nextflow_process {
                 input[0] = Channel.of("test").combine(Channel.of(params.input_path))
                 input[1] = params.taxid_field_1
                 input[2] = params.taxid_field_2
-                input[3] = params.distance_field
-                input[4] = params.nodes_db_path
+                input[3] = params.distance_field_1
+                input[4] = params.distance_field_2
+                input[5] = params.nodes_db_path
                 '''
             }
         }
@@ -100,7 +137,8 @@ nextflow_process {
                 input_path = "${projectDir}/test-data/toy-data/empty_file.txt"
                 taxid_field_1 = "x"
                 taxid_field_2 = "a"
-                distance_field = "distance"
+                distance_field_1 = "distance_1"
+                distance_field_2 = "distance_2"
                 nodes_db_path = "${projectDir}/test-data/toy-data/taxonomy-distance/test-nodes.dmp"
             }
             process {
@@ -108,8 +146,9 @@ nextflow_process {
                 input[0] = Channel.of("test").combine(Channel.of(params.input_path))
                 input[1] = params.taxid_field_1
                 input[2] = params.taxid_field_2
-                input[3] = params.distance_field
-                input[4] = params.nodes_db_path
+                input[3] = params.distance_field_1
+                input[4] = params.distance_field_2
+                input[5] = params.nodes_db_path
                 '''
             }
         }
@@ -129,7 +168,8 @@ nextflow_process {
                 input_path = "${projectDir}/test-data/toy-data/test_tab_empty.tsv"
                 taxid_field_1 = "x"
                 taxid_field_2 = "y"
-                distance_field = "distance"
+                distance_field_1 = "distance_1"
+                distance_field_2 = "distance_2"
                 nodes_db_path = "${projectDir}/test-data/toy-data/taxonomy-distance/test-nodes.dmp"
             }
             process {
@@ -137,8 +177,9 @@ nextflow_process {
                 input[0] = Channel.of("test").combine(Channel.of(params.input_path))
                 input[1] = params.taxid_field_1
                 input[2] = params.taxid_field_2
-                input[3] = params.distance_field
-                input[4] = params.nodes_db_path
+                input[3] = params.distance_field_1
+                input[4] = params.distance_field_2
+                input[5] = params.nodes_db_path
                 '''
             }
         }
@@ -155,10 +196,11 @@ nextflow_process {
             // Output header should have one additional field
             def inputHeaders = inputLines[0].split("\t")
             def outputHeaders = outputLines[0].split("\t")
-            assert outputHeaders.size() == inputHeaders.size() + 1
+            assert outputHeaders.size() == inputHeaders.size() + 2
             // Output header should be the same as input header, plus the new distance field
-            assert outputHeaders[0..-2] == inputHeaders
-            assert outputHeaders[-1] == params.distance_field
+            assert outputHeaders[0..-3] == inputHeaders
+            assert outputHeaders[-2] == params.distance_field_1
+            assert outputHeaders[-1] == params.distance_field_2
         }
     }
 
@@ -170,7 +212,8 @@ nextflow_process {
                 input_path = "${projectDir}/test-data/toy-data/taxonomy-distance/test-input.tsv"
                 taxid_field_1 = "taxid1"
                 taxid_field_2 = "taxid2"
-                distance_field = "distance"
+                distance_field_1 = "distance_1"
+                distance_field_2 = "distance_2"
                 nodes_db_path = "${projectDir}/test-data/toy-data/taxonomy-distance/test-nodes.dmp"
             }
             process {
@@ -178,8 +221,9 @@ nextflow_process {
                 input[0] = Channel.of("test").combine(Channel.of(params.input_path))
                 input[1] = params.taxid_field_1
                 input[2] = params.taxid_field_2
-                input[3] = params.distance_field
-                input[4] = params.nodes_db_path
+                input[3] = params.distance_field_1
+                input[4] = params.distance_field_2
+                input[5] = params.nodes_db_path
                 '''
             }
         }
@@ -191,7 +235,7 @@ nextflow_process {
             def tab_out = path(process.out.output[0][1]).csv(sep: "\t")
             assert tab_out.rowCount == tab_in.rowCount
             // Column names should be identical except for the new distance column
-            assert tab_out.columnNames == tab_in.columnNames + [params.distance_field]
+            assert tab_out.columnNames == tab_in.columnNames + [params.distance_field_1, params.distance_field_2]
             // Taxid columns should be present
             assert params.taxid_field_1 in tab_out.columnNames
             assert params.taxid_field_2 in tab_out.columnNames
@@ -201,9 +245,12 @@ nextflow_process {
             }
             // Distance column should be computed correctly
             for (int r = 0; r < tab_out.rowCount; r++) {
-                def exp_dist = tab_out.columns["exp_distance"][r]
-                def obs_dist = tab_out.columns[params.distance_field][r]
-                assert exp_dist == obs_dist
+                def exp_dist_1 = tab_out.columns["exp_distance_1"][r]
+                def exp_dist_2 = tab_out.columns["exp_distance_2"][r]
+                def obs_dist_1 = tab_out.columns[params.distance_field_1][r]
+                def obs_dist_2 = tab_out.columns[params.distance_field_2][r]
+                assert exp_dist_1 == obs_dist_1
+                assert exp_dist_2 == obs_dist_2
             }
         }
     }

--- a/tests/subworkflows/local/validateClusterRepresentatives/main.nf.test
+++ b/tests/subworkflows/local/validateClusterRepresentatives/main.nf.test
@@ -16,7 +16,8 @@ nextflow_workflow {
                 lca_tsv = "${projectDir}/test-data/toy-data/validate-cluster-reps/test-lca.tsv"
                 hits_taxid_column = "taxid"
                 lca_taxid_column = "lca_taxid"
-                tax_dist_column = "tax_dist"
+                tax_dist_column_1 = "tax_dist_1"
+                tax_dist_column_2 = "tax_dist_2"
                 ref_dir = "${projectDir}/test-data/toy-data/validate-cluster-reps/"
             }
             workflow {
@@ -25,8 +26,9 @@ nextflow_workflow {
                 input[1] = Channel.of("test").combine(Channel.of(params.lca_tsv)) // lca_tsv
                 input[2] = params.hits_taxid_column // hits_taxid_column
                 input[3] = params.lca_taxid_column // lca_taxid_column
-                input[4] = params.tax_dist_column // tax_dist_column
-                input[5] = params.ref_dir // ref_dir
+                input[4] = params.tax_dist_column_1 // tax_dist_column_1
+                input[5] = params.tax_dist_column_2 // tax_dist_column_2
+                input[6] = params.ref_dir // ref_dir
                 '''
             }
         }
@@ -59,8 +61,9 @@ nextflow_workflow {
             // Distance computation should work as expected
             def tab_dist = path(workflow.out.test_dist[0][1]).csv(sep: "\t", decompress: true)
             assert tab_dist.rowCount == tab_join.rowCount
-            assert tab_dist.columnCount == tab_join.columnCount + 1
-            assert tab_dist.columns[params.tax_dist_column] == tab_dist.columns["exp_distance"]
+            assert tab_dist.columnCount == tab_join.columnCount + 2
+            assert tab_dist.columns[params.tax_dist_column_1] == tab_dist.columns["exp_distance_1"]
+            assert tab_dist.columns[params.tax_dist_column_2] == tab_dist.columns["exp_distance_2"]
             // Final column renaming should work as expected
             def tab_out = path(workflow.out.output[0][1]).csv(sep: "\t", decompress: true)
             assert tab_out.rowCount == tab_dist.rowCount


### PR DESCRIPTION
After discussions with @jeffkaufman and @katherine-stansifer, I'm updating the taxonomic distance metric used for post-hoc validation from a one-column metric (in which an integer number indicated that one taxonomy assignment was a direct ancestor of another, and NA indicated otherwise) to a two-column metric (where each column gives the integer distance between each tax ID and their lowest common ancestor). This PR implements that change.