### PR TITLE
Fix value channel bug in DOWNSTREAM

### DIFF
--- a/workflows/downstream.nf
+++ b/workflows/downstream.nf
@@ -31,7 +31,7 @@ workflow DOWNSTREAM {
         MARK_VIRAL_DUPLICATES(group_ch, params.aln_dup_deviation)
         // Prepare inputs for clade counting and validating taxonomic assignments
         viral_db_path = "${params.ref_dir}/results/total-virus-db-annotated.tsv.gz"
-        viral_db = Channel.of(viral_db_path)
+        viral_db = channel.value(viral_db_path)
         dup_ch = MARK_VIRAL_DUPLICATES.out.dup.map{ label, tab, _stats -> [label, tab] }
         // 4. Generate clade counts
         COUNT_READS_PER_CLADE(dup_ch, viral_db)


### PR DESCRIPTION
Running DOWNSTREAM on test data revealed that COUNT_READS_PER_CLADE was only running one time even when there were multiple groups.

The problem was that `channel.of` creates a [queue channel](https://www.nextflow.io/docs/latest/channel.html#queue-channels), so `channel.of(viral_db_path)` is a queue that emits a single value. COUNT_READS_PER_CLADE uses it up along with the first value emitted by `dup_ch` and then quietly stops pulling from all channels.

Changing to `channel.value(viral_db_path)`, we instead get a [value channel](https://www.nextflow.io/docs/latest/channel.html#value-channels), which is bound to a single value. It doesn’t get consumed, so COUNT_READS_PER_CLADE keeps pulling values from `dup_ch`.

The mystery is why VALIDATE_VIRAL_ASSIGNMENTS seemed to be working before...


