### PR TITLE
Release 3.0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# v3.0.1.4-dev
+# v3.0.1.4
 - Removed `nextflow.preview.output` statement from `main.nf` for compatibility with Nextflow 25.10
-- Updated Github Actions to use new Nextflow version.
+- Updated Github Actions to use Nextflow 25.10.0.
 - Updated container and dependency management
     - Implemented container dependency scanning with Trivy (`bin/scan_containers.py`) and wrote corresponding Github Actions test (currently expected to fail).
     - Implemented programmatic generation of Wave containers from YAML configuration files (`bin/build_wave_container.py` and `bin/build_wave_containers.py`) and replaced Docker Hub containers with generated Wave Containers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mgs-workflow"
-version = "3.0.1.4-dev"
+version = "3.0.1.4"
 requires-python = ">=3.12"
 dependencies = [
     "biopython>=1.85",


### PR DESCRIPTION
Testing:
- [x] nf-test tests passed except for #514, which resolved upon rerunning.
- [x] pytest tests passed
- [x] Test dataset run completed.

I notice one discrepancy between the produced and expected output for DOWNSTREAM:

* [Expected](https://github.com/securebio/nao-mgs-workflow/blob/release/dan/3.0.1.4/expected-outputs-downstream.txt): `input_downstream/input_file.csv`. 
* Got: `input_downstream/input.csv`

Git blame suggests that this discrepancy is old and unrelated to this release. Filing #516 and moving on.

I had claude code review whether the docs had been updated sufficiently and it found one thing that would be good to do, but I don't think should block this release. Opened #517.