### PR TITLE
Reduce maxRetries to 1 and add job queue closure documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v3.1.0.1-dev
+# v3.1.0.1
 
 - Reduced `maxRetries` from 3 to 2 in `standard` and `batch` profiles for spot-to-on-demand fallback (#662)
 - Add `CLAUDE.md` with guidelines for Claude Code: GitHub interaction policies, PR workflows, testing, versioning, and changelog updates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v3.1.0.1
 
-- Reduced `maxRetries` from 3 to 2 in `standard` and `batch` profiles for spot-to-on-demand fallback (#662)
+- Reduced `maxRetries` from 3 to 1 in `standard` and `batch` profiles for spot-to-on-demand fallback (#662)
+- Added docs on using a Groovy closure for spot-to-on-demand queue fallback (#662)
 - Add `CLAUDE.md` with guidelines for Claude Code: GitHub interaction policies, PR workflows, testing, versioning, and changelog updates.
 - Extract testing documentation from `docs/developer.md` into standalone `docs/testing.md`; add snapshot safety warning.
 - Add CHANGELOG formatting guidelines to `docs/versioning.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v3.1.0.1-dev
 
+- Reduced `maxRetries` from 3 to 2 in `standard` and `batch` profiles for spot-to-on-demand fallback (#662)
 - Add `CLAUDE.md` with guidelines for Claude Code: GitHub interaction policies, PR workflows, testing, versioning, and changelog updates.
 - Extract testing documentation from `docs/developer.md` into standalone `docs/testing.md`; add snapshot safety warning.
 - Add CHANGELOG formatting guidelines to `docs/versioning.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v3.1.0.1
+# v3.1.0.1-dev
 
 - Reduced `maxRetries` from 3 to 1 in `standard` and `batch` profiles for spot-to-on-demand fallback (#662)
 - Added docs on using a Groovy closure for spot-to-on-demand queue fallback (#662)

--- a/configs/profiles.config
+++ b/configs/profiles.config
@@ -25,7 +25,6 @@ profiles {
         process.executor = "awsbatch"
         process.errorStrategy = "retry"
         process.maxRetries = 2
-        aws.batch.maxSpotAttempts = 0 // Disable AWS Batch internal spot retries; Nextflow handles retries via errorStrategy
         aws.batch.volumes = ['/scratch:/scratch'] // Shared directory for large reference files
     }
     batch { // Run on AWS Batch
@@ -34,7 +33,6 @@ profiles {
         process.executor = "awsbatch"
         process.errorStrategy = "retry"
         process.maxRetries = 2
-        aws.batch.maxSpotAttempts = 0 // Disable AWS Batch internal spot retries; Nextflow handles retries via errorStrategy
         aws.batch.volumes = ['/scratch:/scratch'] // Shared directory for large reference files
     }
     ec2_local { // Run on EC2 instance with a local working directory

--- a/configs/profiles.config
+++ b/configs/profiles.config
@@ -24,7 +24,7 @@ profiles {
         fusion.exportStorageCredentials = true
         process.executor = "awsbatch"
         process.errorStrategy = "retry"
-        process.maxRetries = 2
+        process.maxRetries = 1
         aws.batch.volumes = ['/scratch:/scratch'] // Shared directory for large reference files
     }
     batch { // Run on AWS Batch
@@ -32,7 +32,7 @@ profiles {
         fusion.exportStorageCredentials = true
         process.executor = "awsbatch"
         process.errorStrategy = "retry"
-        process.maxRetries = 2
+        process.maxRetries = 1
         aws.batch.volumes = ['/scratch:/scratch'] // Shared directory for large reference files
     }
     ec2_local { // Run on EC2 instance with a local working directory

--- a/configs/profiles.config
+++ b/configs/profiles.config
@@ -24,7 +24,8 @@ profiles {
         fusion.exportStorageCredentials = true
         process.executor = "awsbatch"
         process.errorStrategy = "retry"
-        process.maxRetries = 3
+        process.maxRetries = 2
+        aws.batch.maxSpotAttempts = 0 // Disable AWS Batch internal spot retries; Nextflow handles retries via errorStrategy
         aws.batch.volumes = ['/scratch:/scratch'] // Shared directory for large reference files
     }
     batch { // Run on AWS Batch
@@ -32,7 +33,8 @@ profiles {
         fusion.exportStorageCredentials = true
         process.executor = "awsbatch"
         process.errorStrategy = "retry"
-        process.maxRetries = 3
+        process.maxRetries = 2
+        aws.batch.maxSpotAttempts = 0 // Disable AWS Batch internal spot retries; Nextflow handles retries via errorStrategy
         aws.batch.volumes = ['/scratch:/scratch'] // Shared directory for large reference files
     }
     ec2_local { // Run on EC2 instance with a local working directory

--- a/docs/batch.md
+++ b/docs/batch.md
@@ -91,7 +91,7 @@ The last step you need to complete on AWS itself is to set up a job queue that N
 
 ## Spot instance fallback
 
-When using Spot instances, AWS can reclaim your instances mid-job. By default, Nextflow's retry logic (`process.errorStrategy = "retry"`, `process.maxRetries = 2`) will resubmit failed jobs to the same queue. If the queue uses Spot instances, retries may also be reclaimed during a capacity shortage.
+When using Spot instances, AWS can reclaim your instances mid-job. By default, Nextflow's retry logic (`process.errorStrategy = "retry"`, `process.maxRetries = 1`) will resubmit failed jobs to the same queue. If the queue uses Spot instances, retries may also be reclaimed during a capacity shortage.
 
 To mitigate this, you can configure a **fallback queue** that uses On-Demand instances. On the first attempt, jobs run on the Spot queue; if that attempt fails (for any reason), retries are routed to the On-Demand queue.
 

--- a/docs/batch.md
+++ b/docs/batch.md
@@ -104,13 +104,7 @@ To mitigate this, you can configure a **fallback queue** that uses On-Demand ins
 process.queue = { task.attempt > 1 ? "my-on-demand-queue" : "my-spot-queue" }
 ```
 
-If using the [orchestrator](https://github.com/securebio/nao-mgs-orchestrator), set both `batch_queue` (primary/spot) and `batch_queue_fallback` (on-demand) in your TOML config. The orchestrator generates the closure syntax automatically.
-
-### How it works
-
-- `process.maxRetries = 2` allows up to 2 retries (3 total attempts): 1 on Spot + up to 2 on On-Demand.
-- The closure checks `task.attempt`: attempt 1 uses the primary queue, attempts 2+ use the fallback.
-- Nextflow cannot distinguish Spot reclamation from other failures (both surface as exit code 1). All retries are routed to the fallback queue regardless of failure cause.
+Note: Nextflow cannot distinguish Spot reclamation from other failures (both surface as exit code 1), so all retries are routed to the fallback queue regardless of failure cause.
 
 ## 4. Run Nextflow with Batch
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -21,7 +21,7 @@ This configuration file controls the pipeline's main RUN workflow. Its options a
 - `params.bracken_threshold` [int]: Minimum number of reads that must be assigned to a taxon for Bracken to include it. (default 1)
 - `params.host_taxon` [str]: Host taxon to use for host-infecting virus identification with Kraken2. (default "vertebrate")
 - `random_seed` [str]: Seed for non-deterministic processes. If left blank; a random seed will be chosen; we generally recommend setting a value for reproducibility.
-- `process.queue` [str]: The [AWS Batch job queue](./batch.md) to use for this pipeline run.
+- `process.queue` [str or closure]: The [AWS Batch job queue](./batch.md) to use for this pipeline run. For spot instance fallback, a Groovy closure can be used to switch queues on retry: `process.queue = { task.attempt > 1 ? "on-demand-queue" : "spot-queue" }`. See [Spot instance fallback](./batch.md#spot-instance-fallback) for details.
 
 ## Index workflow (`configs/index.config`)
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -21,7 +21,7 @@ This configuration file controls the pipeline's main RUN workflow. Its options a
 - `params.bracken_threshold` [int]: Minimum number of reads that must be assigned to a taxon for Bracken to include it. (default 1)
 - `params.host_taxon` [str]: Host taxon to use for host-infecting virus identification with Kraken2. (default "vertebrate")
 - `random_seed` [str]: Seed for non-deterministic processes. If left blank; a random seed will be chosen; we generally recommend setting a value for reproducibility.
-- `process.queue` [str or closure]: The [AWS Batch job queue](./batch.md) to use for this pipeline run. For spot instance fallback, a Groovy closure can be used to switch queues on retry: `process.queue = { task.attempt > 1 ? "on-demand-queue" : "spot-queue" }`. See [Spot instance fallback](./batch.md#spot-instance-fallback) for details.
+- `process.queue` [str or closure]: The [AWS Batch job queue](./batch.md) to use for this pipeline run. Supports a Groovy closure for [spot instance fallback](./batch.md#spot-instance-fallback).
 
 ## Index workflow (`configs/index.config`)
 


### PR DESCRIPTION
## Summary
- Reduce `process.maxRetries` from 3 to 1 in `standard` and `batch` profiles
  - Failures could be either spot reclamations, non-stochastic process errors, or stochastic process errors
  - Reducing from 3 to 1 will handle spot reclamations and surface non-stochastic errors faster
  - Reducing from 3 to 1 might reduce our ability to overcome stochastic process errors. **It's not clear to me how common these are and if the current pattern (retry the entire process 3 times) is the best way to handle them.**
- Add documentation about using closure to switch to backup job queue after one failure

## Acceptance criteria
- [x] Verify retry behavior with a spot reclamation scenario
- [x] Confirm on-demand fallback triggers on first retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)