### PR TITLE
FILTER_VIRAL_SAM CP alignment bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Increased resources for PROCESS_VIRAL_MINIMAP2_SAM to avoid frequent out-of-memory errors
 - Fixed line iteration bug in tests for LOAD_SAMPLESHEET and LOAD_DOWNSTREAM_DATA
 - Added new Dockerfiles (custom containers that will be required for caching of large reference files), along with the utility script `bin/build-push-docker.sh` to build and push to Dockerhub.
+- Fixed FILTER_VIRAL_SAM grouping bug for concordant pairs with identical positions but different alignment scores
 
 # v3.0.0.0
 

--- a/modules/local/filterViralSam/resources/usr/bin/filter_viral_sam.py
+++ b/modules/local/filterViralSam/resources/usr/bin/filter_viral_sam.py
@@ -336,6 +336,11 @@ def group_other_alignments(
         group_id = pair_key_to_group[pair_key]
         by_group[group_id].append(alignment)
 
+    # Verify that each group has exactly 2 alignments (one forward, one reverse)
+    for group_id, group_alignments in by_group.items():
+        assert len(group_alignments) == 2, \
+            f"Group {group_id} for CP/DP alignments should have exactly 2 reads (forward/reverse pair), got {len(group_alignments)}"
+    
     return dict(by_group)
 
 


### PR DESCRIPTION
Fixed FILTER_VIRAL_SAM grouping bug for concordant pairs with identical positions but different alignment scores. This bug resulted in a sorting issue that lead to two forward reads being consecutive in the SAM file, breaking the requirement of PROCESS_VIRAL_BOWTIE2_SAM.

The way FILTER_VIRAL_SAM works is that we try to group reads with their forward/reverse mate if they have one. In the case of paired reads, we try to find a unique key. In this case, the unique key was not unique, resulting in 2 separate secondary alignments being grouped together. Once in a group, we can usually just sort by flag to get the forward and reverse reads in the order required by PROCESS_VIRAL_BOWTIE2_SAM; however, with 2 separate secondary alignments, this would cause the forward alignments to show up consecutively. This change updates the key used for grouping such that it is unique. 