### PR TITLE
Fix storage error in Github Actions index test

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   test-index:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     env:
       AWS_ACCESS_KEY_ID: ${{secrets.NAO_TESTING_ACCESS_KEY }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.NAO_TESTING_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
The Github Actions index test has been failing with a "no space on device" error, preventing PRs from getting merged without (dangerous) admin override. This PR fixes the issue by (1) clearing unneeded content from the runner instance disk and (2) raising the timeout limit. The test now passes.