### PR TITLE
Verify expected outputs in CI tests

### DIFF
--- a/.github/workflows/benchmark-illumina-100M.yml
+++ b/.github/workflows/benchmark-illumina-100M.yml
@@ -39,6 +39,7 @@ jobs:
               - 'tests/workflows/**'
               - 'workflows/**'
               - 'bin/chain_workflows.py'
+              - 'bin/verify_outputs.py'
               - 'configs/**'
               - 'tests/configs/**'
               - '.github/workflows/benchmark-illumina-100M.yml'
@@ -63,3 +64,18 @@ jobs:
             --samplesheet s3://nao-testing/benchmarks/Illumina_100M/samplesheet.csv \
             --launch-dir test_run_benchmark_100M \
             --base-dir s3://nao-testing-scratch/mgs-workflow-test/benchmark-illumina-100M/
+
+      - name: Verify RUN workflow outputs
+        if: steps.filter.outputs.relevant == 'true'
+        run: |
+          python bin/verify_outputs.py \
+            --output-dir s3://nao-testing-scratch/mgs-workflow-test/benchmark-illumina-100M/run/output \
+            --expected-outputs-key run
+
+      - name: Verify DOWNSTREAM workflow outputs
+        if: steps.filter.outputs.relevant == 'true'
+        run: |
+          python bin/verify_outputs.py \
+            --output-dir s3://nao-testing-scratch/mgs-workflow-test/benchmark-illumina-100M/downstream/output \
+            --expected-outputs-key downstream \
+            --input-csv test_run_benchmark_100M/downstream/input.csv

--- a/.github/workflows/benchmark-illumina-100M.yml
+++ b/.github/workflows/benchmark-illumina-100M.yml
@@ -62,9 +62,9 @@ jobs:
           bin/chain_workflows.py \
             --no-resume \
             --base-dir s3://nao-testing-scratch/mgs-workflow-test/benchmark-illumina-100M/
+            --launch-dir test_run_benchmark_100M/
             --ref-dir s3://nao-testing/mgs-workflow-test/index-latest/output/ \
             --samplesheet s3://nao-testing/benchmarks/Illumina_100M/samplesheet.csv \
-            --launch-dir test_run_benchmark_100M/
 
       - name: Verify RUN workflow outputs
         if: steps.filter.outputs.relevant == 'true'

--- a/.github/workflows/benchmark-illumina-100M.yml
+++ b/.github/workflows/benchmark-illumina-100M.yml
@@ -61,10 +61,10 @@ jobs:
         run: |
           bin/chain_workflows.py \
             --no-resume \
-            --base-dir s3://nao-testing-scratch/mgs-workflow-test/benchmark-illumina-100M/
-            --launch-dir test_run_benchmark_100M/
+            --base-dir s3://nao-testing-scratch/mgs-workflow-test/benchmark-illumina-100M/ \
+            --launch-dir test_run_benchmark_100M/ \
             --ref-dir s3://nao-testing/mgs-workflow-test/index-latest/output/ \
-            --samplesheet s3://nao-testing/benchmarks/Illumina_100M/samplesheet.csv \
+            --samplesheet s3://nao-testing/benchmarks/Illumina_100M/samplesheet.csv
 
       - name: Verify RUN workflow outputs
         if: steps.filter.outputs.relevant == 'true'

--- a/.github/workflows/benchmark-illumina-100M.yml
+++ b/.github/workflows/benchmark-illumina-100M.yml
@@ -41,6 +41,7 @@ jobs:
               - 'bin/chain_workflows.py'
               - 'configs/**'
               - 'tests/configs/**'
+              - '.github/workflows/benchmark-illumina-100M.yml'
 
       - name: Setup nf-test environment
         if: steps.filter.outputs.relevant == 'true'

--- a/.github/workflows/benchmark-illumina-100M.yml
+++ b/.github/workflows/benchmark-illumina-100M.yml
@@ -60,10 +60,11 @@ jobs:
         if: steps.filter.outputs.relevant == 'true'
         run: |
           bin/chain_workflows.py \
+            --no-resume \
+            --base-dir s3://nao-testing-scratch/mgs-workflow-test/benchmark-illumina-100M/
             --ref-dir s3://nao-testing/mgs-workflow-test/index-latest/output/ \
             --samplesheet s3://nao-testing/benchmarks/Illumina_100M/samplesheet.csv \
-            --launch-dir test_run_benchmark_100M \
-            --base-dir s3://nao-testing-scratch/mgs-workflow-test/benchmark-illumina-100M/
+            --launch-dir test_run_benchmark_100M/
 
       - name: Verify RUN workflow outputs
         if: steps.filter.outputs.relevant == 'true'

--- a/.github/workflows/benchmark-illumina-50M.yml
+++ b/.github/workflows/benchmark-illumina-50M.yml
@@ -1,4 +1,4 @@
-name: Benchmark test (Illumina 100M)
+name: Benchmark test (Illumina 50M)
 
 on:
   push:
@@ -11,11 +11,11 @@ on:
       - ci-test
 
 concurrency:
-  group: benchmark-illumina-100M-pr-${{ github.event.pull_request.number }}
+  group: benchmark-illumina-50M-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
-  benchmark-illumina-100M:
+  benchmark-illumina-50M:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
@@ -42,7 +42,7 @@ jobs:
               - 'bin/verify_outputs.py'
               - 'configs/**'
               - 'tests/configs/**'
-              - '.github/workflows/benchmark-illumina-100M.yml'
+              - '.github/workflows/benchmark-illumina-50M.yml'
 
       - name: Setup nf-test environment
         if: steps.filter.outputs.relevant == 'true'
@@ -61,22 +61,22 @@ jobs:
         run: |
           bin/chain_workflows.py \
             --no-resume \
-            --base-dir s3://nao-testing-scratch/mgs-workflow-test/benchmark-illumina-100M/ \
-            --launch-dir test_run_benchmark_100M/ \
+            --base-dir s3://nao-testing-scratch/mgs-workflow-test/benchmark-illumina-50M/ \
+            --launch-dir test_run_benchmark_50M/ \
             --ref-dir s3://nao-testing/mgs-workflow-test/index-latest/output/ \
-            --samplesheet s3://nao-testing/benchmarks/Illumina_100M/samplesheet.csv
+            --samplesheet s3://nao-testing/benchmarks/Illumina_50M/samplesheet.csv
 
       - name: Verify RUN workflow outputs
         if: steps.filter.outputs.relevant == 'true'
         run: |
           python bin/verify_outputs.py \
-            --output-dir s3://nao-testing-scratch/mgs-workflow-test/benchmark-illumina-100M/run/output \
+            --output-dir s3://nao-testing-scratch/mgs-workflow-test/benchmark-illumina-50M/run/output \
             --expected-outputs-key run
 
       - name: Verify DOWNSTREAM workflow outputs
         if: steps.filter.outputs.relevant == 'true'
         run: |
           python bin/verify_outputs.py \
-            --output-dir s3://nao-testing-scratch/mgs-workflow-test/benchmark-illumina-100M/downstream/output \
+            --output-dir s3://nao-testing-scratch/mgs-workflow-test/benchmark-illumina-50M/downstream/output \
             --expected-outputs-key downstream \
-            --input-csv test_run_benchmark_100M/downstream/input.csv
+            --input-csv test_run_benchmark_50M/downstream/input.csv

--- a/.github/workflows/nf-test-modules.yml
+++ b/.github/workflows/nf-test-modules.yml
@@ -34,6 +34,7 @@ jobs:
               - 'modules/**'
               - 'configs/**'
               - 'tests/configs/**'
+              - '.github/workflows/nf-test-modules.yml'
       - name: Setup nf-test environment
         if: steps.filter.outputs.modules == 'true'
         uses: ./.github/actions/setup-nf-test

--- a/.github/workflows/nf-test-subworkflows.yml
+++ b/.github/workflows/nf-test-subworkflows.yml
@@ -36,6 +36,7 @@ jobs:
               - 'subworkflows/**'
               - 'configs/**'
               - 'tests/configs/**'
+              - '.github/workflows/nf-test-subworkflows.yml'
       - name: Setup nf-test environment
         if: steps.filter.outputs.subworkflows == 'true'
         uses: ./.github/actions/setup-nf-test

--- a/.github/workflows/nf-test-workflows-downstream.yml
+++ b/.github/workflows/nf-test-workflows-downstream.yml
@@ -37,6 +37,7 @@ jobs:
               - 'configs/**'
               - 'tests/configs/**'
               - '.github/workflows/nf-test-workflows-downstream.yml'
+              - 'bin/verify_outputs.py'
 
       - name: Setup nf-test environment
         if: steps.filter.outputs.downstream == 'true'
@@ -47,6 +48,39 @@ jobs:
       - name: Run workflow tests
         if: steps.filter.outputs.downstream == 'true'
         run: bin/run-nf-test.sh --num-workers 4 tests/workflows/downstream.nf.test --output-log test-logs-workflows-downstream.txt --ci
+
+      - name: Verify DOWNSTREAM workflow outputs
+        if: steps.filter.outputs.downstream == 'true'
+        run: |
+          # Find all nf-test output directories that have downstream results
+          FOUND=0
+          for OUTPUT_DIR in $(find .nf-test/tests -name "output" -type d); do
+            if [ -d "$OUTPUT_DIR/results_downstream" ]; then
+              echo "Verifying outputs in: $OUTPUT_DIR"
+              INPUT_CSV="$OUTPUT_DIR/input_downstream/input_file.csv"
+              PLATFORM=$(jq -r '.platform' "$OUTPUT_DIR/input_downstream/params-downstream.json")
+              if [ "$PLATFORM" = "ont" ]; then
+                echo "Detected ONT downstream output"
+                python bin/verify_outputs.py \
+                  --output-dir "$OUTPUT_DIR" \
+                  --expected-outputs-key downstream-ont \
+                  --input-csv "$INPUT_CSV"
+              else
+                echo "Detected Illumina downstream output"
+                python bin/verify_outputs.py \
+                  --output-dir "$OUTPUT_DIR" \
+                  --expected-outputs-key downstream \
+                  --input-csv "$INPUT_CSV"
+              fi
+              FOUND=$((FOUND + 1))
+            fi
+          done
+          if [ "$FOUND" -eq 0 ]; then
+            echo "No downstream output directories found"
+            exit 1
+          fi
+          echo "Verified $FOUND downstream output directories"
+
       - name: Upload test results
         if: failure() && steps.filter.outputs.downstream == 'true'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/nf-test-workflows-downstream.yml
+++ b/.github/workflows/nf-test-workflows-downstream.yml
@@ -36,6 +36,7 @@ jobs:
               - 'workflows/downstream*'
               - 'configs/**'
               - 'tests/configs/**'
+              - '.github/workflows/nf-test-workflows-downstream.yml'
 
       - name: Setup nf-test environment
         if: steps.filter.outputs.downstream == 'true'

--- a/.github/workflows/nf-test-workflows-index.yml
+++ b/.github/workflows/nf-test-workflows-index.yml
@@ -36,6 +36,7 @@ jobs:
               - 'workflows/index*'
               - 'configs/**'
               - 'tests/configs/**'
+              - '.github/workflows/nf-test-workflows-index.yml'
       - name: Setup nf-test environment
         if: steps.filter.outputs.index == 'true'
         uses: ./.github/actions/setup-nf-test

--- a/.github/workflows/nf-test-workflows-run.yml
+++ b/.github/workflows/nf-test-workflows-run.yml
@@ -36,6 +36,8 @@ jobs:
               - 'workflows/run*'
               - 'configs/**'
               - 'tests/configs/**'
+              - '.github/workflows/nf-test-workflows-run.yml'
+              - 'bin/verify_outputs.py'
       - name: Setup nf-test environment
         if: steps.filter.outputs.run == 'true'
         uses: ./.github/actions/setup-nf-test

--- a/.github/workflows/nf-test-workflows-run.yml
+++ b/.github/workflows/nf-test-workflows-run.yml
@@ -45,6 +45,27 @@ jobs:
       - name: Run workflow tests
         if: steps.filter.outputs.run == 'true'
         run: bin/run-nf-test.sh --num-workers 4 tests/workflows/run.nf.test --output-log test-logs-workflows-run.txt --ci
+
+      - name: Verify RUN workflow outputs
+        if: steps.filter.outputs.run == 'true'
+        run: |
+          # Find all nf-test output directories that have results
+          FOUND=0
+          for OUTPUT_DIR in $(find .nf-test/tests -name "output" -type d); do
+            if ls "$OUTPUT_DIR"/results/*.gz 1>/dev/null 2>&1; then
+              echo "Verifying outputs in: $OUTPUT_DIR"
+              python bin/verify_outputs.py \
+                --output-dir "$OUTPUT_DIR" \
+                --expected-outputs-key run
+              FOUND=$((FOUND + 1))
+            fi
+          done
+          if [ "$FOUND" -eq 0 ]; then
+            echo "No output directories with results found"
+            exit 1
+          fi
+          echo "Verified $FOUND output directories"
+
       - name: Upload test results
         if: failure() && steps.filter.outputs.run == 'true'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -26,6 +26,7 @@ jobs:
           filters: |
             python:
               - '**/*.py'
+              - '.github/workflows/pytest.yml'
 
       - name: Set up Python 3.12
         if: steps.filter.outputs.python == 'true'

--- a/.github/workflows/test-chained.yml
+++ b/.github/workflows/test-chained.yml
@@ -40,6 +40,7 @@ jobs:
               - 'bin/chain_workflows.py'
               - 'configs/**'
               - 'tests/configs/**'
+              - '.github/workflows/test-chained.yml'
       - name: Setup nf-test environment
         if: steps.filter.outputs.chained == 'true'
         uses: ./.github/actions/setup-nf-test

--- a/.github/workflows/test-chained.yml
+++ b/.github/workflows/test-chained.yml
@@ -38,6 +38,7 @@ jobs:
               - 'tests/workflows/**'
               - 'workflows/**'
               - 'bin/chain_workflows.py'
+              - 'bin/verify_outputs.py'
               - 'configs/**'
               - 'tests/configs/**'
               - '.github/workflows/test-chained.yml'
@@ -56,3 +57,18 @@ jobs:
         if: steps.filter.outputs.chained == 'true'
         run: |
           bin/chain_workflows.py --no-resume --base-dir s3://nao-testing-scratch/mgs-workflow-test
+
+      - name: Verify RUN workflow outputs
+        if: steps.filter.outputs.chained == 'true'
+        run: |
+          python bin/verify_outputs.py \
+            --output-dir s3://nao-testing-scratch/mgs-workflow-test/run/output \
+            --expected-outputs-key run
+
+      - name: Verify DOWNSTREAM workflow outputs
+        if: steps.filter.outputs.chained == 'true'
+        run: |
+          python bin/verify_outputs.py \
+            --output-dir s3://nao-testing-scratch/mgs-workflow-test/downstream/output \
+            --expected-outputs-key downstream \
+            --input-csv test_run/downstream/input.csv

--- a/.github/workflows/test-chained.yml
+++ b/.github/workflows/test-chained.yml
@@ -68,13 +68,13 @@ jobs:
         if: steps.filter.outputs.chained == 'true'
         run: |
           python bin/verify_outputs.py \
-            --output-dir s3://nao-testing-scratch/mgs-workflow-test/run/output \
+            --output-dir s3://nao-testing-scratch/mgs-workflow-test/chained-test/run/output \
             --expected-outputs-key run
 
       - name: Verify DOWNSTREAM workflow outputs
         if: steps.filter.outputs.chained == 'true'
         run: |
           python bin/verify_outputs.py \
-            --output-dir s3://nao-testing-scratch/mgs-workflow-test/downstream/output \
+            --output-dir s3://nao-testing-scratch/mgs-workflow-test/chained-test/downstream/output \
             --expected-outputs-key downstream \
-            --input-csv test_run/downstream/input.csv
+            --input-csv test_run_chained/downstream/input.csv

--- a/.github/workflows/test-chained.yml
+++ b/.github/workflows/test-chained.yml
@@ -61,7 +61,8 @@ jobs:
         run: |
           bin/chain_workflows.py \
               --no-resume \
-              --base-dir s3://nao-testing-scratch/mgs-workflow-test/chained-test/
+              --base-dir s3://nao-testing-scratch/mgs-workflow-test/chained-test/ \
+              --launch-dir test_run_chained/
 
       - name: Verify RUN workflow outputs
         if: steps.filter.outputs.chained == 'true'

--- a/.github/workflows/test-chained.yml
+++ b/.github/workflows/test-chained.yml
@@ -25,6 +25,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Check for relevant changes
         uses: dorny/paths-filter@v3
         id: filter
@@ -42,6 +43,7 @@ jobs:
               - 'configs/**'
               - 'tests/configs/**'
               - '.github/workflows/test-chained.yml'
+
       - name: Setup nf-test environment
         if: steps.filter.outputs.chained == 'true'
         uses: ./.github/actions/setup-nf-test
@@ -53,10 +55,13 @@ jobs:
         if: steps.filter.outputs.chained == 'true'
         run: |
           pip install boto3
+
       - name: Run chain workflows integration test
         if: steps.filter.outputs.chained == 'true'
         run: |
-          bin/chain_workflows.py --no-resume --base-dir s3://nao-testing-scratch/mgs-workflow-test
+          bin/chain_workflows.py \
+              --no-resume \
+              --base-dir s3://nao-testing-scratch/mgs-workflow-test/chained-test/
 
       - name: Verify RUN workflow outputs
         if: steps.filter.outputs.chained == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Streamlining releases by moving large tests into Github Actions
     - Whole `nf-test` suite now runs on PRs to main (`.github/workflows/nf-test-*`)
     - Chained `INDEX -> RUN -> DOWNSTREAM` integration test on toy data runs before PRs to `main` (`.github/workflows/test-chained.yml`)
+    - Chained `RUN -> DOWNSTREAM` integration tests for real benchmark data.
+    - Verification that outputs of integration tests match the expected outputs specified in `pyproject.toml`
     - Added test to enforce `CHANGELOG.md` updates in PRs to `dev` (`.github/workflows/check-changelog.yml`)
     - Consolidated version & output tracking into `pyproject.toml` & added a test for version consistency between `pyproject.toml` and `CHANGELOG.md`.
     - Moved release documentation from private internal docs to `docs/developer.md` and updated formatting to match Github requirements.

--- a/bin/test_check_nextflow_version.py
+++ b/bin/test_check_nextflow_version.py
@@ -117,7 +117,7 @@ class TestMain:
         captured = capsys.readouterr()
         assert "Pinned Nextflow version: 25.10.0" in captured.out
         assert "Latest Nextflow version: 25.10.0" in captured.out
-        assert "OK: Pinned version matches latest release" in captured.out
+        assert "OK: Pinned version matches target release" in captured.out
 
     def test_versions_mismatch(self, tmp_path):
         config = tmp_path / "profiles.config"

--- a/bin/test_verify_outputs.py
+++ b/bin/test_verify_outputs.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Unit tests for verify_outputs.py"""
+
+import pytest
+
+from verify_outputs import (
+    compare_outputs,
+    expand_group_placeholder,
+    get_expected_outputs,
+    is_excluded,
+    list_s3_files,
+    parse_groups_from_file,
+    report_verification,
+    resolve_groups,
+)
+
+
+class TestExpandGroupPlaceholder:
+    @pytest.mark.parametrize(
+        "patterns,groups,expected",
+        [
+            (["file.txt"], ["a", "b"], {"file.txt"}),
+            (["{GROUP}/out.txt"], ["a", "b"], {"a/out.txt", "b/out.txt"}),
+            (["static.txt", "{GROUP}/data.csv"], ["x"], {"static.txt", "x/data.csv"}),
+            (["{GROUP}/out.txt", "static.txt"], [], {"static.txt"}),
+            (["{GROUP}/{GROUP}.txt"], ["a"], {"a/a.txt"}),
+        ],
+    )
+    def test_expansion(self, patterns, groups, expected):
+        assert expand_group_placeholder(patterns, groups) == expected
+
+
+class TestIsExcluded:
+    @pytest.mark.parametrize(
+        "path,patterns,expected",
+        [
+            ("logging/trace.txt", ["logging/trace.txt"], True),
+            ("logging/trace-12345.txt", ["logging/trace*"], True),
+            ("results/output.csv", ["logging/trace*"], False),
+            ("logging/trace.log", ["logging/trace*", "temp/*"], True),
+            ("temp/scratch.txt", ["logging/trace*", "temp/*"], True),
+            ("results/final.csv", ["logging/trace*", "temp/*"], False),
+            ("any/file.txt", [], False),
+        ],
+    )
+    def test_exclusion(self, path, patterns, expected):
+        assert is_excluded(path, patterns) == expected
+
+
+class TestCompareOutputs:
+    @pytest.mark.parametrize(
+        "expected,actual,excluded,want_missing,want_unexpected",
+        [
+            ({"a.txt", "b.txt"}, {"a.txt", "b.txt"}, [], set(), set()),
+            ({"a.txt", "b.txt"}, {"a.txt"}, [], {"b.txt"}, set()),
+            ({"a.txt"}, {"a.txt", "b.txt"}, [], set(), {"b.txt"}),
+            ({"a.txt"}, {"a.txt", "log/trace.txt"}, ["log/*"], set(), set()),
+            ({"a.txt", "b.txt"}, {"a.txt", "c.txt"}, [], {"b.txt"}, {"c.txt"}),
+        ],
+    )
+    def test_comparison(self, expected, actual, excluded, want_missing, want_unexpected):
+        missing, unexpected = compare_outputs(expected, actual, excluded)
+        assert missing == want_missing
+        assert unexpected == want_unexpected
+
+
+class TestParseGroupsFromFile:
+    @pytest.mark.parametrize(
+        "filename,content,expected",
+        [
+            ("groups.tsv", "sample\tgroup\ns1\ta\ns2\ta\ns3\tb\n", ["a", "b"]),
+            ("samplesheet.csv", "sample,fastq_1\ns1,f1.fq\ns2,f2.fq\n", ["s1", "s2"]),
+            ("groups.csv", "sample,group\ns1,alpha\ns2,beta\n", ["alpha", "beta"]),
+            ("groups.tsv", "sample\tgroup\ns1\tzebra\ns2\talpha\n", ["alpha", "zebra"]),
+        ],
+    )
+    def test_valid_files(self, tmp_path, filename, content, expected):
+        groups_file = tmp_path / filename
+        groups_file.write_text(content)
+        assert parse_groups_from_file(str(groups_file)) == expected
+
+    def test_missing_required_column(self, tmp_path):
+        bad_file = tmp_path / "bad.csv"
+        bad_file.write_text("name,value\nfoo,bar\n")
+        with pytest.raises(ValueError, match="must have 'group' or 'sample' column"):
+            parse_groups_from_file(str(bad_file))
+
+
+class TestResolveGroups:
+    def test_local_file(self, tmp_path):
+        groups_file = tmp_path / "groups.tsv"
+        groups_file.write_text("sample\tgroup\ns1\tgroup_a\ns2\tgroup_b\n")
+        assert resolve_groups(str(groups_file)) == ["group_a", "group_b"]
+
+
+class TestGetExpectedOutputs:
+    @pytest.mark.parametrize(
+        "workflow,outputs",
+        [
+            ("run", ["file1.txt", "file2.txt"]),
+            ("downstream", ["{GROUP}/output.csv"]),
+            ("downstream-ont", ["ont_results.tsv"]),
+        ],
+    )
+    def test_valid_keys(self, tmp_path, workflow, outputs):
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(f"""
+[tool.mgs-workflow]
+expected-outputs-{workflow} = {outputs!r}
+""")
+        assert get_expected_outputs(pyproject, workflow) == outputs
+
+    @pytest.mark.parametrize(
+        "content,workflow,match",
+        [
+            ("[tool.mgs-workflow]\nexpected-outputs-run = []", "downstream", "expected-outputs-downstream"),
+            ("[tool.other]\nkey = 'value'", "run", "expected-outputs-run"),
+        ],
+    )
+    def test_missing_key(self, tmp_path, content, workflow, match):
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(content)
+        with pytest.raises(ValueError, match=f"Missing '{match}'"):
+            get_expected_outputs(pyproject, workflow)
+
+
+class TestReportVerification:
+    def test_success_does_not_raise(self):
+        report_verification("test", set(), set())
+
+    @pytest.mark.parametrize(
+        "missing,unexpected,match",
+        [
+            ({"a.txt"}, set(), "1 missing"),
+            (set(), {"a.txt"}, "1 unexpected"),
+            ({"a.txt", "b.txt"}, {"c.txt"}, "2 missing.*1 unexpected"),
+        ],
+    )
+    def test_failure_raises(self, missing, unexpected, match):
+        with pytest.raises(ValueError, match=match):
+            report_verification("test", missing, unexpected)
+
+    def test_error_includes_workflow_name(self):
+        with pytest.raises(ValueError, match="MY_WORKFLOW"):
+            report_verification("MY_WORKFLOW", {"file.txt"}, set())
+
+
+class TestListS3Files:
+    def test_invalid_s3_path(self):
+        with pytest.raises(ValueError, match="Invalid S3 path"):
+            list_s3_files("/local/path")

--- a/bin/test_verify_outputs.py
+++ b/bin/test_verify_outputs.py
@@ -8,6 +8,8 @@ from verify_outputs import (
     expand_group_placeholder,
     get_expected_outputs,
     is_excluded,
+    list_files,
+    list_local_files,
     list_s3_files,
     parse_groups_from_file,
     report_verification,
@@ -143,6 +145,29 @@ class TestReportVerification:
     def test_error_includes_workflow_name(self):
         with pytest.raises(ValueError, match="MY_WORKFLOW"):
             report_verification("MY_WORKFLOW", {"file.txt"}, set())
+
+
+class TestListLocalFiles:
+    def test_lists_files_recursively(self, tmp_path):
+        (tmp_path / "a.txt").write_text("a")
+        (tmp_path / "subdir").mkdir()
+        (tmp_path / "subdir" / "b.txt").write_text("b")
+        result = list_local_files(str(tmp_path))
+        assert result == {"a.txt", "subdir/b.txt"}
+
+    def test_empty_directory(self, tmp_path):
+        assert list_local_files(str(tmp_path)) == set()
+
+    def test_nonexistent_directory(self, tmp_path):
+        with pytest.raises(ValueError, match="does not exist"):
+            list_local_files(str(tmp_path / "nonexistent"))
+
+
+class TestListFiles:
+    def test_local_path(self, tmp_path):
+        (tmp_path / "file.txt").write_text("content")
+        result = list_files(str(tmp_path))
+        assert result == {"file.txt"}
 
 
 class TestListS3Files:

--- a/bin/verify_outputs.py
+++ b/bin/verify_outputs.py
@@ -56,6 +56,7 @@ EXCLUDED_PATTERNS = [
     "logging/trace*",
     "logging_downstream/trace*",
     "intermediates/*",
+    "intermediates_downstream/*",
     "results/merged_blast_*",
 ]
 

--- a/bin/verify_outputs.py
+++ b/bin/verify_outputs.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""
+Verify pipeline outputs match expected outputs from pyproject.toml.
+
+This script checks that:
+1. All expected output files are present
+2. No unexpected files are present (except explicitly excluded patterns)
+"""
+
+#=============================================================================
+# Imports
+#=============================================================================
+
+# Standard library imports
+import argparse
+import csv
+import fnmatch
+import logging
+import tempfile
+import tomllib
+from datetime import UTC, datetime
+from pathlib import Path
+
+# Third-party imports
+import boto3
+
+#=============================================================================
+# Logging
+#=============================================================================
+
+class UTCFormatter(logging.Formatter):
+    """Custom logging formatter that displays timestamps in UTC."""
+
+    def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
+        """Format log timestamps in UTC timezone."""
+        dt = datetime.fromtimestamp(record.created, UTC)
+        return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger()
+handler = logging.StreamHandler()
+formatter = UTCFormatter("[%(asctime)s] %(message)s")
+handler.setFormatter(formatter)
+logger.handlers.clear()
+logger.addHandler(handler)
+
+#=============================================================================
+# Constants
+#=============================================================================
+
+DEFAULT_PYPROJECT_PATH = Path(__file__).parent.parent / "pyproject.toml"
+
+# Patterns to exclude from verification (matched against relative paths)
+EXCLUDED_PATTERNS = [
+    "logging/trace*",
+    "logging_downstream/trace*",
+]
+
+#=============================================================================
+# S3 helpers
+#=============================================================================
+
+def list_s3_files(s3_path: str) -> set[str]:
+    """
+    List all files under an S3 path.
+    Args:
+        s3_path (str): S3 URI (s3://bucket/prefix)
+    Returns:
+        set[str]: Set of relative paths (relative to s3_path)
+    """
+    if not s3_path.startswith("s3://"):
+        raise ValueError(f"Invalid S3 path: {s3_path}")
+    path_without_scheme = s3_path.removeprefix("s3://")
+    parts = path_without_scheme.split("/", 1)
+    bucket = parts[0]
+    prefix = parts[1].rstrip("/") + "/" if len(parts) > 1 else ""
+    s3_client = boto3.client("s3")
+    files = set()
+    paginator = s3_client.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            if key.startswith(prefix):
+                relative_path = key.removeprefix(prefix)
+                if relative_path:
+                    files.add(relative_path)
+    return files
+
+def download_s3_file(s3_path: str, local_path: Path) -> None:
+    """
+    Download a file from S3.
+    Args:
+        s3_path (str): S3 URI to download
+        local_path (Path): Local path to save file
+    """
+    path_without_scheme = s3_path.removeprefix("s3://")
+    parts = path_without_scheme.split("/", 1)
+    bucket = parts[0]
+    key = parts[1]
+    s3_client = boto3.client("s3")
+    s3_client.download_file(bucket, key, str(local_path))
+
+#=============================================================================
+# Config helpers
+#=============================================================================
+
+def get_expected_outputs(pyproject_path: Path, workflow: str) -> list[str]:
+    """
+    Read expected outputs from pyproject.toml for a specific workflow.
+    Args:
+        pyproject_path (Path): Path to pyproject.toml
+        workflow (str): Workflow name ('run', 'downstream', or 'downstream-ont')
+    Returns:
+        list[str]: List of expected output paths (may contain {GROUP} placeholder)
+    """
+    with open(pyproject_path, "rb") as f:
+        data = tomllib.load(f)
+    key = f"expected-outputs-{workflow}"
+    mgs_config = data.get("tool", {}).get("mgs-workflow", {})
+    if key not in mgs_config:
+        raise ValueError(
+            f"Missing '{key}' in [tool.mgs-workflow] section of {pyproject_path}"
+        )
+    return mgs_config[key]
+
+def parse_groups_from_file(groups_file: str) -> list[str]:
+    """
+    Extract unique groups from a groups TSV (uses 'group' column) or samplesheet (uses 'sample' column).
+    Args:
+        groups_file (str): Local path to groups TSV or samplesheet CSV
+    Returns:
+        list[str]: List of unique group names
+    """
+    # Detect delimiter from file extension
+    delimiter = "\t" if groups_file.endswith(".tsv") else ","
+    with open(groups_file) as f:
+        reader = csv.DictReader(f, delimiter=delimiter)
+        if "group" in reader.fieldnames:
+            column = "group"
+        elif "sample" in reader.fieldnames:
+            column = "sample"
+        else:
+            raise ValueError(
+                f"File must have 'group' or 'sample' column: {groups_file}"
+            )
+        groups = {row[column] for row in reader}
+    return sorted(groups)
+
+def resolve_groups(groups_file: str) -> list[str]:
+    """
+    Resolve groups file path and extract groups.
+    Args:
+        groups_file (str): Path to groups TSV or samplesheet (local or S3)
+    Returns:
+        list[str]: List of group names
+    """
+    if groups_file.startswith("s3://"):
+        suffix = ".tsv" if groups_file.endswith(".tsv") else ".csv"
+        with tempfile.NamedTemporaryFile(suffix=suffix) as tmp:
+            download_s3_file(groups_file, Path(tmp.name))
+            return parse_groups_from_file(tmp.name)
+    return parse_groups_from_file(groups_file)
+
+#=============================================================================
+# Verification helpers
+#=============================================================================
+
+def expand_group_placeholder(patterns: list[str], groups: list[str]) -> set[str]:
+    """
+    Expand {GROUP} placeholders in patterns.
+    Args:
+        patterns (list[str]): List of patterns that may contain {GROUP}
+        groups (list[str]): List of group names to expand
+    Returns:
+        set[str]: Set of expanded patterns with {GROUP} replaced
+    """
+    expanded = set()
+    for pattern in patterns:
+        if "{GROUP}" in pattern:
+            for group in groups:
+                expanded.add(pattern.replace("{GROUP}", group))
+        else:
+            expanded.add(pattern)
+    return expanded
+
+def is_excluded(path: str, excluded_patterns: list[str]) -> bool:
+    """
+    Check if a path matches any exclusion pattern.
+    Args:
+        path (str): Relative file path
+        excluded_patterns (list[str]): List of glob patterns to exclude
+    Returns:
+        bool: True if path should be excluded
+    """
+    return any(fnmatch.fnmatch(path, pattern) for pattern in excluded_patterns)
+
+def compare_outputs(
+    expected: set[str],
+    actual: set[str],
+    excluded_patterns: list[str],
+) -> tuple[set[str], set[str]]:
+    """
+    Compare expected vs actual outputs.
+    Args:
+        expected (set[str]): Set of expected file paths
+        actual (set[str]): Set of actual file paths
+        excluded_patterns (list[str]): Patterns to exclude from unexpected file detection
+    Returns:
+        tuple[set[str], set[str]]: Tuple of (missing files, unexpected files)
+    """
+    missing = expected - actual
+    unexpected_candidates = actual - expected
+    unexpected = {
+        path
+        for path in unexpected_candidates
+        if not is_excluded(path, excluded_patterns)
+    }
+    return missing, unexpected
+
+def report_verification(
+    workflow_name: str,
+    missing: set[str],
+    unexpected: set[str],
+) -> None:
+    """
+    Report verification results and raise if failed.
+    Args:
+        workflow_name (str): Name for logging (e.g., "RUN", "DOWNSTREAM")
+        missing (set[str]): Set of missing file paths
+        unexpected (set[str]): Set of unexpected file paths
+    """
+    if not missing and not unexpected:
+        logger.info(f"{workflow_name} outputs: OK")
+        return
+    msg = (
+        f"Expected output verification failed for {workflow_name}. "
+        f"{len(missing)} missing files, {len(unexpected)} unexpected files"
+    )
+    logger.error(msg)
+    if missing:
+        logger.error("Missing files:")
+        for path in sorted(missing):
+            logger.error(f"  - {path}")
+    if unexpected:
+        logger.error("Unexpected files:")
+        for path in sorted(unexpected):
+            logger.error(f"  - {path}")
+    raise ValueError(msg)
+
+def verify_outputs(
+    workflow_name: str,
+    output_dir: str,
+    expected_patterns: list[str],
+    excluded_patterns: list[str],
+    groups: list[str] | None,
+) -> None:
+    """
+    Verify outputs for a single workflow.
+    Args:
+        workflow_name (str): Name for logging (e.g., "RUN", "DOWNSTREAM")
+        output_dir (str): S3 path to output directory
+        expected_patterns (list[str]): Expected output patterns (may contain {GROUP})
+        excluded_patterns (list[str]): Patterns to exclude from unexpected file detection
+        groups (list[str] | None): Group names for placeholder expansion (None to skip)
+    Raises:
+        ValueError: If verification fails (missing or unexpected files)
+    """
+    logger.info(f"Verifying {workflow_name} outputs: {output_dir}")
+    if groups is not None:
+        expected = expand_group_placeholder(expected_patterns, groups)
+    else:
+        expected = set(expected_patterns)
+    actual = list_s3_files(output_dir)
+    logger.info(f"Expected: {len(expected)} files, Actual: {len(actual)} files")
+    missing, unexpected = compare_outputs(expected, actual, excluded_patterns)
+    report_verification(workflow_name, missing, unexpected)
+
+#=============================================================================
+# Argument parsing
+#=============================================================================
+
+def parse_args() -> argparse.Namespace:
+    """
+    Parse command line arguments.
+    """
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        required=True,
+        help="S3 path to output directory to verify",
+    )
+    parser.add_argument(
+        "--expected-outputs-key",
+        type=str,
+        required=True,
+        choices=["run", "downstream", "downstream-ont"],
+        help="Key in pyproject.toml specifying expected outputs",
+    )
+    parser.add_argument(
+        "--groups",
+        type=str,
+        default=None,
+        help="Optional: path to groups TSV or samplesheet (local or S3) for {GROUP} expansion",
+    )
+    parser.add_argument(
+        "--pyproject",
+        type=Path,
+        default=DEFAULT_PYPROJECT_PATH,
+        help=f"Path to pyproject.toml (default: {DEFAULT_PYPROJECT_PATH})",
+    )
+    parser.add_argument(
+        "--exclude",
+        type=str,
+        action="append",
+        default=[],
+        help=f"Additional exclusion patterns (can be repeated). "
+             f"Default exclusions: {EXCLUDED_PATTERNS}",
+    )
+    return parser.parse_args()
+
+#=============================================================================
+# Main function
+#=============================================================================
+
+def main() -> None:
+    """
+    Main function.
+    """
+    logger.info("Starting output verification")
+    start_time = time.time()
+    args = parse_args()
+    logger.info(f"Parsed arguments: {args}")
+    excluded_patterns = EXCLUDED_PATTERNS + args.exclude
+    logger.info(f"Excluded patterns: {excluded_patterns}")
+    if args.groups:
+        groups = resolve_groups(args.groups)
+        logger.info(f"Groups: {groups}")
+    else:
+        groups = None
+    expected_patterns = get_expected_outputs(args.pyproject, args.expected_outputs_key)
+    verify_outputs(
+        args.expected_outputs_key,
+        args.output_dir,
+        expected_patterns,
+        excluded_patterns,
+        groups,
+    )
+    end_time = time.time()
+    logger.info(f"Output verification completed in {end_time - start_time:.2f} seconds")
+
+if __name__ == "__main__":
+    main()

--- a/bin/verify_outputs.py
+++ b/bin/verify_outputs.py
@@ -18,6 +18,7 @@ import fnmatch
 import logging
 import tempfile
 import tomllib
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 

--- a/bin/verify_outputs.py
+++ b/bin/verify_outputs.py
@@ -55,6 +55,8 @@ DEFAULT_PYPROJECT_PATH = Path(__file__).parent.parent / "pyproject.toml"
 EXCLUDED_PATTERNS = [
     "logging/trace*",
     "logging_downstream/trace*",
+    "intermediates/*",
+    "results/merged_blast_*",
 ]
 
 #=============================================================================

--- a/bin/verify_outputs.py
+++ b/bin/verify_outputs.py
@@ -93,7 +93,7 @@ def list_s3_files(s3_path: str) -> set[str]:
     path_without_scheme = s3_path.removeprefix("s3://")
     parts = path_without_scheme.split("/", 1)
     bucket = parts[0]
-    prefix = parts[1].rstrip("/") + "/" if len(parts) > 1 else ""
+    prefix = f'{parts[1].rstrip("/")}/' if len(parts) > 1 and parts[1] else ""
     s3_client = boto3.client("s3")
     files = set()
     paginator = s3_client.get_paginator("list_objects_v2")

--- a/bin/verify_outputs.py
+++ b/bin/verify_outputs.py
@@ -164,7 +164,7 @@ def parse_groups_from_file(groups_file: str) -> list[str]:
         list[str]: List of unique group names
     """
     delimiter = "\t" if groups_file.endswith(".tsv") else ","
-    with open(groups_file) as f:
+    with open(groups_file, encoding="utf-8", newline="") as f:
         reader = csv.DictReader(f, delimiter=delimiter)
         fieldnames = reader.fieldnames or []
         if "group" in fieldnames:

--- a/configs/profiles.config
+++ b/configs/profiles.config
@@ -1,7 +1,7 @@
 // Enforce minimum Nextflow version required to run this pipeline
 // The '!' prefix makes this a hard requirement (fails instead of warning)
 manifest {
-    nextflowVersion = '!>=25.10.0'
+    nextflowVersion = '!>=25.10.3'
 }
 
 // Currently universal settings

--- a/configs/profiles.config
+++ b/configs/profiles.config
@@ -1,7 +1,7 @@
 // Enforce minimum Nextflow version required to run this pipeline
 // The '!' prefix makes this a hard requirement (fails instead of warning)
 manifest {
-    nextflowVersion = '!>=25.10.3'
+    nextflowVersion = '!>=25.10.0'
 }
 
 // Currently universal settings

--- a/configs/profiles.config
+++ b/configs/profiles.config
@@ -1,7 +1,7 @@
 // Enforce minimum Nextflow version required to run this pipeline
 // The '!' prefix makes this a hard requirement (fails instead of warning)
 manifest {
-    nextflowVersion = '!>=25.10.3'
+    nextflowVersion = '!>=25.10.2'
 }
 
 // Currently universal settings

--- a/modules/local/checkVersions/main.nf
+++ b/modules/local/checkVersions/main.nf
@@ -43,8 +43,7 @@ def isVersionLess(version1, version2) {
 ***********/
 
 process CHECK_VERSIONS {
-    label "single"
-    label "coreutils"
+    executor 'local'
     input:
         val pipeline_version
         val index_version

--- a/modules/local/checkVersions/main.nf
+++ b/modules/local/checkVersions/main.nf
@@ -1,0 +1,64 @@
+// Check that pipeline and index versions are compatible
+
+/**********************
+| AUXILIARY FUNCTIONS |
+**********************/
+
+def isVersionLess(version1, version2) {
+    /* Compare two semantic versions and return a boolean stating
+    whether the first is less (i.e. older) than the second. */
+    // Remove terminal tags (anything after a hyphen)
+    def cleanVersion1 = version1.tokenize("-")[0]
+    def cleanVersion2 = version2.tokenize("-")[0]
+    // Split components by periods
+    def v1Components = cleanVersion1.tokenize(".")
+    def v2Components = cleanVersion2.tokenize(".")
+    // Convert to integers (and raise error if unable)
+    def v1IntComponents
+    def v2IntComponents
+    try {
+        v1IntComponents = v1Components.collect{ it.toInteger() }
+    } catch (NumberFormatException _e) {
+        def msg1 = "Invalid version format: version 1 (${version1}) contains non-integer components."
+        throw new IllegalArgumentException(msg1)
+    }
+    try {
+        v2IntComponents = v2Components.collect{ it.toInteger() }
+    } catch (NumberFormatException _e) {
+        def msg2 = "Invalid version format: version 2 (${version2}) contains non-integer components."
+        throw new IllegalArgumentException(msg2)
+    }
+    // Get the longest version length and pad shorter version with zeros
+    def maxLength = Math.max(v1IntComponents.size(), v2IntComponents.size())
+    def paddedV1 = v1IntComponents + [0] * (maxLength - v1IntComponents.size())
+    def paddedV2 = v2IntComponents + [0] * (maxLength - v2IntComponents.size())
+
+    // Find first differing component
+    def diff = (0..<maxLength).find { i -> paddedV1[i] != paddedV2[i] }
+    return diff != null ? paddedV1[diff] < paddedV2[diff] : false
+}
+
+/***********
+| PROCESS |
+***********/
+
+process CHECK_VERSIONS {
+    label "single"
+    label "coreutils"
+    input:
+        val pipeline_version
+        val index_version
+        val pipeline_min_index
+        val index_min_pipeline
+    output:
+        val true
+    exec:
+        if (index_min_pipeline && isVersionLess(pipeline_version, index_min_pipeline)) {
+            def msg_a = "Pipeline version is older than index minimum: ${pipeline_version} < ${index_min_pipeline}"
+            throw new Exception(msg_a)
+        }
+        if (pipeline_min_index && isVersionLess(index_version, pipeline_min_index)) {
+            def msg_b = "Index version is older than pipeline minimum: ${index_version} < ${pipeline_min_index}"
+            throw new Exception(msg_b)
+        }
+}

--- a/modules/local/createEmptyGroupOutputs/main.nf
+++ b/modules/local/createEmptyGroupOutputs/main.nf
@@ -1,0 +1,16 @@
+// Create empty output files for groups with no virus hits
+process CREATE_EMPTY_GROUP_OUTPUTS {
+    label "python"
+    label "single"
+    input:
+        path(empty_groups_tsv)
+        path(pyproject_toml)
+        val(platform)
+    output:
+        path("*_*.tsv.gz"), emit: outputs, optional: true
+    script:
+        def platform_arg = platform == "ont" ? "--platform ont" : "--platform illumina"
+        """
+        create_empty_group_outputs.py ${empty_groups_tsv} ${pyproject_toml} ./ ${platform_arg}
+        """
+}

--- a/modules/local/createEmptyGroupOutputs/resources/usr/bin/create_empty_group_outputs.py
+++ b/modules/local/createEmptyGroupOutputs/resources/usr/bin/create_empty_group_outputs.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""
+Create empty output files for groups with no virus hits.
+
+Reads empty group names from a TSV file and creates empty gzipped files
+for each expected per-group output defined in pyproject.toml.
+"""
+
+#=============================================================================
+# Imports
+#=============================================================================
+
+# Standard library imports
+import argparse
+import csv
+import gzip
+import io
+import logging
+import time
+import tomllib
+from datetime import UTC, datetime
+from pathlib import Path
+
+#=============================================================================
+# Logging
+#=============================================================================
+
+class UTCFormatter(logging.Formatter):
+    """Custom logging formatter that displays timestamps in UTC."""
+
+    def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
+        """Format log timestamps in UTC timezone."""
+        dt = datetime.fromtimestamp(record.created, UTC)
+        return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger()
+handler = logging.StreamHandler()
+formatter = UTCFormatter("[%(asctime)s] %(message)s")
+handler.setFormatter(formatter)
+logger.handlers.clear()
+logger.addHandler(handler)
+
+#=============================================================================
+# File I/O helpers
+#=============================================================================
+
+def open_by_suffix(filename: str | Path, mode: str = "r") -> io.TextIOWrapper:
+    """
+    Open a file using the appropriate method based on its suffix.
+    Args:
+        filename (str | Path): Path to file to open.
+        mode (str): File open mode (default "r").
+    Returns:
+        io.TextIOWrapper: File handle appropriate for the file compression type.
+    """
+    filename_str = str(filename)
+    if filename_str.endswith(".gz"):
+        return gzip.open(filename_str, mode + "t")
+    else:
+        return open(filename_str, mode)
+
+#=============================================================================
+# Core functions
+#=============================================================================
+
+def get_unique_groups(tsv_path: str) -> set[str]:
+    """
+    Extract unique group names from a TSV file.
+    Args:
+        tsv_path (str): Path to gzipped TSV file with 'group' column.
+    Returns:
+        set[str]: Set of unique group names found in the file.
+    """
+    groups: set[str] = set()
+    with open_by_suffix(tsv_path, "r") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        if "group" not in (reader.fieldnames or []):
+            logger.warning(f"'group' column not found in {tsv_path}")
+            return groups
+        for row in reader:
+            groups.add(row["group"])
+    return groups
+
+def get_group_output_patterns(pyproject_path: str, platform: str) -> list[str]:
+    """
+    Extract per-group output patterns from pyproject.toml.
+    Args:
+        pyproject_path (str): Path to pyproject.toml file.
+        platform (str): Platform name ("illumina" or "ont").
+    Returns:
+        list[str]: List of filename patterns containing {GROUP} placeholder.
+    """
+    with open(pyproject_path, "rb") as f:
+        data = tomllib.load(f)
+    key = "expected-outputs-downstream-ont" if platform == "ont" else "expected-outputs-downstream"
+    outputs: list[str] = data.get("tool", {}).get("mgs-workflow", {}).get(key, [])
+    patterns: list[str] = []
+    for output in outputs:
+        if "{GROUP}" in output:
+            filename = output.split("/")[-1]
+            patterns.append(filename)
+    return patterns
+
+def create_empty_outputs(
+    groups: set[str],
+    patterns: list[str],
+    output_dir: str,
+) -> list[str]:
+    """
+    Create empty gzipped files for each group and pattern combination.
+    Args:
+        groups (set[str]): Set of group names to create outputs for.
+        patterns (list[str]): List of filename patterns with {GROUP} placeholder.
+        output_dir (str): Directory to write output files.
+    Returns:
+        list[str]: List of paths to created files.
+    """
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+    created_files: list[str] = []
+    for group in sorted(groups):
+        for pattern in patterns:
+            filename = pattern.replace("{GROUP}", group)
+            filepath = output_path / filename
+            with open_by_suffix(filepath, "w") as f:
+                pass # Empty file
+            created_files.append(str(filepath))
+            logger.info(f"Created: {filepath}")
+    return created_files
+
+#=============================================================================
+# Argument parsing
+#=============================================================================
+
+def parse_args() -> argparse.Namespace:
+    """
+    Parse command line arguments.
+    Returns:
+        argparse.Namespace: Parsed argument namespace.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "empty_groups_tsv",
+        help="Path to TSV file listing empty groups (must have 'group' column)",
+    )
+    parser.add_argument(
+        "pyproject_toml",
+        help="Path to pyproject.toml containing expected outputs",
+    )
+    parser.add_argument(
+        "output_dir",
+        help="Directory to write empty output files",
+    )
+    parser.add_argument(
+        "--platform",
+        choices=["illumina", "ont"],
+        default="illumina",
+        help="Platform to determine which expected outputs to use (default: illumina)",
+    )
+    return parser.parse_args()
+
+#=============================================================================
+# Main
+#=============================================================================
+
+def main() -> None:
+    """Main entry point for the script."""
+    start_time = time.time()
+    logger.info("Initializing script.")
+    args = parse_args()
+    logger.info(f"Arguments: {args}")
+    logger.info("Getting unique groups from empty groups TSV.")
+    groups = get_unique_groups(args.empty_groups_tsv)
+    if not groups:
+        logger.info("No empty groups found, nothing to create")
+        return
+    logger.info(f"Found {len(groups)} empty groups: {sorted(groups)}")
+    patterns = get_group_output_patterns(args.pyproject_toml, args.platform)
+    if not patterns:
+        logger.warning("No per-group output patterns found in pyproject.toml")
+        return
+    logger.info(f"Found {len(patterns)} per-group output patterns: {patterns}")
+    created = create_empty_outputs(groups, patterns, args.output_dir)
+    logger.info(f"Created {len(created)} empty output files")
+    end_time = time.time()
+    logger.info(f"Total time elapsed: {end_time - start_time} seconds")
+    logger.info("Script completed successfully.")
+
+if __name__ == "__main__":
+    main()

--- a/modules/local/createEmptyGroupOutputs/resources/usr/bin/test_create_empty_group_outputs.py
+++ b/modules/local/createEmptyGroupOutputs/resources/usr/bin/test_create_empty_group_outputs.py
@@ -1,0 +1,225 @@
+import gzip
+import pytest
+from create_empty_group_outputs import (
+    open_by_suffix,
+    get_unique_groups,
+    get_group_output_patterns,
+    create_empty_outputs,
+    parse_args,
+)
+
+
+#=============================================================================
+# Test helpers
+#=============================================================================
+
+def write_tsv_by_suffix(path, header, rows):
+    """Write a TSV file using appropriate compression based on suffix."""
+    with open_by_suffix(path, "w") as f:
+        f.write("\t".join(header) + "\n")
+        for row in rows:
+            f.write("\t".join(row) + "\n")
+
+
+def write_pyproject(path, illumina_outputs, ont_outputs):
+    """Write a minimal pyproject.toml with expected outputs."""
+    content = "[tool.mgs-workflow]\n"
+    content += f"expected-outputs-downstream = {illumina_outputs!r}\n"
+    content += f"expected-outputs-downstream-ont = {ont_outputs!r}\n"
+    path.write_text(content)
+
+
+#=============================================================================
+# Tests for open_by_suffix
+#=============================================================================
+
+class TestOpenBySuffix:
+    """Tests for open_by_suffix function."""
+
+    @pytest.mark.parametrize("suffix", [".gz", ".tsv"])
+    def test_writes_and_reads_file(self, tmp_path, suffix):
+        """Test that files can be written and read with correct compression."""
+        filepath = tmp_path / f"test{suffix}"
+        test_content = "hello\nworld"
+
+        with open_by_suffix(filepath, "w") as f:
+            f.write(test_content)
+
+        with open_by_suffix(filepath, "r") as f:
+            assert f.read() == test_content
+
+
+#=============================================================================
+# Tests for get_unique_groups
+#=============================================================================
+
+class TestGetUniqueGroups:
+    """Tests for get_unique_groups function."""
+
+    @pytest.mark.parametrize("rows,expected", [
+        # Multiple samples, multiple groups
+        ([["S1", "g1"], ["S2", "g1"], ["S3", "g2"]], {"g1", "g2"}),
+        # Single group
+        ([["S1", "g1"], ["S2", "g1"]], {"g1"}),
+        # Header only (empty)
+        ([], set()),
+    ])
+    def test_extracts_groups(self, tmp_path, rows, expected):
+        """Test extraction of unique groups from TSV."""
+        tsv_path = tmp_path / "empty_groups.tsv.gz"
+        write_tsv_by_suffix(tsv_path, ["sample", "group"], rows)
+        assert get_unique_groups(str(tsv_path)) == expected
+
+    def test_missing_group_column_returns_empty(self, tmp_path):
+        """Test that missing 'group' column returns empty set."""
+        tsv_path = tmp_path / "empty_groups.tsv.gz"
+        write_tsv_by_suffix(tsv_path, ["sample", "other"], [["S1", "x"]])
+        assert get_unique_groups(str(tsv_path)) == set()
+
+
+#=============================================================================
+# Tests for get_group_output_patterns
+#=============================================================================
+
+class TestGetGroupOutputPatterns:
+    """Tests for get_group_output_patterns function."""
+
+    @pytest.mark.parametrize("platform,illumina,ont,expected", [
+        # Illumina platform extracts illumina patterns
+        (
+            "illumina",
+            ["input/file.csv", "results/{GROUP}_clade.tsv.gz", "results/{GROUP}_dup.tsv.gz"],
+            ["results/{GROUP}_val.tsv.gz"],
+            ["{GROUP}_clade.tsv.gz", "{GROUP}_dup.tsv.gz"],
+        ),
+        # ONT platform extracts ont patterns
+        (
+            "ont",
+            ["results/{GROUP}_clade.tsv.gz"],
+            ["input/file.csv", "results/{GROUP}_val.tsv.gz"],
+            ["{GROUP}_val.tsv.gz"],
+        ),
+        # No {GROUP} patterns returns empty
+        (
+            "illumina",
+            ["input/file.csv", "results/output.tsv"],
+            ["input/file.csv"],
+            [],
+        ),
+    ])
+    def test_extracts_patterns(self, tmp_path, platform, illumina, ont, expected):
+        """Test extraction of patterns containing {GROUP}."""
+        pyproject_path = tmp_path / "pyproject.toml"
+        write_pyproject(pyproject_path, illumina, ont)
+        assert get_group_output_patterns(str(pyproject_path), platform) == expected
+
+
+#=============================================================================
+# Tests for create_empty_outputs
+#=============================================================================
+
+class TestCreateEmptyOutputs:
+    """Tests for create_empty_outputs function."""
+
+    @pytest.mark.parametrize("groups,patterns,expected_count", [
+        # Multiple groups and patterns
+        ({"g1", "g2"}, ["{GROUP}_a.tsv.gz", "{GROUP}_b.tsv.gz"], 4),
+        # Single group, single pattern
+        ({"g1"}, ["{GROUP}_a.tsv.gz"], 1),
+        # Empty groups
+        (set(), ["{GROUP}_a.tsv.gz"], 0),
+        # Empty patterns
+        ({"g1"}, [], 0),
+    ])
+    def test_creates_correct_number_of_files(self, tmp_path, groups, patterns, expected_count):
+        """Test that correct number of files are created."""
+        output_dir = tmp_path / "output"
+        created = create_empty_outputs(groups, patterns, str(output_dir))
+        assert len(created) == expected_count
+
+    def test_files_are_empty_and_valid_gzip(self, tmp_path):
+        """Test that created files are valid empty gzip files."""
+        output_dir = tmp_path / "output"
+        create_empty_outputs({"g1"}, ["{GROUP}_test.tsv.gz"], str(output_dir))
+
+        filepath = output_dir / "g1_test.tsv.gz"
+        assert filepath.exists()
+        with gzip.open(filepath, "rt") as f:
+            assert f.read() == ""
+
+    def test_creates_nested_output_directory(self, tmp_path):
+        """Test that nested output directory is created if needed."""
+        output_dir = tmp_path / "nested" / "output"
+        assert not output_dir.exists()
+        create_empty_outputs({"g1"}, ["{GROUP}_test.tsv.gz"], str(output_dir))
+        assert output_dir.exists()
+
+
+#=============================================================================
+# Tests for parse_args
+#=============================================================================
+
+class TestParseArgs:
+    """Tests for parse_args function."""
+
+    def test_parses_required_args(self, monkeypatch):
+        """Test parsing of required arguments."""
+        monkeypatch.setattr(
+            "sys.argv",
+            ["prog", "empty.tsv.gz", "pyproject.toml", "output/"],
+        )
+        args = parse_args()
+        assert args.empty_groups_tsv == "empty.tsv.gz"
+        assert args.pyproject_toml == "pyproject.toml"
+        assert args.output_dir == "output/"
+        assert args.platform == "illumina"  # default
+
+    @pytest.mark.parametrize("platform", ["illumina", "ont"])
+    def test_parses_platform_option(self, monkeypatch, platform):
+        """Test parsing of --platform option."""
+        monkeypatch.setattr(
+            "sys.argv",
+            ["prog", "empty.tsv.gz", "pyproject.toml", "output/", "--platform", platform],
+        )
+        args = parse_args()
+        assert args.platform == platform
+
+
+#=============================================================================
+# Integration tests
+#=============================================================================
+
+class TestIntegration:
+    """Integration tests for the full workflow."""
+
+    @pytest.mark.parametrize("platform,expected_patterns", [
+        ("illumina", ["{GROUP}_clade.tsv.gz", "{GROUP}_dup.tsv.gz"]),
+        ("ont", ["{GROUP}_val.tsv.gz"]),
+    ])
+    def test_full_workflow(self, tmp_path, platform, expected_patterns):
+        """Test the complete workflow from TSV to output files."""
+        # Create empty groups TSV
+        tsv_path = tmp_path / "empty_groups.tsv.gz"
+        write_tsv_by_suffix(tsv_path, ["sample", "group"], [
+            ["S1", "empty_g1"],
+            ["S2", "empty_g2"],
+        ])
+
+        # Create pyproject.toml
+        pyproject_path = tmp_path / "pyproject.toml"
+        write_pyproject(
+            pyproject_path,
+            illumina_outputs=["input/f.csv", "results/{GROUP}_clade.tsv.gz", "results/{GROUP}_dup.tsv.gz"],
+            ont_outputs=["input/f.csv", "results/{GROUP}_val.tsv.gz"],
+        )
+
+        # Run the workflow
+        groups = get_unique_groups(str(tsv_path))
+        patterns = get_group_output_patterns(str(pyproject_path), platform)
+        output_dir = tmp_path / "output"
+        created = create_empty_outputs(groups, patterns, str(output_dir))
+
+        # Verify
+        assert groups == {"empty_g1", "empty_g2"}
+        assert patterns == expected_patterns
+        assert len(created) == len(groups) * len(patterns)

--- a/modules/local/extractVersions/main.nf
+++ b/modules/local/extractVersions/main.nf
@@ -1,0 +1,17 @@
+// Extract version information from pyproject.toml files
+process EXTRACT_VERSIONS {
+    label "single"
+    label "python"
+    input:
+        path pipeline_pyproject, stageAs: "pipeline_pyproject.toml"
+        path index_pyproject, stageAs: "index_pyproject.toml"
+    output:
+        env PIPELINE_VERSION, emit: pipeline_version
+        env INDEX_VERSION, emit: index_version
+        env PIPELINE_MIN_INDEX, emit: pipeline_min_index
+        env INDEX_MIN_PIPELINE, emit: index_min_pipeline
+    script:
+        """
+        eval \$(extract_versions.py pipeline_pyproject.toml index_pyproject.toml)
+        """
+}

--- a/modules/local/extractVersions/resources/usr/bin/extract_versions.py
+++ b/modules/local/extractVersions/resources/usr/bin/extract_versions.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+
+"""
+Extract version information from pyproject.toml files and output as environment variables.
+"""
+
+import argparse
+from dataclasses import dataclass
+from typing import Optional
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
+
+
+@dataclass
+class VersionInfo:
+    """Version information extracted from a pyproject.toml file."""
+
+    version: str
+    min_index_version: Optional[str] = None
+    min_pipeline_version: Optional[str] = None
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Extract version information from pyproject.toml files"
+    )
+    parser.add_argument(
+        "pipeline_pyproject",
+        help="Path to pipeline pyproject.toml file",
+    )
+    parser.add_argument(
+        "index_pyproject",
+        help="Path to index pyproject.toml file",
+    )
+    return parser.parse_args()
+
+
+def read_toml(path: str) -> dict:
+    """Read and parse a TOML file."""
+    with open(path, "rb") as f:
+        return tomllib.load(f)
+
+
+def get_nested_value(data: dict, *keys, default=None):
+    """
+    Safely get a nested value from a dictionary.
+
+    Args:
+        data: Dictionary to traverse
+        *keys: Keys to traverse in order
+        default: Default value if key path doesn't exist
+
+    Returns:
+        The value at the key path, or default if not found
+    """
+    current = data
+    for key in keys:
+        if not isinstance(current, dict):
+            return default
+        current = current.get(key)
+        if current is None:
+            return default
+    return current
+
+
+def extract_version_info(toml_data: dict) -> VersionInfo:
+    """
+    Extract version information from parsed TOML data.
+
+    Args:
+        toml_data: Parsed TOML data as a dictionary
+
+    Returns:
+        VersionInfo with extracted version data
+    """
+    version = toml_data["project"]["version"]
+    min_index_version = get_nested_value(
+        toml_data, "tool", "mgs-workflow", "pipeline-min-index-version"
+    )
+    min_pipeline_version = get_nested_value(
+        toml_data, "tool", "mgs-workflow", "index-min-pipeline-version"
+    )
+    return VersionInfo(
+        version=version,
+        min_index_version=min_index_version,
+        min_pipeline_version=min_pipeline_version,
+    )
+
+
+def extract_versions(pipeline_path: str, index_path: str) -> None:
+    """
+    Extract version information from pyproject.toml files and print as
+    shell variable assignments.
+
+    Args:
+        pipeline_path: Path to pipeline pyproject.toml
+        index_path: Path to index pyproject.toml
+    """
+    pipeline_info = extract_version_info(read_toml(pipeline_path))
+    index_info = extract_version_info(read_toml(index_path))
+
+    # Output as shell variable assignments
+    print(f"PIPELINE_VERSION={pipeline_info.version}")
+    print(f"INDEX_VERSION={index_info.version}")
+    print(f"PIPELINE_MIN_INDEX={pipeline_info.min_index_version or ''}")
+    print(f"INDEX_MIN_PIPELINE={index_info.min_pipeline_version or ''}")
+
+
+def main() -> None:
+    """Main entry point."""
+    args = parse_args()
+    extract_versions(args.pipeline_pyproject, args.index_pyproject)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/local/extractVersions/resources/usr/bin/test_extract_versions.py
+++ b/modules/local/extractVersions/resources/usr/bin/test_extract_versions.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+
+import pytest
+
+import extract_versions
+from extract_versions import VersionInfo, get_nested_value, extract_version_info
+
+
+class TestGetNestedValue:
+    """Test the get_nested_value function."""
+
+    @pytest.mark.parametrize(
+        "data,keys,default,expected",
+        [
+            ({"a": {"b": {"c": "value"}}}, ("a", "b", "c"), None, "value"),
+            ({"a": {"b": "value"}}, ("a", "c"), None, None),
+            ({"a": {"b": "value"}}, ("a", "c"), "custom", "custom"),
+            ({"a": "not_a_dict"}, ("a", "b"), None, None),
+            ({"a": "value"}, (), None, {"a": "value"}),
+            ({"key": "value"}, ("key",), None, "value"),
+        ],
+        ids=[
+            "nested_value",
+            "missing_key",
+            "custom_default",
+            "non_dict_intermediate",
+            "no_keys",
+            "single_key",
+        ],
+    )
+    def test_get_nested_value(self, data, keys, default, expected):
+        """Test retrieving nested values with various inputs."""
+        assert get_nested_value(data, *keys, default=default) == expected
+
+
+class TestExtractVersionInfo:
+    """Test the extract_version_info function."""
+
+    @pytest.mark.parametrize(
+        "toml_data,expected",
+        [
+            (
+                {"project": {"version": "1.2.3"}},
+                VersionInfo("1.2.3", None, None),
+            ),
+            (
+                {
+                    "project": {"version": "2.0.0"},
+                    "tool": {
+                        "mgs-workflow": {
+                            "pipeline-min-index-version": "1.0.0",
+                            "index-min-pipeline-version": "1.5.0",
+                        }
+                    },
+                },
+                VersionInfo("2.0.0", "1.0.0", "1.5.0"),
+            ),
+            (
+                {
+                    "project": {"version": "1.0.0"},
+                    "tool": {"other-tool": {"key": "value"}},
+                },
+                VersionInfo("1.0.0", None, None),
+            ),
+            (
+                {
+                    "project": {"version": "1.0.0"},
+                    "tool": {"mgs-workflow": {"pipeline-min-index-version": "0.5.0"}},
+                },
+                VersionInfo("1.0.0", "0.5.0", None),
+            ),
+            (
+                {"project": {"version": "1.0.0-alpha"}},
+                VersionInfo("1.0.0-alpha", None, None),
+            ),
+        ],
+        ids=[
+            "minimal",
+            "full",
+            "missing_mgs_workflow",
+            "partial_min_versions",
+            "prerelease_tag",
+        ],
+    )
+    def test_extract_version_info(self, toml_data, expected):
+        """Test extracting version info from various TOML structures."""
+        assert extract_version_info(toml_data) == expected
+
+    @pytest.mark.parametrize(
+        "toml_data",
+        [
+            {"project": {}},
+            {"tool": {"mgs-workflow": {}}},
+        ],
+        ids=["missing_version", "missing_project"],
+    )
+    def test_extract_version_info_raises(self, toml_data):
+        """Test that missing required fields raise KeyError."""
+        with pytest.raises(KeyError):
+            extract_version_info(toml_data)
+
+
+class TestExtractVersionsIntegration:
+    """Integration tests for the full extract_versions workflow."""
+
+    @pytest.mark.parametrize(
+        "pipeline_toml,index_toml,expected_lines",
+        [
+            (
+                '[project]\nversion = "2.1.0"\n[tool.mgs-workflow]\npipeline-min-index-version = "1.0.0"',
+                '[project]\nversion = "1.5.0"\n[tool.mgs-workflow]\nindex-min-pipeline-version = "2.0.0"',
+                ["PIPELINE_VERSION=2.1.0", "INDEX_VERSION=1.5.0", "PIPELINE_MIN_INDEX=1.0.0", "INDEX_MIN_PIPELINE=2.0.0"],
+            ),
+            (
+                '[project]\nversion = "1.0.0"',
+                '[project]\nversion = "0.9.0"',
+                ["PIPELINE_VERSION=1.0.0", "INDEX_VERSION=0.9.0", "PIPELINE_MIN_INDEX=", "INDEX_MIN_PIPELINE="],
+            ),
+        ],
+        ids=["with_optional_fields", "without_optional_fields"],
+    )
+    def test_extract_versions_output(
+        self, temp_file_helper, capsys, pipeline_toml, index_toml, expected_lines
+    ):
+        """Test extracting versions from TOML files."""
+        pipeline_file = temp_file_helper.create_file("pipeline.toml", pipeline_toml)
+        index_file = temp_file_helper.create_file("index.toml", index_toml)
+
+        extract_versions.extract_versions(pipeline_file, index_file)
+
+        captured = capsys.readouterr()
+        lines = captured.out.strip().split("\n")
+        for expected in expected_lines:
+            assert expected in lines

--- a/modules/local/partitionTsv/main.nf
+++ b/modules/local/partitionTsv/main.nf
@@ -6,7 +6,7 @@ process PARTITION_TSV {
         tuple val(sample), path(tsv)
         val(column)
     output:
-        tuple val(sample), path("partition_*_${tsv}"), emit: output
+        tuple val(sample), path("partition_*_${tsv}"), emit: output, optional: true
         tuple val(sample), path("input_${tsv}"), emit: input
     shell:
         '''

--- a/modules/local/partitionTsv/resources/usr/bin/partition_tsv.py
+++ b/modules/local/partitionTsv/resources/usr/bin/partition_tsv.py
@@ -53,8 +53,7 @@ def partition(input_path, column):
         # Read first line of data and initialize first output file
         fields = read_line(inf)
         if fields is None: # Empty apart from headers
-            outf = initialize_output_file(input_path, "empty", headers)
-            outf.close()
+            print_log("Input file has no data rows, skipping partition.")
             return
         index = fields[column_index]
         file_index = index

--- a/modules/local/partitionTsv/resources/usr/bin/test_partition_tsv.py
+++ b/modules/local/partitionTsv/resources/usr/bin/test_partition_tsv.py
@@ -44,7 +44,7 @@ class TestPartitionTsv:
             os.chdir(original_cwd)
 
     def test_header_only_input(self, tsv_factory, tmp_path):
-        """Test that header-only input produces single empty output file."""
+        """Test that header-only input produces no output files."""
         input_content = "x\ty\tz\n"
         input_file = tsv_factory.create_plain("input.tsv", input_content)
 
@@ -56,15 +56,9 @@ class TestPartitionTsv:
         try:
             partition_tsv.partition(os.path.basename(input_file), "x")
 
-            # Check that exactly one partition file was created
+            # Check that no partition files were created
             partition_files = glob.glob("partition_*_input.tsv")
-            assert len(partition_files) == 1
-            assert partition_files[0] == "partition_empty_input.tsv"
-
-            # Check that it contains only the header
-            with open(partition_files[0], "r") as f:
-                content = f.read()
-            assert content == input_content
+            assert len(partition_files) == 0
         finally:
             os.chdir(original_cwd)
 

--- a/modules/local/validateGrouping/main.nf
+++ b/modules/local/validateGrouping/main.nf
@@ -6,15 +6,16 @@ process VALIDATE_GROUPING {
         tuple val(label), path(input_file), path(groups_file)
     output:
         tuple val(label), path(input_file), path("validated_${groups_file}"), emit: output
-        tuple val(label), path("zero_vv_${label}_${input_file}"), emit: zero_vv_log
+        tuple val(label), path("partial_group_${label}.tsv"), emit: partial_group_log
+        tuple val(label), path("empty_group_${label}.tsv"), emit: empty_group_log
         tuple val(label), path("input_${input_file}"), path("input_${groups_file}"), emit: input
-    shell:
-        '''
-        out_validated=validated_!{groups_file}
-        out_zero_vv=zero_vv_!{label}_!{input_file}
-        validate_grouping.py !{input_file} !{groups_file} ${out_validated} ${out_zero_vv}
-        # Link input files for testing
-        ln -s !{input_file} input_!{input_file}
-        ln -s !{groups_file} input_!{groups_file}
-        '''
+    script:
+        def out_validated = "validated_${groups_file}"
+        def out_partial = "partial_group_${label}.tsv"
+        def out_empty = "empty_group_${label}.tsv"
+        """
+        validate_grouping.py ${input_file} ${groups_file} ${out_validated} ${out_partial} ${out_empty}
+        ln -s ${input_file} input_${input_file}
+        ln -s ${groups_file} input_${groups_file}
+        """
 }

--- a/modules/local/validateGrouping/resources/usr/bin/validate_grouping.py
+++ b/modules/local/validateGrouping/resources/usr/bin/validate_grouping.py
@@ -1,10 +1,15 @@
 #!/usr/bin/env python
 
 """
-Write a new grouping file with only samples observed in the hits file, and write a list of samples without viral hits.
+Write a new grouping file with only samples observed in the hits file, and categorize samples without viral hits.
+
+Samples without viral hits are split into two categories:
+1. Samples whose group still has other samples with hits (group has partial data)
+2. Samples whose entire group has no hits (empty group)
 
 Usage:
-    validate_grouping.py virus_hits.tsv grouping.tsv validated_grouping.tsv.gz samples_without_vv_hits.tsv
+    validate_grouping.py virus_hits.tsv grouping.tsv validated_grouping.tsv.gz \\
+        samples_partial_group.tsv samples_empty_group.tsv
 """
 
 #=======================================================================
@@ -73,19 +78,21 @@ def open_by_suffix(filename: str, mode: str = "r") -> TextIO:
 
 def parse_args() -> argparse.Namespace:
     """Parse command-line arguments.
-    
+
     Returns:
         argparse.Namespace: Parsed command-line arguments containing:
             - virus_hits_file: Path to virus hits TSV file
             - grouping_file: Path to grouping TSV file
             - validated_output: Path to validated grouping output file
-            - samples_without_vv_hits: Path to samples without viral hits log file
+            - samples_partial_group: Path to TSV listing empty samples with non-empty group-mates
+            - samples_empty_group: Path to TSV listing empty samples with empty group-mates only
     """
     parser = argparse.ArgumentParser(description="Validate grouping file against virus hits file")
     parser.add_argument("virus_hits_file", help="Path to virus hits TSV file (must contain a 'sample' column)")
     parser.add_argument("grouping_file", help="Path to grouping TSV file (columns: group	sample)")
     parser.add_argument("validated_output", help="Path to validated grouping output file (.tsv or .tsv.gz)")
-    parser.add_argument("samples_without_vv_hits", help="Path to samples-without-viral-hits output (.tsv or .tsv.gz)")
+    parser.add_argument("samples_partial_group", help="Path to TSV listing empty samples with non-empty group-mates")
+    parser.add_argument("samples_empty_group", help="Path to TSV listing empty samples with empty group-mates only")
     return parser.parse_args()
 
 #=======================================================================
@@ -170,45 +177,79 @@ def _write_outputs(
     sample_to_group: dict[str, str],
     seen_in_hits: set[str],
     out_new_grouping_path: str,
-    out_no_vv_samples_path: str,
+    out_partial_group_path: str,
+    out_empty_group_path: str,
 ) -> None:
-    """Write samples with no viral hits (grouping - hits) and new grouping (intersection).
-    
+    """Write validated grouping and categorize samples without viral hits.
+
+    Samples without viral hits are split into two categories:
+    1. Samples whose group has at least one sample with hits (partial group)
+    2. Samples whose entire group has no hits (empty group)
+
     Args:
         sample_to_group (dict[str, str]): Mapping from sample ID to group ID
         seen_in_hits (set[str]): Set of sample IDs observed in virus hits
         out_new_grouping_path (str): Path to write validated grouping file
-        out_no_vv_samples_path (str): Path to write samples with no viral hits
+        out_partial_group_path (str): Path for empty samples with non-empty group-mates
+        out_empty_group_path (str): Path for empty samples with empty group-mates only
     """
     grouping_samples = set(sample_to_group.keys())
-    samples_no_viral_hits = sorted(grouping_samples - seen_in_hits)
-    with open_by_suffix(out_no_vv_samples_path, 'w') as out_unused:
-        out_unused.write("sample\n")
-        for s in samples_no_viral_hits:
-            out_unused.write(f"{s}\n")
-    logger.info(f"Wrote {len(samples_no_viral_hits)} samples with no viral hits to {out_no_vv_samples_path}")
-    samples_with_viral_hits = sorted(grouping_samples & seen_in_hits)
+    samples_with_viral_hits = grouping_samples & seen_in_hits
+    samples_no_viral_hits = grouping_samples - seen_in_hits
+
+    # Determine which groups have at least one sample with viral hits
+    groups_with_hits: set[str] = set()
+    for sample in samples_with_viral_hits:
+        groups_with_hits.add(sample_to_group[sample])
+
+    # Split samples without VV into two categories
+    partial_group_samples: list[str] = []  # Empty samples with non-empty group-mates
+    empty_group_samples: list[str] = []    # Empty samples with empty group-mates only
+    for sample in sorted(samples_no_viral_hits):
+        group = sample_to_group[sample]
+        if group in groups_with_hits:
+            partial_group_samples.append(sample)
+        else:
+            empty_group_samples.append(sample)
+
+    # Write validated grouping (samples with viral hits)
     with open_by_suffix(out_new_grouping_path, 'w') as out_group:
         out_group.write("group\tsample\n")
-        for s in samples_with_viral_hits:
+        for s in sorted(samples_with_viral_hits):
             out_group.write(f"{sample_to_group[s]}\t{s}\n")
     logger.info(f"Wrote validated grouping with {len(samples_with_viral_hits)} samples to {out_new_grouping_path}")
+
+    # Write empty samples with non-empty group-mates
+    with open_by_suffix(out_partial_group_path, 'w') as out_partial:
+        out_partial.write("sample\tgroup\n")
+        for s in partial_group_samples:
+            out_partial.write(f"{s}\t{sample_to_group[s]}\n")
+    logger.info(f"Wrote {len(partial_group_samples)} empty samples with non-empty group-mates to {out_partial_group_path}")
+
+    # Write empty samples with empty group-mates only
+    with open_by_suffix(out_empty_group_path, 'w') as out_empty:
+        out_empty.write("sample\tgroup\n")
+        for s in empty_group_samples:
+            out_empty.write(f"{s}\t{sample_to_group[s]}\n")
+    logger.info(f"Wrote {len(empty_group_samples)} empty samples with empty group-mates only to {out_empty_group_path}")
 
 
 def validate_grouping(
     grouping_path: str,
     virus_hits_path: str,
-    out_no_vv_samples_path: str,
     out_new_grouping_path: str,
+    out_partial_group_path: str,
+    out_empty_group_path: str,
 ) -> None:
     """Update grouping file to only include samples observed in the viral hits file.
-    
+
     Args:
         grouping_path (str): Path to the grouping TSV file
         virus_hits_path (str): Path to the virus hits TSV file
-        out_no_vv_samples_path (str): Path to write samples with no viral hits
         out_new_grouping_path (str): Path to write validated grouping file
-    
+        out_partial_group_path (str): Path for empty samples with non-empty group-mates
+        out_empty_group_path (str): Path for empty samples with empty group-mates only
+
     Raises:
         ValueError: If virus hits contain samples missing from grouping
     """
@@ -216,8 +257,14 @@ def validate_grouping(
     sample_to_group = _read_grouping(grouping_path)
     # 2) Stream hits and validate that samples are subset of grouping
     seen_in_hits = _stream_hits(virus_hits_path, sample_to_group)
-    # 3) Write samples with no viral hits to out_no_vv_samples_path and new grouping to out_new_grouping_path
-    _write_outputs(sample_to_group, seen_in_hits, out_new_grouping_path, out_no_vv_samples_path)
+    # 3) Write validated grouping and categorize samples without viral hits
+    _write_outputs(
+        sample_to_group,
+        seen_in_hits,
+        out_new_grouping_path,
+        out_partial_group_path,
+        out_empty_group_path,
+    )
 
 
 #=======================================================================
@@ -236,8 +283,9 @@ def main() -> None:
         validate_grouping(
             grouping_path=args.grouping_file,
             virus_hits_path=args.virus_hits_file,
-            out_no_vv_samples_path=args.samples_without_vv_hits,
             out_new_grouping_path=args.validated_output,
+            out_partial_group_path=args.samples_partial_group,
+            out_empty_group_path=args.samples_empty_group,
         )
     except ValueError as e:
         logger.error(str(e))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ version = "3.0.1.8-dev"
 requires-python = ">=3.12"
 dependencies = [
     "biopython>=1.85",
+    "boto3",
     "mypy>=1.18.1",
     # Needed until https://github.com/securebio/nao-dedup/pull/12 has been
     # merged and we've updated post-processing/nao-dedup/ to depend on the

--- a/subworkflows/local/checkVersionCompatibility/main.nf
+++ b/subworkflows/local/checkVersionCompatibility/main.nf
@@ -5,55 +5,8 @@
 /* Takes in pipeline and index pyproject.toml paths and raises an error
 if their versions are incompatible. */
 
-import groovy.toml.TomlSlurper
-
-/**********************
-| AUXILIARY FUNCTIONS |
-**********************/
-
-def readVersions(Object pyprojectPath) {
-    /* Read version information from a pyproject.toml file. */
-    def toml = new TomlSlurper().parse(new File(pyprojectPath.toString()))
-    return [
-        pipeline: toml.project.version,
-        indexMinPipeline: toml.tool?.'mgs-workflow'?.'index-min-pipeline-version',
-        pipelineMinIndex: toml.tool?.'mgs-workflow'?.'pipeline-min-index-version'
-    ]
-}
-
-def isVersionLess(version1, version2) {
-    /* Compare two semantic versions and return a boolean stating
-    whether the first is less (i.e. older) than the second. */
-    // Remove terminal tags (anything after a hyphen)
-    def cleanVersion1 = version1.tokenize("-")[0]
-    def cleanVersion2 = version2.tokenize("-")[0]
-    // Split components by periods
-    def v1Components = cleanVersion1.tokenize(".")
-    def v2Components = cleanVersion2.tokenize(".")
-    // Convert to integers (and raise error if unable)
-    def v1IntComponents
-    def v2IntComponents
-    try {
-        v1IntComponents = v1Components.collect{ it.toInteger() }
-    } catch (NumberFormatException _e) {
-        def msg1 = "Invalid version format: version 1 (${version1}) contains non-integer components."
-        throw new IllegalArgumentException(msg1)
-    }
-    try {
-        v2IntComponents = v2Components.collect{ it.toInteger() }
-    } catch (NumberFormatException _e) {
-        def msg2 = "Invalid version format: version 2 (${version2}) contains non-integer components."
-        throw new IllegalArgumentException(msg2)
-    }
-    // Get the longest version length and pad shorter version with zeros
-    def maxLength = Math.max(v1IntComponents.size(), v2IntComponents.size())
-    def paddedV1 = v1IntComponents + [0] * (maxLength - v1IntComponents.size())
-    def paddedV2 = v2IntComponents + [0] * (maxLength - v2IntComponents.size())
-
-    // Find first differing component
-    def diff = (0..<maxLength).find { i -> paddedV1[i] != paddedV2[i] }
-    return diff != null ? paddedV1[diff] < paddedV2[diff] : false
-}
+include { EXTRACT_VERSIONS } from "../../../modules/local/extractVersions/main.nf"
+include { CHECK_VERSIONS } from "../../../modules/local/checkVersions/main.nf"
 
 /***********
 | WORKFLOW |
@@ -64,22 +17,15 @@ workflow CHECK_VERSION_COMPATIBILITY {
         pipeline_pyproject_path  // Local pyproject.toml
         index_pyproject_path     // Index's pyproject.toml from S3
     main:
-        // Read version info from pyproject.toml files
-        def pipelineVersions = readVersions(pipeline_pyproject_path)
-        def indexVersions = readVersions(index_pyproject_path)
+        // Extract version info from pyproject.toml files using a process
+        // (handles S3 paths correctly by staging files in the container)
+        EXTRACT_VERSIONS(pipeline_pyproject_path, index_pyproject_path)
 
-        def pipeline_version = pipelineVersions.pipeline
-        def index_version = indexVersions.pipeline
-        def pipeline_min_index_version = pipelineVersions.pipelineMinIndex
-        def index_min_pipeline_version = indexVersions.indexMinPipeline
-
-        // Check version compatibilities
-        if (isVersionLess(pipeline_version, index_min_pipeline_version)) {
-            def msg_a = "Pipeline version is older than index minimum: ${pipeline_version} < ${index_min_pipeline_version}"
-            throw new Exception(msg_a)
-        }
-        if (isVersionLess(index_version, pipeline_min_index_version)) {
-            def msg_b = "Index version is older than pipeline minimum: ${index_version} < ${pipeline_min_index_version}"
-            throw new Exception(msg_b)
-        }
+        // Check version compatibility
+        CHECK_VERSIONS(
+            EXTRACT_VERSIONS.out.pipeline_version,
+            EXTRACT_VERSIONS.out.index_version,
+            EXTRACT_VERSIONS.out.pipeline_min_index,
+            EXTRACT_VERSIONS.out.index_min_pipeline
+        )
 }

--- a/test-data/downstream/input_file_empty_only.csv
+++ b/test-data/downstream/input_file_empty_only.csv
@@ -1,0 +1,2 @@
+label,hits_tsv,groups_tsv
+empty_test,s3://nao-testing/tiny-test/empty/virus_hits_empty.tsv.gz,s3://nao-testing/tiny-test/empty/sample_groups_empty.tsv

--- a/test-data/extractVersions/pyproject-index.toml
+++ b/test-data/extractVersions/pyproject-index.toml
@@ -1,0 +1,1 @@
+../tiny-index/output/logging/pyproject.toml

--- a/test-data/validateGrouping/grouping_mixed.tsv
+++ b/test-data/validateGrouping/grouping_mixed.tsv
@@ -1,0 +1,6 @@
+group	sample
+g1	S1
+g1	S2
+g2	S3
+g2	S4
+g3	S5

--- a/test-data/validateGrouping/virus_hits_partial.tsv
+++ b/test-data/validateGrouping/virus_hits_partial.tsv
@@ -1,0 +1,3 @@
+sample	other_col
+S1	data1
+S5	data5

--- a/tests/modules/local/checkVersions/main.nf.test
+++ b/tests/modules/local/checkVersions/main.nf.test
@@ -1,0 +1,75 @@
+nextflow_process {
+
+    name "Test CHECK_VERSIONS"
+    script "modules/local/checkVersions/main.nf"
+    process "CHECK_VERSIONS"
+    config "tests/configs/run.config"
+    tag "check_versions"
+    tag "module"
+
+    test("Should pass when versions are compatible") {
+        when {
+            process {
+                """
+                input[0] = "2.0.0"  // pipeline_version
+                input[1] = "1.5.0"  // index_version
+                input[2] = "1.0.0"  // pipeline_min_index
+                input[3] = "1.5.0"  // index_min_pipeline
+                """
+            }
+        }
+        then {
+            assert process.success
+        }
+    }
+
+    test("Should pass when min versions are empty") {
+        when {
+            process {
+                """
+                input[0] = "2.0.0"  // pipeline_version
+                input[1] = "1.5.0"  // index_version
+                input[2] = ""       // pipeline_min_index (empty)
+                input[3] = ""       // index_min_pipeline (empty)
+                """
+            }
+        }
+        then {
+            assert process.success
+        }
+    }
+
+    test("Should fail when pipeline version is too old") {
+        when {
+            process {
+                """
+                input[0] = "1.0.0"  // pipeline_version (too old)
+                input[1] = "1.5.0"  // index_version
+                input[2] = "1.0.0"  // pipeline_min_index
+                input[3] = "2.0.0"  // index_min_pipeline (requires 2.0.0)
+                """
+            }
+        }
+        then {
+            assert process.failed
+            assert process.errorReport.contains("Pipeline version is older than index minimum")
+        }
+    }
+
+    test("Should fail when index version is too old") {
+        when {
+            process {
+                """
+                input[0] = "2.0.0"  // pipeline_version
+                input[1] = "0.5.0"  // index_version (too old)
+                input[2] = "1.0.0"  // pipeline_min_index (requires 1.0.0)
+                input[3] = "1.0.0"  // index_min_pipeline
+                """
+            }
+        }
+        then {
+            assert process.failed
+            assert process.errorReport.contains("Index version is older than pipeline minimum")
+        }
+    }
+}

--- a/tests/modules/local/extractVersions/main.nf.test
+++ b/tests/modules/local/extractVersions/main.nf.test
@@ -1,0 +1,27 @@
+nextflow_process {
+
+    name "Test EXTRACT_VERSIONS"
+    script "modules/local/extractVersions/main.nf"
+    process "EXTRACT_VERSIONS"
+    config "tests/configs/run.config"
+    tag "extract_versions"
+    tag "module"
+
+    test("Should extract versions from pyproject.toml files") {
+        when {
+            process {
+                """
+                input[0] = file("${projectDir}/pyproject.toml")
+                input[1] = file("${projectDir}/test-data/extractVersions/pyproject-index.toml")
+                """
+            }
+        }
+        then {
+            assert process.success
+            assert process.out.pipeline_version
+            assert process.out.index_version
+            assert process.out.pipeline_min_index
+            assert process.out.index_min_pipeline
+        }
+    }
+}

--- a/tests/modules/local/validateGrouping/main.nf.test
+++ b/tests/modules/local/validateGrouping/main.nf.test
@@ -1,0 +1,42 @@
+nextflow_process {
+
+    name "Test process VALIDATE_GROUPING"
+    script "modules/local/validateGrouping/main.nf"
+    process "VALIDATE_GROUPING"
+    config "tests/configs/run.config"
+    tag "module"
+    tag "validate_grouping"
+
+    test("Categorizes samples into validated, partial, and empty groups") {
+        tag "expect_success"
+        when {
+            params {}
+            process {
+                '''
+                // g1: S1 has hits, S2 no hits (partial)
+                // g2: S3 no hits, S4 no hits (empty)
+                // g3: S5 has hits (complete)
+                input[0] = Channel.of(["test_label",
+                    file("${projectDir}/test-data/validateGrouping/virus_hits_partial.tsv"),
+                    file("${projectDir}/test-data/validateGrouping/grouping_mixed.tsv")])
+                '''
+            }
+        }
+        then {
+            assert process.success
+
+            // Check validated output - should have S1 and S5
+            def validated = path(process.out.output[0][2]).csv(sep: "\t")
+            assert validated.columns["sample"] as Set == ["S1", "S5"] as Set
+
+            // Check partial group log - S2 should be here (g1 has S1 with hits)
+            def partial = path(process.out.partial_group_log[0][1]).csv(sep: "\t")
+            assert partial.columns["sample"] as Set == ["S2"] as Set
+
+            // Check empty group log - S3 and S4 should be here (g2 has no hits)
+            def empty_log = path(process.out.empty_group_log[0][1]).csv(sep: "\t")
+            assert empty_log.columns["sample"] as Set == ["S3", "S4"] as Set
+        }
+    }
+
+}

--- a/tests/subworkflows/local/checkVersionCompatibility/main.nf.test
+++ b/tests/subworkflows/local/checkVersionCompatibility/main.nf.test
@@ -55,11 +55,11 @@ nextflow_workflow {
             }
         }
         then {
-            // Should run without errors
             assert workflow.failed
-            assert workflow.stdout.any{ it.contains("Index version is older than pipeline minimum") }
-            assert !workflow.stdout.any{ it.contains("Pipeline version is older than index minimum") }
-            assert !workflow.stdout.any{ it.contains("Invalid version format") }
+            // Check for actual error (with version numbers), not source code (with ${variable})
+            assert workflow.stdout.any{ it.contains("Index version is older than pipeline minimum") && !it.contains('${') }
+            assert !workflow.stdout.any{ it.contains("Pipeline version is older than index minimum") && !it.contains('${') }
+            assert !workflow.stdout.any{ it.contains("Invalid version format") && !it.contains('${') }
         }
     }
 
@@ -76,11 +76,11 @@ nextflow_workflow {
             }
         }
         then {
-            // Should run without errors
             assert workflow.failed
-            assert !workflow.stdout.any{ it.contains("Index version is older than pipeline minimum") }
-            assert workflow.stdout.any{ it.contains("Pipeline version is older than index minimum") }
-            assert !workflow.stdout.any{ it.contains("Invalid version format") }
+            // Check for actual error (with version numbers), not source code (with ${variable})
+            assert !workflow.stdout.any{ it.contains("Index version is older than pipeline minimum") && !it.contains('${') }
+            assert workflow.stdout.any{ it.contains("Pipeline version is older than index minimum") && !it.contains('${') }
+            assert !workflow.stdout.any{ it.contains("Invalid version format") && !it.contains('${') }
         }
     }
 
@@ -97,10 +97,10 @@ nextflow_workflow {
             }
         }
         then {
-            // Should run without errors
             assert workflow.failed
-            assert !workflow.stdout.any{ it.contains("Index version is older than pipeline minimum") }
-            assert !workflow.stdout.any{ it.contains("Pipeline version is older than index minimum") }
+            // Check for actual error, not source code
+            assert !workflow.stdout.any{ it.contains("Index version is older than pipeline minimum") && !it.contains('${') }
+            assert !workflow.stdout.any{ it.contains("Pipeline version is older than index minimum") && !it.contains('${') }
             assert workflow.stdout.any{ it.contains("Invalid version format") }
         }
     }

--- a/tests/subworkflows/local/prepareGroupTsvs/main.nf.test
+++ b/tests/subworkflows/local/prepareGroupTsvs/main.nf.test
@@ -84,6 +84,12 @@ nextflow_workflow {
                     assert output_tabs[i].columnNames == tab.columnNames
                 }
             }
+            // Partial group logs should have sample and group columns
+            def partial_log_cols = path(workflow.out.partial_group_logs[0][1]).linesGzip[0].split("\t") as List
+            assert partial_log_cols == ["sample", "group"]
+            // Empty group logs should have sample and group columns
+            def empty_log_cols = path(workflow.out.empty_group_logs[0][1]).linesGzip[0].split("\t") as List
+            assert empty_log_cols == ["sample", "group"]
         }
     }
 }

--- a/tests/workflows/downstream.nf.test
+++ b/tests/workflows/downstream.nf.test
@@ -32,4 +32,28 @@ nextflow_pipeline {
             ).match("downstream_ont_output")
         }
     }
+
+    test("Should create empty output files for groups with no hits") {
+        tag "downstream_empty_groups"
+        tag "empty_input"
+        when {
+            params {
+                input_file = "${projectDir}/test-data/downstream/input_file_empty_only.csv"
+            }
+        }
+        then {
+            assert workflow.success
+            // Verify exactly the expected empty output files are created
+            def resultsDir = path("${launchDir}/output/results_downstream")
+            def actualFiles = resultsDir.list().collect { it.getFileName().toString() }.sort()
+            // Dynamically extract expected patterns from pyproject.toml (non-ONT section only)
+            def pyprojectText = path("${projectDir}/pyproject.toml").text
+            def sectionMatch = (pyprojectText =~ /expected-outputs-downstream = \[([\s\S]*?)\]/)
+            def sectionText = sectionMatch[0][1]
+            def expectedFiles = (sectionText =~ /"results_downstream\/([^"]*\{GROUP\}[^"]*)"/)
+                .collect { it[1].replace("{GROUP}", "empty_group") }
+                .sort()
+            assert actualFiles == expectedFiles : "Expected files ${expectedFiles} but got ${actualFiles}"
+        }
+    }
 }

--- a/workflows/downstream.nf
+++ b/workflows/downstream.nf
@@ -43,7 +43,7 @@ workflow DOWNSTREAM {
             viral_hits_ch = MARK_VIRAL_DUPLICATES.out.dup.map { label, tab, _stats -> [label, tab] }
             dup_output_ch = MARK_VIRAL_DUPLICATES.out.dup
             // Generate clade counts
-            clade_counts_ch = COUNT_READS_PER_CLADE(viral_hits_ch, viral_db)
+            clade_counts_ch = COUNT_READS_PER_CLADE(viral_hits_ch, viral_db).output
         }
         // Validate taxonomic assignments
         def validation_params = params.collectEntries { k, v -> [k, v] }

--- a/workflows/downstream.nf
+++ b/workflows/downstream.nf
@@ -55,8 +55,7 @@ workflow DOWNSTREAM {
         time_ch = start_time_str.map { it + "\n" }.collectFile(name: "time.txt")
         pipeline_pyproject_path = file("${projectDir}/pyproject.toml")
         pyproject_ch = COPY_PYPROJECT(Channel.fromPath(pipeline_pyproject_path), "pyproject.toml")
-        input_newpath = file(params.input_file).getFileName().toString()
-        input_file_ch = COPY_INPUT(Channel.fromPath(params.input_file), input_newpath)
+        input_file_ch = COPY_INPUT(Channel.fromPath(params.input_file), "input_file.csv")
 
     emit:
        input_downstream = params_ch.mix(input_file_ch)


### PR DESCRIPTION
A major source of potential bugs in our infrastructure is a mismatch between the outputs `nao-mgs-workflow` produces, and those expected by other parts of our codebase. This is controlled via the `expected-outputs-*` elements in `pyproject.toml`. This PR adds verification that the results of our CI checks match those expected outputs.