### PR TITLE
Fix bug that prevents DOWNSTREAM workflow from running when the viral hits table has samples that are not in the grouping file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v3.0.1.1-dev
 - Updated `docs/developer.md` to reflect the new branch naming convention.
 - Added pyproject.toml at the top level directory to set ruff, and mypy settings.
+- Fixed bug in DOWNSTREAM that prevented the workflow from running when the viral hits table had samples that weren't in the grouping file.
 
 # v3.0.1.0
 

--- a/modules/local/validateGrouping/main.nf
+++ b/modules/local/validateGrouping/main.nf
@@ -1,4 +1,3 @@
-// Validate that the samples in the grouping file are a superset of the samples in the input file
 // Filter out the samples from the grouping file that have 0 viral hits
 process VALIDATE_GROUPING {
     label "python"

--- a/modules/local/validateGrouping/resources/usr/bin/test_validate_grouping.py
+++ b/modules/local/validateGrouping/resources/usr/bin/test_validate_grouping.py
@@ -9,33 +9,39 @@ def write_tsv(path, header, rows):
         for row in rows:
             f.write('\t'.join(row) + '\n')
 
-def test_validate_grouping_superset_and_fail():
+def test_validate_grouping_basic():
     with tempfile.TemporaryDirectory() as tmp:
         grouping_path = os.path.join(tmp, 'grouping.tsv')
         virus_hits_path = os.path.join(tmp, 'virus_hits.tsv')
         validated_output = os.path.join(tmp, 'validated_grouping.tsv')
         samples_without_vv_hits = os.path.join(tmp, 'samples_without_vv_hits.tsv')
 
-        # Case 1: Fail when grouping is not a superset
+        # Case 1: Pass when there is a sample in the virus hits file that is not in the grouping file, check outputs
         write_tsv(grouping_path, ['group', 'sample'], [['g1', 'S1']])
         write_tsv(virus_hits_path, ['sample'], [['S1'], ['S2']])
-        with pytest.raises(ValueError):
-            validate_grouping(grouping_path, virus_hits_path, samples_without_vv_hits, validated_output)
+        validate_grouping(grouping_path, virus_hits_path, samples_without_vv_hits, validated_output)
+        # Output should be untouched because S1 is in both; S2 doesn't effect output since it's not in grouping
+        with open(validated_output) as f:
+            lines = [l.strip() for l in f if l.strip()]
+        assert lines == ['group\tsample', 'g1\tS1']
+        # Output should be empty
+        with open(samples_without_vv_hits) as f:
+            unused_lines = [l.strip() for l in f if l.strip()]
+        assert unused_lines == []
 
         # Case 2: Pass when grouping is superset, check outputs
         write_tsv(grouping_path, ['group', 'sample'], [['g1', 'S1'], ['g2', 'S2']])
         write_tsv(virus_hits_path, ['sample'], [['S1']])
         validate_grouping(grouping_path, virus_hits_path, samples_without_vv_hits, validated_output)
-
         with open(validated_output) as f:
             lines = [l.strip() for l in f if l.strip()]
         assert lines == ['group\tsample', 'g1\tS1']
-
         with open(samples_without_vv_hits) as f:
             unused_lines = [l.strip() for l in f if l.strip()]
         assert unused_lines == ['S2']
 
 def test_validate_grouping_empty_files():
+    """Test that the code correctly handles an emtpy virus hits file with non-empty grouping file."""
     with tempfile.TemporaryDirectory() as tmp:
         grouping_path = os.path.join(tmp, 'grouping.tsv')
         virus_hits_path = os.path.join(tmp, 'virus_hits.tsv')

--- a/modules/local/validateGrouping/resources/usr/bin/test_validate_grouping.py
+++ b/modules/local/validateGrouping/resources/usr/bin/test_validate_grouping.py
@@ -20,7 +20,7 @@ def test_validate_grouping_basic():
         write_tsv(grouping_path, ['group', 'sample'], [['g1', 'S1']])
         write_tsv(virus_hits_path, ['sample'], [['S1'], ['S2']])
         validate_grouping(grouping_path, virus_hits_path, samples_without_vv_hits, validated_output)
-        # Output should be untouched because S1 is in both; S2 doesn't effect output since it's not in grouping
+        # Output should be untouched because S1 is in both; S2 doesn't affect output since it's not in grouping
         with open(validated_output) as f:
             lines = [l.strip() for l in f if l.strip()]
         assert lines == ['group\tsample', 'g1\tS1']
@@ -41,7 +41,7 @@ def test_validate_grouping_basic():
         assert unused_lines == ['S2']
 
 def test_validate_grouping_empty_files():
-    """Test that the code correctly handles an emtpy virus hits file with non-empty grouping file."""
+    """Test that the code correctly handles an empty virus hits file with non-empty grouping file."""
     with tempfile.TemporaryDirectory() as tmp:
         grouping_path = os.path.join(tmp, 'grouping.tsv')
         virus_hits_path = os.path.join(tmp, 'virus_hits.tsv')

--- a/modules/local/validateGrouping/resources/usr/bin/validate_grouping.py
+++ b/modules/local/validateGrouping/resources/usr/bin/validate_grouping.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
 """
-Check that the samples in the grouping file are a superset of the samples in the virus hits file.
-If it's not throw an error; otherwise, write a new grouping file with only samples observed in the hits file,
-and write a list of samples without viral hits.
+Write a new grouping file with only samples observed in the hits file, and write a list of samples without viral hits.
 
 Usage:
     validate_grouping.py virus_hits.tsv grouping.tsv validated_grouping.tsv.gz samples_without_vv_hits.tsv
@@ -140,9 +138,6 @@ def _stream_hits(virus_hits_path: str, sample_to_group: dict[str, str]) -> set[s
     
     Returns:
         set[str]: Set of sample IDs that appeared in virus_hits
-    
-    Raises:
-        ValueError: If virus hits header does not contain a 'sample' column or if samples are missing from grouping
     """
     seen: set[str] = set()
     header_idx = None
@@ -165,7 +160,7 @@ def _stream_hits(virus_hits_path: str, sample_to_group: dict[str, str]) -> set[s
     missing = seen - set(sample_to_group.keys())
     if missing:
         sorted_missing = sorted(missing)
-        raise ValueError(
+        logger.debug(
             f"Found {len(missing)} samples present in virus_hits but MISSING from grouping: "
             f"{', '.join(sorted_missing[:10])}{'...' if len(missing) > 10 else ''}"
         )
@@ -205,7 +200,7 @@ def validate_grouping(
     out_no_vv_samples_path: str,
     out_new_grouping_path: str,
 ) -> None:
-    """Validate that samples in grouping file are a superset of samples in virus hits file. Update grouping file to only include samples observed in virus hits.
+    """Update grouping file to only include samples observed in the viral hits file.
     
     Args:
         grouping_path (str): Path to the grouping TSV file


### PR DESCRIPTION
Addressing #438. Instead of raising an error when a sample is found in the viral hits table, and not in the grouping file, we now log a  statement for debugging. I also updated the tests to reflect this new functionality. 

The validateGrouping test works, and so do all tests that use prepareGroupingTsv.