### PR TITLE
Fixed line iteration bug in tests for loadDownstreamData and loadSampleSheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Fixed bug in ANNOTATE_VIRUS_INFECTION that incorrectly assigned viruses as potentially infecting specific hosts when they did not, and added a pytest to verify that functionality.
 - Updated Github Actions to retry downloading nf-test since it often fails to download on the first try due to a 403 error
 - Increased resources for PROCESS_VIRAL_MINIMAP2_SAM to avoid frequent out-of-memory errors
+- Fixed line iteration bug in tests for LOAD_SAMPLESHEET and LOAD_DOWNSTREAM_DATA
 
 # v2.10.0.1
 - Removed extremely long reads (>500000bp) before FASTQC on ONT data, and upped memory resources for FASTQC, to avoid out-of-memory errors.

--- a/tests/subworkflows/local/loadDownstreamData/main.nf.test
+++ b/tests/subworkflows/local/loadDownstreamData/main.nf.test
@@ -25,7 +25,7 @@ nextflow_workflow {
             def tab_in = path(workflow.out.test_input[0]).csv
             assert workflow.out.input.size() == tab_in.rowCount
             def currentDir = new File(".").getAbsolutePath()
-            for (int i=1; i < tab_in.rowCount; i++){
+            for (int i=0; i < tab_in.rowCount; i++){
                 assert workflow.out.input[i][0] == tab_in.columns["label"][i]
                 assert tab_in.columns["hits_tsv"][i].contains(workflow.out.input[i][1])
                 assert tab_in.columns["groups_tsv"][i].contains(workflow.out.input[i][2])

--- a/tests/subworkflows/local/loadSampleSheet/main.nf.test
+++ b/tests/subworkflows/local/loadSampleSheet/main.nf.test
@@ -26,13 +26,13 @@ nextflow_workflow {
             // Should produce correctly structured output
             def tab_in = path(workflow.out.test_input[0]).csv
             assert workflow.out.samplesheet.size() == tab_in.rowCount
-            for (int i=1; i < tab_in.rowCount; i++){
+            for (int i=0; i < tab_in.rowCount; i++){
                 def entry = workflow.out.samplesheet[i]
                 assert entry.size() == 2
                 assert entry[1].size() == 2
                 assert entry[0] == tab_in.columns["sample"][i]
-                assert entry[1][0] == tab_in.columns["fastq_1"][i]
-                assert entry[1][1] == tab_in.columns["fastq_2"][i]
+                assert entry[1][0] == tab_in.columns["fastq_1"][i].replaceFirst(/^s3:\//, "")
+                assert entry[1][1] == tab_in.columns["fastq_2"][i].replaceFirst(/^s3:\//, "")
             }
             // Should correctly infer pairing status
             assert workflow.out.single_end.size() == 1
@@ -60,13 +60,13 @@ nextflow_workflow {
             // Should produce correctly structured output
             def tab_in = path(workflow.out.test_input[0]).csv
             assert workflow.out.samplesheet.size() == tab_in.rowCount
-            for (int i=1; i < tab_in.rowCount; i++){
+            for (int i=0; i < tab_in.rowCount; i++){
                 def entry = workflow.out.samplesheet[i]
                 assert entry.size() == 2
                 assert entry[1].size() == 2
                 assert entry[0] == tab_in.columns["sample"][i]
-                assert entry[1][0] == tab_in.columns["fastq_1"][i]
-                assert entry[1][1] == tab_in.columns["fastq_2"][i]
+                assert entry[1][0] == tab_in.columns["fastq_1"][i].replaceFirst(/^s3:\//, "")
+                assert entry[1][1] == tab_in.columns["fastq_2"][i].replaceFirst(/^s3:\//, "")
             }
             // Should correctly infer pairing status
             assert workflow.out.single_end.size() == 1
@@ -94,11 +94,11 @@ nextflow_workflow {
             // Should produce correctly structured output
             def tab_in = path(workflow.out.test_input[0]).csv
             assert workflow.out.samplesheet.size() == tab_in.rowCount
-            for (int i=1; i < tab_in.rowCount; i++){
+            for (int i=0; i < tab_in.rowCount; i++){
                 def entry = workflow.out.samplesheet[i]
                 assert entry.size() == 2
                 assert entry[0] == tab_in.columns["sample"][i]
-                assert entry[1] == tab_in.columns["fastq"][i]
+                assert entry[1][0] == tab_in.columns["fastq"][i].replaceFirst(/^s3:\//, "")
             }
             // Should correctly infer pairing status
             assert workflow.out.single_end.size() == 1
@@ -232,11 +232,11 @@ nextflow_workflow {
             // Should produce correctly structured output
             def tab_in = path(workflow.out.test_input[0]).csv
             assert workflow.out.samplesheet.size() == tab_in.rowCount
-            for (int i=1; i < tab_in.rowCount; i++){
+            for (int i=0; i < tab_in.rowCount; i++){
                 def entry = workflow.out.samplesheet[i]
                 assert entry.size() == 2
                 assert entry[0] == tab_in.columns["sample"][i]
-                assert entry[1] == tab_in.columns["fastq"][i]
+                assert entry[1][0] == tab_in.columns["fastq"][i].replaceFirst(/^s3:\//, "")
             }
             // Should correctly infer pairing status
             assert workflow.out.single_end.size() == 1


### PR DESCRIPTION
While implementing samplesheet loading for Chimera Detection v2, I came across a bug in the tests that was causing the first line of the test data output to be skipped, causing assertions that should have failed to be skipped over. This PR fixes that bug and then also fixes the failing assertions thus exposed.