### PR TITLE
remove trace.txt from expected outputs of RUN workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
     - Added column to track the status of whether an alignment is primary, secondary, or supplementary in PROCESS_VIRAL_{MINIMAP2,BOWTIE2}_SAM
     - Created new temporary workflow, EXTRACT_VIRAL_READS_ONT_LCA, that will eventually replace EXTRACT_VIRAL_READS_ONT which makes MINIMAP2 run with multiple alignments, then runs LCA on this output
     - Temporarily made EXTRACT_VIRAL_READS_SHORT_LCA and EXTRACT_VIRAL_READS_ONT_LCA incompatible with DOWNSTREAM
+- Removed `trace.txt` from expected pipeline outputs (as we have changed the trace filename to include a timestamp)
 
 # v2.10.0.0
 - Moved all outputs to main workflow for compatibility with Nextflow 25.04, and made pipeline compliant with new strict syntax. 

--- a/docs/output.md
+++ b/docs/output.md
@@ -27,7 +27,7 @@ Main heading represents the folder name, and subheadings represent a description
 - `pipeline-version-index.txt`: Version of the pipeline used to generate the specified index directory (copied from index directory).
 - `pipeline-version.txt`: Version of the pipeline used to run the workflow (copied from repository).
 - `time.txt`: Start time of the run.
-- `trace.txt`: Tab delimited log of all the information for each task run in the pipeline including runtime, memory usage, exit status, etc. Can be used to create an execution timeline using the the script `bin/plot-timeline-script.R` after the pipeline has finished running. More information regarding the trace file format can be found [here](https://www.nextflow.io/docs/latest/reports.html#trace-file).
+- `trace_<timestamp>.tsv`: Tab delimited log of all the information for each task run in the pipeline including runtime, memory usage, exit status, etc. Can be used to create an execution timeline using the the script `bin/plot-timeline-script.R` after the pipeline has finished running. More information regarding the trace file format can be found [here](https://www.nextflow.io/docs/latest/reports.html#trace-file).
 
 ### `intermediates/`
 

--- a/expected-outputs-run.txt
+++ b/expected-outputs-run.txt
@@ -7,7 +7,6 @@ logging/pipeline-min-index-version.txt
 logging/pipeline-version-index.txt
 logging/pipeline-version.txt
 logging/time.txt
-logging/trace.txt
 results/bracken_reports_merged.tsv.gz
 results/kraken_reports_merged.tsv.gz
 results/read_counts.tsv.gz


### PR DESCRIPTION
No tests run. I did grep the codebase for "trace.txt"; after these changes there are no hits other than the changelog. 