### PR TITLE
Adding preference for using pytest for processes that use python over nf-test for unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Added bugfix for `RAISE_TAXONOMY_RANKS` to account for change in classification of "Viruses" taxon in NCBI taxonomy database.
 - Fixed FILTER_VIRAL_SAM grouping bug for concordant pairs with identical positions but different alignment scores
 - Updated DOWNSTREAM workflow to work on viral hits tables where a sample has no viral hits, but is in the grouping specification.
+- Updated documentation to note that we now use pytest for Python process unit tests.
 
 # v3.0.0.0
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -70,7 +70,7 @@ Build and push the custom containers using the script `bin/build-push-docker.sh`
     
 ## Testing
 
-All tests use the [nf-test](https://www.nf-test.com/) framework. (We do not currently have any unit tests of Python/Rust/R scripts.)
+We use [nf-test](https://www.nf-test.com/) for integration and end-to-end tests. For Python process unit tests, we use pytest. As we continue developing, we will transition away from nf-test unit tests for Python scripts.
 
 ### Organization of tests 
 
@@ -221,8 +221,8 @@ Feel free to use AI tools (Cursor, GitHub Copilot, Claude Code, etc.) to generat
 
 1. **Write new tests** for the changes that you make using `nf-test` if those tests don't already exist. At the very least, these tests should check that the new implementation runs to completion; tests that also verify the output on the test dataset are strongly encouraged.
 2. **Run all relevant tests locally** and make sure they pass. "Relevant" means: 1) Any tests of any process or workflow modified by the PR; 2) Any tests for any workflows that source any such process or workflow, and 3) Any tests that use any such process or workflow in setup.
-    - You may run all existing tests as described in the "Testing" section above.
-    - Or, you may identify relevant tests by recursively grepping for the process name in the `workflows`, `subworkflows`, and `tests` directories.
+    - For **nf-test**: You may run all existing tests as described in the "Testing" section above, or identify relevant tests by recursively grepping for the process name in the `workflows`, `subworkflows`, and `tests` directories.
+    - For **pytest**: If you modify Python scripts, run `pytest` on the corresponding test files to ensure unit tests pass.
     - **Note which tests were run in your PR description.**
     - If you make any changes that affect the output of the pipeline, list/describe the changes that occurred in the pull request. 
 3. **Update the `CHANGELOG.md` file** with the changes that you are making, and update the `pipeline-version.txt` file with the new version number.


### PR DESCRIPTION
Pytest tests are faster, easier to write, and allow more complicated logic than nf-test. For unit tests, these will now be preferred.  