### PR TITLE
Adjusting processLcaAlignerOutput to be more flexible such that we can use it for ONT LCA

### DIFF
--- a/subworkflows/local/extractViralReadsShortLca/main.nf
+++ b/subworkflows/local/extractViralReadsShortLca/main.nf
@@ -47,6 +47,19 @@ workflow EXTRACT_VIRAL_READS_SHORT_LCA {
         virus_db_path = "${ref_dir}/results/total-virus-db-annotated.tsv.gz"
         nodes_db = "${ref_dir}/results/taxonomy-nodes.dmp"
         names_db = "${ref_dir}/results/taxonomy-names.dmp"
+       // Define columns to keep, separating by ones to prefix and ones to not
+        col_keep_no_prefix = ["seq_id", "aligner_taxid_lca", "aligner_taxid_top", 
+                              "aligner_length_normalized_score_mean", "aligner_taxid_lca_natural",
+                              "aligner_n_assignments_natural", "aligner_length_normalized_score_mean_natural",
+                              "aligner_taxid_lca_artificial", "aligner_n_assignments_artificial", 
+                              "aligner_length_normalized_score_mean_artificial"]
+        col_keep_add_prefix = ["genome_id_all", "taxid_all", "fragment_length", 
+                               "best_alignment_score", "best_alignment_score_rev",
+                               "edit_distance", "edit_distance_rev", "ref_start", 
+                               "ref_start_rev", "query_len", "query_len_rev",
+                               "query_seq", "query_seq_rev", "query_rc", 
+                               "query_rc_rev", "query_qual", "query_qual_rev", 
+                               "pair_status"]
          // 1. Run initial screen against viral genomes with BBDuk
         bbduk_ch = BBDUK_HITS(reads_ch, viral_genome_path, min_kmer_hits, k, bbduk_suffix)
         // 2. Carry out stringent adapter removal with FASTP and Cutadapt
@@ -78,6 +91,8 @@ workflow EXTRACT_VIRAL_READS_SHORT_LCA {
         processed_ch = PROCESS_LCA_ALIGNER_OUTPUT(
             lca_ch.output,
             bowtie2_tsv_ch.output,
+            col_keep_no_prefix,
+            col_keep_add_prefix,
             "prim_align_"
         )
         // 10. Add sample to column

--- a/subworkflows/local/processLcaAlignerOutput/main.nf
+++ b/subworkflows/local/processLcaAlignerOutput/main.nf
@@ -18,26 +18,14 @@ workflow PROCESS_LCA_ALIGNER_OUTPUT {
     take:
         lca_tsv        // Output from LCA_TSV process
         aligner_tsv    // Output from PROCESS_VIRAL_{MINIMAP2,BOWTIE2}_SAM
+        col_keep_no_prefix // Columns to keep without prefix
+        col_keep_add_prefix // Columns to keep with prefix
         column_prefix  // Prefix to add to specified columns
     main:
-       // Define columns to keep, separating by ones to prefix and ones to not
-        col_keep_no_prefix = ["seq_id", "aligner_taxid_lca", "aligner_taxid_top", 
-                              "aligner_length_normalized_score_mean", "aligner_taxid_lca_natural",
-                              "aligner_n_assignments_natural", "aligner_length_normalized_score_mean_natural",
-                              "aligner_taxid_lca_artificial", "aligner_n_assignments_artificial", 
-                              "aligner_length_normalized_score_mean_artificial"]
-        col_keep_add_prefix = ["genome_id_all", "taxid_all", "fragment_length", 
-                               "best_alignment_score", "best_alignment_score_rev",
-                               "edit_distance", "edit_distance_rev", "ref_start", 
-                               "ref_start_rev", "query_len", "query_len_rev",
-                               "query_seq", "query_seq_rev", "query_rc", 
-                               "query_rc_rev", "query_qual", "query_qual_rev", 
-                               "pair_status"]
-        // Step 1: Sort both TSV files by seq_id for joining
+        // Step 1: Sort LCA tsv by seq_id (aligner_tsv is already sorted)
         lca_sorted_ch = SORT_LCA(lca_tsv, "seq_id")
-        aligner_sorted_ch = SORT_ALIGNER(aligner_tsv, "seq_id")
         // Step 2: Join LCA and aligner TSV on seq_id
-        joined_input_ch = lca_sorted_ch.sorted.join(aligner_sorted_ch.sorted, by: 0)
+        joined_input_ch = lca_sorted_ch.sorted.join(aligner_tsv, by: 0)
         joined_ch = JOIN_TSVS(joined_input_ch, "seq_id", "inner", "lca_aligner")
         // Step 3: Filter to keep only primary alignments
         filtered_ch = FILTER_TSV_COLUMN_BY_VALUE(joined_ch.output, "classification", "primary", true)
@@ -52,6 +40,4 @@ workflow PROCESS_LCA_ALIGNER_OUTPUT {
         output = renamed_ch.output
         test_lca = lca_tsv
         test_aligner = aligner_tsv
-        test_col_add_prefix = col_keep_add_prefix
-        test_col_no_prefix = col_keep_no_prefix
 }

--- a/tests/subworkflows/local/processLcaAlignerOutput/main.nf.test
+++ b/tests/subworkflows/local/processLcaAlignerOutput/main.nf.test
@@ -82,13 +82,17 @@ nextflow_workflow {
         }
         when {
             params {
+                col_keep_no_prefix = ["seq_id", "aligner_taxid_lca"]
+                col_keep_add_prefix = ["genome_id_all"]
                 column_prefix = "prim_align_"
             }
             workflow {
                 """
                 input[0] = LCA_TSV.out.output
                 input[1] = PROCESS_VIRAL_BOWTIE2_SAM_LCA.out.output
-                input[2] = params.column_prefix
+                input[2] = params.col_keep_no_prefix
+                input[3] = params.col_keep_add_prefix
+                input[4] = params.column_prefix
                 """
             }
         }
@@ -107,8 +111,8 @@ nextflow_workflow {
 
           // Get expected columns from workflow outputs
           // The workflow emits these as single values containing the lists
-          def colsNoPrefix = workflow.out.test_col_no_prefix[0]
-          def colsAddPrefix = workflow.out.test_col_add_prefix[0]
+          def colsNoPrefix = params.col_keep_no_prefix
+          def colsAddPrefix = params.col_keep_add_prefix
           
           // Validate expected columns exist
           // Columns without prefix
@@ -219,13 +223,17 @@ nextflow_workflow {
 
         when {
             params {
+                col_keep_no_prefix = ["seq_id", "aligner_taxid_lca"]
+                col_keep_add_prefix = ["genome_id_all"]
                 column_prefix = "prim_align_"
             }
             workflow {
                 """
                 input[0] = GZIP_LCA_EMPTY.out
                 input[1] = GZIP_BOWTIE_EMPTY.out
-                input[2] = params.column_prefix
+                input[2] = params.col_keep_no_prefix
+                input[3] = params.col_keep_add_prefix
+                input[4] = params.column_prefix
                 """
             }
         }
@@ -271,14 +279,28 @@ nextflow_workflow {
 
         when {
             params {
+                col_keep_no_prefix = ["seq_id", "aligner_taxid_lca", "aligner_taxid_top", 
+                                      "aligner_length_normalized_score_mean", "aligner_taxid_lca_natural",
+                                      "aligner_n_assignments_natural", "aligner_length_normalized_score_mean_natural",
+                                      "aligner_taxid_lca_artificial", "aligner_n_assignments_artificial", 
+                                      "aligner_length_normalized_score_mean_artificial"]
+                col_keep_add_prefix = ["genome_id_all", "taxid_all", "fragment_length", 
+                                       "best_alignment_score", "best_alignment_score_rev",
+                                       "edit_distance", "edit_distance_rev", "ref_start", 
+                                       "ref_start_rev", "query_len", "query_len_rev",
+                                       "query_seq", "query_seq_rev", "query_rc", 
+                                       "query_rc_rev", "query_qual", "query_qual_rev", 
+                                       "pair_status"]
                 column_prefix = "prim_align_"
             }
             workflow {
                 """
                 input[0] = GZIP_LCA_HEADER_ONLY.out
                 input[1] = GZIP_BOWTIE2_SAM_PROCESSED_HEADER_ONLY.out
-                input[2] = params.column_prefix
-                """
+                input[2] = params.col_keep_no_prefix
+                input[3] = params.col_keep_add_prefix
+                input[4] = params.column_prefix
+                 """
             }
         }
 
@@ -296,8 +318,8 @@ nextflow_workflow {
 
             // Get expected columns from workflow outputs
             // The workflow emits these as single values containing the lists
-            def colsNoPrefix = workflow.out.test_col_no_prefix[0]
-            def colsAddPrefix = workflow.out.test_col_add_prefix[0]
+            def colsNoPrefix = params.col_keep_no_prefix
+            def colsAddPrefix = params.col_keep_add_prefix
             
             // Validate expected columns exist
             // Columns without prefix


### PR DESCRIPTION
As the title says, due to ONT having different output columns than the short read pipeline (no `rev` columns from aligner), we need to adjust the workflow a bit.

Tests passing:
- processLcaAlignerOutput
- extractViralReadsShortLca