### PR TITLE
Updating the ONT workflow to reflect the column name change.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # v2.10.0.1-dev
 - Made new processes and subworkflows in preparation for introducing LCA to our pipeline:
-    - Updated column names for output viral hits table in EXTRACT_VIRAL_READS_SHORT_LCA to make them more user-friendly
+    - Updated column names for output viral hits table in EXTRACT_VIRAL_READS_SHORT_LCA and EXTRACT_VIRAL_READS_SHORT_ONT to make them more user-friendly
         - Updated LCA_TSV to allow user to pass in empty prefix
         - Removed "_all" and "total" strings from LCA_TSV to improve readability
     - Added column to track the status of whether an alignment is primary, secondary, or supplementary in PROCESS_VIRAL_{MINIMAP2,BOWTIE2}_SAM
     - Created new temporary workflow, EXTRACT_VIRAL_READS_ONT_LCA, that will eventually replace EXTRACT_VIRAL_READS_ONT which makes MINIMAP2 run with multiple alignments, then runs LCA on this output
-    - Temporarily made EXTRACT_VIRAL_READS_SHORT_LCA incompatible with DOWNSTREAM and EXTRACT_VIRAL_READS_ONT_LCA due to column name changes
+    - Temporarily made EXTRACT_VIRAL_READS_SHORT_LCA and EXTRACT_VIRAL_READS_ONT_LCA incompatible with DOWNSTREAM
 
 # v2.10.0.0
 - Moved all outputs to main workflow for compatibility with Nextflow 25.04, and made pipeline compliant with new strict syntax. 

--- a/modules/local/processViralMinimap2SamLca/resources/usr/bin/process_viral_minimap2_sam.py
+++ b/modules/local/processViralMinimap2SamLca/resources/usr/bin/process_viral_minimap2_sam.py
@@ -43,10 +43,14 @@ def parse_sam_alignment(read, genbank_metadata, viral_taxids, clean_query_record
 
     reference_genome_name = read.reference_name
     out["genome_id"] = reference_genome_name
+    # Added to keep consistent with short read pipeline
+    out["genome_id_all"] = out["genome_id"]
     reference_taxid = extract_viral_taxid(
         reference_genome_name, genbank_metadata, viral_taxids
     )
     out["taxid"] = reference_taxid
+    # Added to keep consistent with short read pipeline
+    out["taxid_all"] = out["taxid"]
 
     # Adding original read sequence and quality
     if read.is_reverse:
@@ -105,7 +109,9 @@ def process_sam(sam_file, out_file, genbank_metadata, viral_taxids, clean_read_d
         header = (
             "seq_id\t"
             "genome_id\t"
+            "genome_id_all\t"
             "taxid\t"
+            "taxid_all\t"
             "map_qual\t"
             "ref_start\t"
             "cigar\t"

--- a/subworkflows/local/extractViralReadsONTLca/main.nf
+++ b/subworkflows/local/extractViralReadsONTLca/main.nf
@@ -44,7 +44,7 @@ workflow EXTRACT_VIRAL_READS_ONT_LCA {
                               "aligner_n_assignments_natural", "aligner_length_normalized_score_mean_natural",
                               "aligner_taxid_lca_artificial", "aligner_n_assignments_artificial", 
                               "aligner_length_normalized_score_mean_artificial"]
-        col_keep_add_prefix = ["genome_id", "taxid", "best_alignment_score", "edit_distance",  
+        col_keep_add_prefix = ["genome_id_all", "taxid_all", "best_alignment_score", "edit_distance",  
                                "ref_start", "query_len", "query_seq",  
                                "query_rc", "query_qual"]
         // Filter reads by length and quality scores

--- a/tests/subworkflows/local/processLcaAlignerOutput/main.nf.test
+++ b/tests/subworkflows/local/processLcaAlignerOutput/main.nf.test
@@ -7,6 +7,78 @@ nextflow_workflow {
     tag "subworkflow"
     tag "process_lca_aligner_output"
 
+    // Helper function to validate output structure
+    def validateOutputStructure = { outputData, colsNoPrefix, colsAddPrefix, columnPrefix ->
+        // Basic structure validation
+        assert outputData.columnCount > 0
+        assert outputData.rowCount > 0
+        
+        // Validate expected columns exist
+        for (col in colsNoPrefix) {
+            assert col in outputData.columns.keySet()
+        }
+        
+        for (col in colsAddPrefix) {
+            assert "${columnPrefix}${col}".toString() in outputData.columns.keySet()
+        }
+        
+        // Total column count should match
+        assert outputData.columnCount == colsNoPrefix.size() + colsAddPrefix.size()
+    }
+
+    // Helper function to validate join integrity
+    def validateJoinIntegrity = { outputSeqIds, lcaSeqIds, alignerSeqIds ->
+        for (seqId in outputSeqIds) {
+            assert seqId in lcaSeqIds
+            assert seqId in alignerSeqIds
+        }
+    }
+
+    // Helper function to get primary alignment seq IDs
+    def getPrimaryAlignmentSeqIds = { alignerData ->
+        def primaryAlignerSeqIds = []
+        for (int i = 0; i < alignerData.rowCount; i++) {
+            if (alignerData.columns["classification"][i] == "primary") {
+                primaryAlignerSeqIds.add(alignerData.columns["seq_id"][i])
+            }
+        }
+        return primaryAlignerSeqIds.toSet()
+    }
+
+    // Helper function to validate data integrity
+    def validateDataIntegrity = { outputData, lcaData, alignerData, colsNoPrefix, colsAddPrefix, columnPrefix ->
+        for (int i = 0; i < outputData.rowCount; i++) {
+            def seqId = outputData.columns["seq_id"][i]
+            
+            // Find corresponding rows in input files
+            def lcaIndex = lcaData.columns["seq_id"].findIndexOf { it == seqId }
+            
+            // Find the primary alignment for this seq_id
+            def alignerIndex = -1
+            for (int j = 0; j < alignerData.rowCount; j++) {
+                if (alignerData.columns["seq_id"][j] == seqId && alignerData.columns["classification"][j] == "primary") {
+                    alignerIndex = j
+                    break
+                }
+            }
+            
+            // Check columns without prefix preserve values from LCA
+            for (col in colsNoPrefix) {
+                if (col in lcaData.columns.keySet()) {
+                    assert outputData.columns[col][i] == lcaData.columns[col][lcaIndex]
+                }
+            }
+            
+            // Check columns with prefix preserve values from Aligner
+            for (col in colsAddPrefix) {
+                if (col in alignerData.columns.keySet()) {
+                    def prefixedCol = "${columnPrefix}${col}".toString()
+                    assert outputData.columns[prefixedCol][i] == alignerData.columns[col][alignerIndex]
+                }
+            }
+        }
+    }
+
     test("Should run without failures on Bowtie2 output") {
         tag "expect_success"
         tag "bowtie2"
@@ -117,90 +189,33 @@ nextflow_workflow {
         }
 
         then {
-          assert workflow.success
-
-          // Parse input files using nf-test CSV helpers
-          def lcaData = path(workflow.out.test_lca[0][1]).csv(sep: "\t", decompress: true)
-          def alignerData = path(workflow.out.test_aligner[0][1]).csv(sep: "\t", decompress: true)
-          def outputData = path(workflow.out.output[0][1]).csv(sep: "\t", decompress: true)
-
-          // Basic structure validation
-          assert outputData.columnCount > 0
-          assert outputData.rowCount > 0
-
-          // Get expected columns from workflow outputs
-          // The workflow emits these as single values containing the lists
-          def colsNoPrefix = params.col_keep_no_prefix
-          def colsAddPrefix = params.col_keep_add_prefix
-          
-          // Validate expected columns exist
-          // Columns without prefix
-          for (col in colsNoPrefix) {
-              assert col in outputData.columns.keySet()
-          }
-          
-          // Columns with prefix
-          for (col in colsAddPrefix) {
-              assert "${params.column_prefix}${col}".toString() in outputData.columns.keySet()
-          }
-          
-          // Total column count should match
-          assert outputData.columnCount == colsNoPrefix.size() + colsAddPrefix.size()
-
-          // Validate join integrity - all output seq_ids should exist in both inputs
-          def outputSeqIds = outputData.columns["seq_id"].toSet()
-          def lcaSeqIds = lcaData.columns["seq_id"].toSet()
-          def alignerSeqIds = alignerData.columns["seq_id"].toSet()
-
-          for (seqId in outputSeqIds) {
-              assert seqId in lcaSeqIds
-              assert seqId in alignerSeqIds
-          }
-
-          // Validate filtering - output should only contain primary alignments
-          // Need to iterate through rows by index to filter
-          def primaryAlignerSeqIds = []
-          for (int i = 0; i < alignerData.rowCount; i++) {
-              if (alignerData.columns["classification"][i] == "primary") {
-                  primaryAlignerSeqIds.add(alignerData.columns["seq_id"][i])
-              }
-          }
-          def primaryAlignerSeqIdsSet = primaryAlignerSeqIds.toSet()
-
-          // Output seq_ids should be intersection of primary alignments and LCA data
-          def expectedSeqIds = primaryAlignerSeqIdsSet.intersect(lcaSeqIds)
-          assert outputSeqIds == expectedSeqIds
-
-          // Validate data integrity - values should match between input and output
-          for (int i = 0; i < outputData.rowCount; i++) {
-              def seqId = outputData.columns["seq_id"][i]
-
-              // Find corresponding rows in input files by index
-              def lcaIndex = lcaData.columns["seq_id"].findIndexOf { it == seqId }
-              // Find the primary alignment for this seq_id
-              def alignerIndex = -1
-              for (int j = 0; j < alignerData.rowCount; j++) {
-                  if (alignerData.columns["seq_id"][j] == seqId && alignerData.columns["classification"][j] == "primary") {
-                      alignerIndex = j
-                      break
-                  }
-              }
-
-              // Check that columns without prefix preserve their values from LCA
-              for (col in colsNoPrefix) {
-                  if (col in lcaData.columns.keySet()) {
-                      assert outputData.columns[col][i] == lcaData.columns[col][lcaIndex]
-                  }
-              }
-
-              // Check that columns with prefix preserve their values from Aligner
-              for (col in colsAddPrefix) {
-                  if (col in alignerData.columns.keySet()) {
-                      def prefixedCol = "${params.column_prefix}${col}".toString()
-                      assert outputData.columns[prefixedCol][i] == alignerData.columns[col][alignerIndex]
-                  }
-              }
-          }
+            assert workflow.success
+            
+            // Parse input files using nf-test CSV helpers
+            def lcaData = path(workflow.out.test_lca[0][1]).csv(sep: "\t", decompress: true)
+            def alignerData = path(workflow.out.test_aligner[0][1]).csv(sep: "\t", decompress: true)
+            def outputData = path(workflow.out.output[0][1]).csv(sep: "\t", decompress: true)
+            
+            // Get expected columns
+            def colsNoPrefix = params.col_keep_no_prefix
+            def colsAddPrefix = params.col_keep_add_prefix
+            
+            // Validate output structure
+            validateOutputStructure(outputData, colsNoPrefix, colsAddPrefix, params.column_prefix)
+            
+            // Validate join integrity
+            def outputSeqIds = outputData.columns["seq_id"].toSet()
+            def lcaSeqIds = lcaData.columns["seq_id"].toSet()
+            def alignerSeqIds = alignerData.columns["seq_id"].toSet()
+            validateJoinIntegrity(outputSeqIds, lcaSeqIds, alignerSeqIds)
+            
+            // Validate filtering - output should only contain primary alignments
+            def primaryAlignerSeqIdsSet = getPrimaryAlignmentSeqIds(alignerData)
+            def expectedSeqIds = primaryAlignerSeqIdsSet.intersect(lcaSeqIds)
+            assert outputSeqIds == expectedSeqIds
+            
+            // Validate data integrity
+            validateDataIntegrity(outputData, lcaData, alignerData, colsNoPrefix, colsAddPrefix, params.column_prefix)
         }
     }
 
@@ -293,91 +308,33 @@ nextflow_workflow {
         }
 
         then {
-          assert workflow.success
-
-          // Parse input files using nf-test CSV helpers
-          def lcaData = path(workflow.out.test_lca[0][1]).csv(sep: "\t", decompress: true)
-          def alignerData = path(workflow.out.test_aligner[0][1]).csv(sep: "\t", decompress: true)
-          def outputData = path(workflow.out.output[0][1]).csv(sep: "\t", decompress: true)
-
-          // Basic structure validation
-          assert outputData.columnCount > 0
-          assert outputData.rowCount > 0
-
-          // Get expected columns from workflow outputs
-          // The workflow emits these as single values containing the lists
-          def colsNoPrefix = params.col_keep_no_prefix
-          def colsAddPrefix = params.col_keep_add_prefix
-          
-          // Validate expected columns exist
-          // Columns without prefix
-          for (col in colsNoPrefix) {
-              assert col in outputData.columns.keySet()
-          }
-          
-          // Columns with prefix
-          for (col in colsAddPrefix) {
-              assert "${params.column_prefix}${col}".toString() in outputData.columns.keySet()
-          }
-          
-          // Total column count should match
-          assert outputData.columnCount == colsNoPrefix.size() + colsAddPrefix.size()
-
-          // Validate join integrity - all output seq_ids should exist in both inputs
-          def outputSeqIds = outputData.columns["seq_id"].toSet()
-          def lcaSeqIds = lcaData.columns["seq_id"].toSet()
-          def alignerSeqIds = alignerData.columns["seq_id"].toSet()
-
-          for (seqId in outputSeqIds) {
-              assert seqId in lcaSeqIds
-              assert seqId in alignerSeqIds
-          }
-
-          // Validate filtering - output should only contain primary alignments
-          // Need to iterate through rows by index to filter
-          def primaryAlignerSeqIds = []
-          for (int i = 0; i < alignerData.rowCount; i++) {
-              if (alignerData.columns["classification"][i] == "primary") {
-                  primaryAlignerSeqIds.add(alignerData.columns["seq_id"][i])
-              }
-          }
-          def primaryAlignerSeqIdsSet = primaryAlignerSeqIds.toSet()
-
-          // Minimap2
-          // Output seq_ids should be intersection of primary alignments and LCA data
-          def expectedSeqIds = primaryAlignerSeqIdsSet.intersect(lcaSeqIds)
-          assert outputSeqIds == expectedSeqIds
-
-          // Validate data integrity - values should match between input and output
-          for (int i = 0; i < outputData.rowCount; i++) {
-              def seqId = outputData.columns["seq_id"][i]
-
-              // Find corresponding rows in input files by index
-              def lcaIndex = lcaData.columns["seq_id"].findIndexOf { it == seqId }
-              // Find the primary alignment for this seq_id
-              def alignerIndex = -1
-              for (int j = 0; j < alignerData.rowCount; j++) {
-                  if (alignerData.columns["seq_id"][j] == seqId && alignerData.columns["classification"][j] == "primary") {
-                      alignerIndex = j
-                      break
-                  }
-              }
-
-              // Check that columns without prefix preserve their values from LCA
-              for (col in colsNoPrefix) {
-                  if (col in lcaData.columns.keySet()) {
-                      assert outputData.columns[col][i] == lcaData.columns[col][lcaIndex]
-                  }
-              }
-
-              // Check that columns with prefix preserve their values from Aligner
-              for (col in colsAddPrefix) {
-                  if (col in alignerData.columns.keySet()) {
-                      def prefixedCol = "${params.column_prefix}${col}".toString()
-                      assert outputData.columns[prefixedCol][i] == alignerData.columns[col][alignerIndex]
-                  }
-              }
-          }
+            assert workflow.success
+            
+            // Parse input files using nf-test CSV helpers
+            def lcaData = path(workflow.out.test_lca[0][1]).csv(sep: "\t", decompress: true)
+            def alignerData = path(workflow.out.test_aligner[0][1]).csv(sep: "\t", decompress: true)
+            def outputData = path(workflow.out.output[0][1]).csv(sep: "\t", decompress: true)
+            
+            // Get expected columns
+            def colsNoPrefix = params.col_keep_no_prefix
+            def colsAddPrefix = params.col_keep_add_prefix
+            
+            // Validate output structure
+            validateOutputStructure(outputData, colsNoPrefix, colsAddPrefix, params.column_prefix)
+            
+            // Validate join integrity
+            def outputSeqIds = outputData.columns["seq_id"].toSet()
+            def lcaSeqIds = lcaData.columns["seq_id"].toSet()
+            def alignerSeqIds = alignerData.columns["seq_id"].toSet()
+            validateJoinIntegrity(outputSeqIds, lcaSeqIds, alignerSeqIds)
+            
+            // Validate filtering - output should only contain primary alignments
+            def primaryAlignerSeqIdsSet = getPrimaryAlignmentSeqIds(alignerData)
+            def expectedSeqIds = primaryAlignerSeqIdsSet.intersect(lcaSeqIds)
+            assert outputSeqIds == expectedSeqIds
+            
+            // Validate data integrity
+            validateDataIntegrity(outputData, lcaData, alignerData, colsNoPrefix, colsAddPrefix, params.column_prefix)
         }
     }
 

--- a/tests/subworkflows/local/processLcaAlignerOutput/main.nf.test
+++ b/tests/subworkflows/local/processLcaAlignerOutput/main.nf.test
@@ -278,7 +278,7 @@ nextflow_workflow {
         when {
             params {
                 col_keep_no_prefix = ["seq_id", "aligner_taxid_lca"]
-                col_keep_add_prefix = ["genome_id"]
+                col_keep_add_prefix = ["genome_id_all"]
                 column_prefix = "prim_align_"
             }
             workflow {

--- a/tests/subworkflows/local/processLcaAlignerOutput/main.nf.test
+++ b/tests/subworkflows/local/processLcaAlignerOutput/main.nf.test
@@ -7,13 +7,10 @@ nextflow_workflow {
     tag "subworkflow"
     tag "process_lca_aligner_output"
 
-    // Helper function to validate output structure
     def validateOutputStructure = { outputData, colsNoPrefix, colsAddPrefix, columnPrefix ->
-        // Basic structure validation
         assert outputData.columnCount > 0
         assert outputData.rowCount > 0
         
-        // Validate expected columns exist
         for (col in colsNoPrefix) {
             assert col in outputData.columns.keySet()
         }
@@ -22,11 +19,9 @@ nextflow_workflow {
             assert "${columnPrefix}${col}".toString() in outputData.columns.keySet()
         }
         
-        // Total column count should match
         assert outputData.columnCount == colsNoPrefix.size() + colsAddPrefix.size()
     }
 
-    // Helper function to validate join integrity
     def validateJoinIntegrity = { outputSeqIds, lcaSeqIds, alignerSeqIds ->
         for (seqId in outputSeqIds) {
             assert seqId in lcaSeqIds
@@ -34,7 +29,6 @@ nextflow_workflow {
         }
     }
 
-    // Helper function to get primary alignment seq IDs
     def getPrimaryAlignmentSeqIds = { alignerData ->
         def primaryAlignerSeqIds = []
         for (int i = 0; i < alignerData.rowCount; i++) {
@@ -45,15 +39,12 @@ nextflow_workflow {
         return primaryAlignerSeqIds.toSet()
     }
 
-    // Helper function to validate data integrity
     def validateDataIntegrity = { outputData, lcaData, alignerData, colsNoPrefix, colsAddPrefix, columnPrefix ->
         for (int i = 0; i < outputData.rowCount; i++) {
             def seqId = outputData.columns["seq_id"][i]
             
-            // Find corresponding rows in input files
             def lcaIndex = lcaData.columns["seq_id"].findIndexOf { it == seqId }
             
-            // Find the primary alignment for this seq_id
             def alignerIndex = -1
             for (int j = 0; j < alignerData.rowCount; j++) {
                 if (alignerData.columns["seq_id"][j] == seqId && alignerData.columns["classification"][j] == "primary") {
@@ -62,14 +53,12 @@ nextflow_workflow {
                 }
             }
             
-            // Check columns without prefix preserve values from LCA
             for (col in colsNoPrefix) {
                 if (col in lcaData.columns.keySet()) {
                     assert outputData.columns[col][i] == lcaData.columns[col][lcaIndex]
                 }
             }
             
-            // Check columns with prefix preserve values from Aligner
             for (col in colsAddPrefix) {
                 if (col in alignerData.columns.keySet()) {
                     def prefixedCol = "${columnPrefix}${col}".toString()
@@ -191,30 +180,24 @@ nextflow_workflow {
         then {
             assert workflow.success
             
-            // Parse input files using nf-test CSV helpers
             def lcaData = path(workflow.out.test_lca[0][1]).csv(sep: "\t", decompress: true)
             def alignerData = path(workflow.out.test_aligner[0][1]).csv(sep: "\t", decompress: true)
             def outputData = path(workflow.out.output[0][1]).csv(sep: "\t", decompress: true)
             
-            // Get expected columns
             def colsNoPrefix = params.col_keep_no_prefix
             def colsAddPrefix = params.col_keep_add_prefix
             
-            // Validate output structure
             validateOutputStructure(outputData, colsNoPrefix, colsAddPrefix, params.column_prefix)
             
-            // Validate join integrity
             def outputSeqIds = outputData.columns["seq_id"].toSet()
             def lcaSeqIds = lcaData.columns["seq_id"].toSet()
             def alignerSeqIds = alignerData.columns["seq_id"].toSet()
             validateJoinIntegrity(outputSeqIds, lcaSeqIds, alignerSeqIds)
             
-            // Validate filtering - output should only contain primary alignments
             def primaryAlignerSeqIdsSet = getPrimaryAlignmentSeqIds(alignerData)
             def expectedSeqIds = primaryAlignerSeqIdsSet.intersect(lcaSeqIds)
             assert outputSeqIds == expectedSeqIds
             
-            // Validate data integrity
             validateDataIntegrity(outputData, lcaData, alignerData, colsNoPrefix, colsAddPrefix, params.column_prefix)
         }
     }
@@ -310,30 +293,24 @@ nextflow_workflow {
         then {
             assert workflow.success
             
-            // Parse input files using nf-test CSV helpers
             def lcaData = path(workflow.out.test_lca[0][1]).csv(sep: "\t", decompress: true)
             def alignerData = path(workflow.out.test_aligner[0][1]).csv(sep: "\t", decompress: true)
             def outputData = path(workflow.out.output[0][1]).csv(sep: "\t", decompress: true)
             
-            // Get expected columns
             def colsNoPrefix = params.col_keep_no_prefix
             def colsAddPrefix = params.col_keep_add_prefix
             
-            // Validate output structure
             validateOutputStructure(outputData, colsNoPrefix, colsAddPrefix, params.column_prefix)
             
-            // Validate join integrity
             def outputSeqIds = outputData.columns["seq_id"].toSet()
             def lcaSeqIds = lcaData.columns["seq_id"].toSet()
             def alignerSeqIds = alignerData.columns["seq_id"].toSet()
             validateJoinIntegrity(outputSeqIds, lcaSeqIds, alignerSeqIds)
             
-            // Validate filtering - output should only contain primary alignments
             def primaryAlignerSeqIdsSet = getPrimaryAlignmentSeqIds(alignerData)
             def expectedSeqIds = primaryAlignerSeqIdsSet.intersect(lcaSeqIds)
             assert outputSeqIds == expectedSeqIds
             
-            // Validate data integrity
             validateDataIntegrity(outputData, lcaData, alignerData, colsNoPrefix, colsAddPrefix, params.column_prefix)
         }
     }
@@ -400,14 +377,11 @@ nextflow_workflow {
         }
 
         then {
-            // Should run without failures
             assert workflow.success
             
-            // Output file should exist but be empty
             def outputFile = path(workflow.out.output[0][1])
             assert outputFile.exists()
             
-            // Check that the file is empty (no lines when decompressed)
             def outputLines = outputFile.linesGzip.size()
             assert outputLines == 0
         }
@@ -466,29 +440,21 @@ nextflow_workflow {
         }
 
         then {
-            // Should run without failures
             assert workflow.success
             
-            // Output file should exist but be empty
             def outputFile = path(workflow.out.output[0][1])
             assert outputFile.exists()
             
-            // Check that the file is empty (no lines when decompressed)
             def outputLines = outputFile.linesGzip
             assert outputLines.size() == 1
 
-            // Get expected columns from workflow outputs
-            // The workflow emits these as single values containing the lists
             def colsNoPrefix = params.col_keep_no_prefix
             def colsAddPrefix = params.col_keep_add_prefix
             
-            // Validate expected columns exist
-            // Columns without prefix
             for (col in colsNoPrefix) {
                 outputLines.contains(col)
             }
             
-            // Columns with prefix
             for (col in colsAddPrefix) {
                 outputLines.contains("${params.column_prefix}${col}".toString())
             }

--- a/tests/subworkflows/local/processLcaAlignerOutput/main.nf.test
+++ b/tests/subworkflows/local/processLcaAlignerOutput/main.nf.test
@@ -7,8 +7,9 @@ nextflow_workflow {
     tag "subworkflow"
     tag "process_lca_aligner_output"
 
-    test("Should run without failures") {
+    test("Should run without failures on Bowtie2 output") {
         tag "expect_success"
+        tag "bowtie2"
         setup {
             run("LOAD_SAMPLESHEET") {
                 script "subworkflows/local/loadSampleSheet/main.nf"
@@ -34,21 +35,39 @@ nextflow_workflow {
                         '''
                         input[0] = INTERLEAVE_FASTQ.out.output 
                         input[1] = "${params.ref_dir}/results/bt2-virus-index"
-                        input[2] = "--local --very-sensitive-local --score-min G,0.1,19"
+                        input[2] = "--local --very-sensitive-local --score-min G,0.1,19 -k 10"
                         input[3] = "virus"
                         input[4] = true
                         input[5] = false
                         input[6] = true
                         '''
                     }
-                }
+            }
             run("SORT_FILE") {
                 script "modules/local/sortFile/main.nf"
                 process {
                     '''
                     input[0] = BOWTIE2.out.sam
-                    input[1] = "-t\\$\'\\t\' -k1,1 -k2,2n"
+                    input[1] = "-t\\$\'\\t\' -k1,1"
                     input[2] = "sam"
+                    '''
+                }
+            }
+            run("SORT_FASTQ"){
+                script "modules/local/sortFastq/main.nf"
+                process {
+                    '''
+                    input[0] = INTERLEAVE_FASTQ.out.output
+                    '''
+                }
+
+            }
+            run("FILTER_VIRAL_SAM"){
+                script "modules/local/filterViralSam/main.nf"
+                process {
+                    '''
+                    input[0] = SORT_FILE.out.output.combine(SORT_FASTQ.out.output, by: 0)
+                    input[1] = 5
                     '''
                 }
             }
@@ -56,7 +75,7 @@ nextflow_workflow {
                 script "modules/local/processViralBowtie2SamLca/main.nf"
                 process {
                     '''
-                    input[0] = SORT_FILE.out.output
+                    input[0] = FILTER_VIRAL_SAM.out.sam
                     input[1] = "${params.ref_dir}/results/virus-genome-metadata-gid.tsv.gz"
                     input[2] = "${params.ref_dir}/results/total-virus-db-annotated.tsv.gz"
                     input[3] = true
@@ -158,7 +177,14 @@ nextflow_workflow {
 
               // Find corresponding rows in input files by index
               def lcaIndex = lcaData.columns["seq_id"].findIndexOf { it == seqId }
-              def alignerIndex = alignerData.columns["seq_id"].findIndexOf { it == seqId }
+              // Find the primary alignment for this seq_id
+              def alignerIndex = -1
+              for (int j = 0; j < alignerData.rowCount; j++) {
+                  if (alignerData.columns["seq_id"][j] == seqId && alignerData.columns["classification"][j] == "primary") {
+                      alignerIndex = j
+                      break
+                  }
+              }
 
               // Check that columns without prefix preserve their values from LCA
               for (col in colsNoPrefix) {
@@ -177,6 +203,184 @@ nextflow_workflow {
           }
         }
     }
+
+    test("Should run without failures on Minimap2 output") {
+        tag "expect_success"
+        tag "minimap2"
+        setup {
+            run("LOAD_SAMPLESHEET") {
+                script "subworkflows/local/loadSampleSheet/main.nf"
+                process {
+                    """
+                    input[0] = "${projectDir}/test-data/ont-samplesheet.csv"
+                    input[1] = "ont"
+                    input[2] = false
+                    """
+                }
+            }
+            run("INTERLEAVE_FASTQ") {
+                script "modules/local/interleaveFastq/main.nf"
+                process {
+                    '''
+                    input[0] = LOAD_SAMPLESHEET.out.samplesheet
+                    '''
+                }
+            }
+            run("MINIMAP2") {
+                    script "modules/local/minimap2/main.nf"
+                    process {
+                        '''
+                        input[0] = INTERLEAVE_FASTQ.out.output 
+                        input[1] = "${params.ref_dir}/results/mm2-virus-index"
+                        input[2] = "virus"
+                        input[3] = false
+                        input[4] = "-N 10"
+                        '''
+                    }
+                }
+            run("PROCESS_VIRAL_MINIMAP2_SAM_LCA") {
+                script "modules/local/processViralMinimap2SamLca/main.nf"
+                process {
+                    '''
+                    input[0] = MINIMAP2.out.sam.join(INTERLEAVE_FASTQ.out.output)
+                    input[1] = "${params.ref_dir}/results/virus-genome-metadata-gid.tsv.gz"
+                    input[2] = "${params.ref_dir}/results/total-virus-db-annotated.tsv.gz"
+                    '''
+                }
+            }
+            run("SORT_TSV") {
+                script "modules/local/sortTsv/main.nf"
+                process {
+                    '''
+                    input[0] = PROCESS_VIRAL_MINIMAP2_SAM_LCA.out.output
+                    input[1] = "seq_id"
+                    '''
+                }
+
+            }
+            run("LCA_TSV") {
+                script "modules/local/lcaTsv/main.nf"
+                process {
+                    '''
+                    input[0] = SORT_TSV.out.sorted
+                    input[1] = "${params.ref_dir}/results/taxonomy-nodes.dmp"
+                    input[2] = "${params.ref_dir}/results/taxonomy-names.dmp"
+                    input[3] = "seq_id"
+                    input[4] = "taxid"
+                    input[5] = "length_normalized_score"
+                    input[6] = "12908"
+                    input[7] = "aligner"
+                    '''
+                }
+            }
+
+        }
+        when {
+            params {
+                col_keep_no_prefix = ["seq_id", "aligner_taxid_lca"]
+                col_keep_add_prefix = ["genome_id"]
+                column_prefix = "prim_align_"
+            }
+            workflow {
+                """
+                input[0] = LCA_TSV.out.output
+                input[1] = SORT_TSV.out.sorted
+                input[2] = params.col_keep_no_prefix
+                input[3] = params.col_keep_add_prefix
+                input[4] = params.column_prefix
+                """
+            }
+        }
+
+        then {
+          assert workflow.success
+
+          // Parse input files using nf-test CSV helpers
+          def lcaData = path(workflow.out.test_lca[0][1]).csv(sep: "\t", decompress: true)
+          def alignerData = path(workflow.out.test_aligner[0][1]).csv(sep: "\t", decompress: true)
+          def outputData = path(workflow.out.output[0][1]).csv(sep: "\t", decompress: true)
+
+          // Basic structure validation
+          assert outputData.columnCount > 0
+          assert outputData.rowCount > 0
+
+          // Get expected columns from workflow outputs
+          // The workflow emits these as single values containing the lists
+          def colsNoPrefix = params.col_keep_no_prefix
+          def colsAddPrefix = params.col_keep_add_prefix
+          
+          // Validate expected columns exist
+          // Columns without prefix
+          for (col in colsNoPrefix) {
+              assert col in outputData.columns.keySet()
+          }
+          
+          // Columns with prefix
+          for (col in colsAddPrefix) {
+              assert "${params.column_prefix}${col}".toString() in outputData.columns.keySet()
+          }
+          
+          // Total column count should match
+          assert outputData.columnCount == colsNoPrefix.size() + colsAddPrefix.size()
+
+          // Validate join integrity - all output seq_ids should exist in both inputs
+          def outputSeqIds = outputData.columns["seq_id"].toSet()
+          def lcaSeqIds = lcaData.columns["seq_id"].toSet()
+          def alignerSeqIds = alignerData.columns["seq_id"].toSet()
+
+          for (seqId in outputSeqIds) {
+              assert seqId in lcaSeqIds
+              assert seqId in alignerSeqIds
+          }
+
+          // Validate filtering - output should only contain primary alignments
+          // Need to iterate through rows by index to filter
+          def primaryAlignerSeqIds = []
+          for (int i = 0; i < alignerData.rowCount; i++) {
+              if (alignerData.columns["classification"][i] == "primary") {
+                  primaryAlignerSeqIds.add(alignerData.columns["seq_id"][i])
+              }
+          }
+          def primaryAlignerSeqIdsSet = primaryAlignerSeqIds.toSet()
+
+          // Minimap2
+          // Output seq_ids should be intersection of primary alignments and LCA data
+          def expectedSeqIds = primaryAlignerSeqIdsSet.intersect(lcaSeqIds)
+          assert outputSeqIds == expectedSeqIds
+
+          // Validate data integrity - values should match between input and output
+          for (int i = 0; i < outputData.rowCount; i++) {
+              def seqId = outputData.columns["seq_id"][i]
+
+              // Find corresponding rows in input files by index
+              def lcaIndex = lcaData.columns["seq_id"].findIndexOf { it == seqId }
+              // Find the primary alignment for this seq_id
+              def alignerIndex = -1
+              for (int j = 0; j < alignerData.rowCount; j++) {
+                  if (alignerData.columns["seq_id"][j] == seqId && alignerData.columns["classification"][j] == "primary") {
+                      alignerIndex = j
+                      break
+                  }
+              }
+
+              // Check that columns without prefix preserve their values from LCA
+              for (col in colsNoPrefix) {
+                  if (col in lcaData.columns.keySet()) {
+                      assert outputData.columns[col][i] == lcaData.columns[col][lcaIndex]
+                  }
+              }
+
+              // Check that columns with prefix preserve their values from Aligner
+              for (col in colsAddPrefix) {
+                  if (col in alignerData.columns.keySet()) {
+                      def prefixedCol = "${params.column_prefix}${col}".toString()
+                      assert outputData.columns[prefixedCol][i] == alignerData.columns[col][alignerIndex]
+                  }
+              }
+          }
+        }
+    }
+
 
     test("Should handle empty input files") {
         tag "empty_input"


### PR DESCRIPTION
Ran ruff on process_viral_minimap2_sam.py which is why some things outside of alignment names changed, and added classification column; updated ONT LCA to use the new column workflow; before, tests weren't using multiple alignments for processLcaAlignerOutput, however i figured that they should so i updated the tests to reflect that, additionally added a test to verify that minimap2 works for that process.

Tests pass:
- processLcaAlignerOutput
- extractViralReadsONTLca