### PR TITLE
Fix `VALIDATE_GROUPING` bug where headerless log files can't be concatenated as the concatenation script expects headers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v3.0.1.2-dev
 - Updated Virus-Host DB, and NCBI taxonomy database to the daily release in the INDEX workflow
 - Updated the list of viruses to exclude in the INDEX workflow
+- Added header to output zero_vv_log in VALIDATE_GROUPING so that CONCATENATE_EMPTY_SAMPLES_LIST in PREPARE_GROUP_TSVS doesn't fail
 
 # v3.0.1.1
 - Added bugfix for `VALIDATE_GROUPING` which allows viral hits tables to have samples that are not found in the groupings file. This previously raised an error, causing `DOWNSTREAM` to not run.

--- a/modules/local/validateGrouping/resources/usr/bin/test_validate_grouping.py
+++ b/modules/local/validateGrouping/resources/usr/bin/test_validate_grouping.py
@@ -24,10 +24,10 @@ def test_validate_grouping_basic():
         with open(validated_output) as f:
             lines = [l.strip() for l in f if l.strip()]
         assert lines == ['group\tsample', 'g1\tS1']
-        # Output should be empty
+        # Output should have header only
         with open(samples_without_vv_hits) as f:
             unused_lines = [l.strip() for l in f if l.strip()]
-        assert unused_lines == []
+        assert unused_lines == ['sample']
 
         # Case 2: Pass when grouping is superset, check outputs
         write_tsv(grouping_path, ['group', 'sample'], [['g1', 'S1'], ['g2', 'S2']])
@@ -38,7 +38,7 @@ def test_validate_grouping_basic():
         assert lines == ['group\tsample', 'g1\tS1']
         with open(samples_without_vv_hits) as f:
             unused_lines = [l.strip() for l in f if l.strip()]
-        assert unused_lines == ['S2']
+        assert unused_lines == ['sample', 'S2']
 
 def test_validate_grouping_empty_files():
     """Test that the code correctly handles an empty virus hits file with non-empty grouping file."""
@@ -57,7 +57,7 @@ def test_validate_grouping_empty_files():
         assert validated_lines == ['group\tsample']
         with open(samples_without_vv_hits) as f:
             unused_lines = [l.strip() for l in f if l.strip()]
-        assert set(unused_lines) == {'S1', 'S2'}
+        assert set(unused_lines) == {'sample', 'S1', 'S2'}
 
 def test_validate_grouping_perfect_match():
     """Test that when all samples in grouping are present in virus hits, 
@@ -78,5 +78,5 @@ def test_validate_grouping_perfect_match():
         assert validated_lines == expected_lines
         with open(samples_without_vv_hits) as f:
             unused_lines = [l.strip() for l in f if l.strip()]
-        assert unused_lines == []
+        assert unused_lines == ['sample']
 

--- a/modules/local/validateGrouping/resources/usr/bin/validate_grouping.py
+++ b/modules/local/validateGrouping/resources/usr/bin/validate_grouping.py
@@ -183,6 +183,7 @@ def _write_outputs(
     grouping_samples = set(sample_to_group.keys())
     samples_no_viral_hits = sorted(grouping_samples - seen_in_hits)
     with open_by_suffix(out_no_vv_samples_path, 'w') as out_unused:
+        out_unused.write("sample\n")
         for s in samples_no_viral_hits:
             out_unused.write(f"{s}\n")
     logger.info(f"Wrote {len(samples_no_viral_hits)} samples with no viral hits to {out_no_vv_samples_path}")


### PR DESCRIPTION
Addresses #448. 

In some DOWNSTREAM runs, we were getting errors from CONCATENATE_EMPTY_SAMPLES_LIST which concatenates the log files from VALIDATE_GROUPING.  CONCATENATE_EMPTY_SAMPLES_LIST requires there to be a header; however, the log files from VALIDATE_GROUPING didn't have headers, which is why this code failed. The test didn't catch this as the test data doesn't have samples with no viral hits. 