### PR TITLE
Adding official formatting for ruff, and mypy through the inclusion of a pyproject.toml

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -59,7 +59,9 @@ These guidelines represent best practices to implement in new code, though some 
 - Python style: 
     - Loosely follow PEP 8 conventions.
     - Type hints are encouraged but not currently required.
-    - Linting is encouraged (our go-to tool is `ruff`), but not currently required. 
+    - Linting and type checking are encouraged (our go-to tools are `ruff` for linting and `mypy` for type checking), but not currently required.
+    - Formatting applied (including in nested directories) will follow the configuration in `pyproject.toml`.
+    - After making any formatting changes, carefully review the diff to ensure no unintended modifications were introduced that could affect functionality. 
     
 ## Containers
 We preferentially use [Seqera containers](https://seqera.io/containers/), with [Docker Hub](https://hub.docker.com/) as a second choice.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,48 @@
+[project]
+name = "mgs-workflow"
+requires-python = ">=3.12"
+
+# Tool configurations below:
+# - [tool.mypy]: Type checking configuration  
+# - [tool.ruff]: Linting and formatting configuration
+# - pytest configuration would go in [tool.pytest.ini_options] (none currently)
+
+[tool.mypy]
+python_version = 3.12
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+
+[tool.ruff]
+# Comprehensive rule selection
+lint.select = [
+    "E",   # pycodestyle errors
+    "F",   # pyflakes (unused imports, etc.)
+    "I",   # isort
+    "B",   # bugbear (likely bugs and design problems)
+    "C4",  # comprehensions (better list/dict comprehensions)
+    "UP",  # pyupgrade (modernize Python code)
+    "N",   # naming (PEP8 naming conventions)
+    "COM", # commas (trailing commas)
+    "PIE", # misc. lints (unnecessary code)
+    "RET", # return statements (consistent returns)
+    "SIM", # simplify (code simplification)
+]
+
+# Ignored rules
+lint.ignore = [
+  "E501" # Ignore line too long
+]
+
+# Basic exclusions
+exclude = [
+    ".git",
+    "__pycache__",
+    "build",
+    "dist",
+]
+
+# Target Python version
+target-version = "py312"


### PR DESCRIPTION
The pyproject.toml will allow us to specify the settings that are used for ruff, mypy, and pytest across all python files in this repo. 

I additionally updated the developer docs to note this, and mentioned that ruff formatting should be checked as we ran into an issue where ruff was setting the [`strict` attribute to false by default if it was not specified in `zip`](https://github.com/naobservatory/mgs-orchestrator/pull/47#discussion_r2261190503).

I ran pytest, ruff, and mypy and they all worked. There were issues (by issues I mean they both said that linting/typing was violated) that came up with ruff, and mypy; however, updating all these files might take a lot of time, so I'd figure we can just have people run `ruff` and `mypy` on scripts as we update them. If you would like me to just run it now and update all the python scripts, I can also do that.