### PR TITLE
Harden Trivy CI scans

### DIFF
--- a/.github/workflows/rust-tools.yml
+++ b/.github/workflows/rust-tools.yml
@@ -78,15 +78,13 @@ jobs:
       - name: Load container
         run: gunzip -c rust-tools.tar.gz | docker load
 
-      - name: Install Trivy
-        run: |
-          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo apt-key add -
-          echo "deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee -a /etc/apt/sources.list.d/trivy.list
-          sudo apt-get update
-          sudo apt-get install -y trivy
-
       - name: Run Trivy vulnerability scan
-        run: trivy image --scanners vuln --severity CRITICAL,HIGH --exit-code 1 nao-rust-tools:local
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
+        with:
+          image-ref: 'nao-rust-tools:local'
+          scanners: 'vuln'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '1'
 
   push-to-ecr:
     needs: build-and-test

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -22,11 +22,13 @@ jobs:
           python-version: '3.12'
 
       - name: Install Trivy
+        env:
+          TRIVY_VERSION: "0.69.3"
+          TRIVY_SHA256: "a484057aafde31089cf2558ca0f79a4bc835125a5ee6834183a5bcf0735af358"
         run: |
-          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo apt-key add -
-          echo "deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee -a /etc/apt/sources.list.d/trivy.list
-          sudo apt-get update
-          sudo apt-get install trivy
+          curl -sL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.deb" -o "trivy_${TRIVY_VERSION}_Linux-64bit.deb"
+          echo "${TRIVY_SHA256}  trivy_${TRIVY_VERSION}_Linux-64bit.deb" | sha256sum --check
+          sudo dpkg -i "trivy_${TRIVY_VERSION}_Linux-64bit.deb"
 
       - name: Run Trivy scan
         run: python bin/scan_containers.py --config configs/containers.config --output-dir trivy_results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
-# v3.2.1.2-dev
-
-- CI: Hardened Trivy vulnerability scans against supply chain attacks by replacing unpinned apt installs with SHA-pinned `trivy-action` (`rust-tools.yml`) and version-pinned GitHub release with SHA256 verification (`trivy-scan.yml`).
-
 # v3.2.1.1-dev
 
+- CI: Hardened Trivy vulnerability scans against supply chain attacks by replacing unpinned apt installs with SHA-pinned `trivy-action` (`rust-tools.yml`) and version-pinned GitHub release with SHA256 verification (`trivy-scan.yml`).
 - Added FASTP JSON output to published DOWNSTREAM outputs for QC (short-read data only; ONT uses FILTLONG), using `CONCAT_JSON_BY_GROUP` to merge per-sample FASTP JSONs into per-group outputs.
 
 # v3.2.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v3.2.1.2-dev
+
+- CI: Hardened Trivy vulnerability scans against supply chain attacks by replacing unpinned apt installs with SHA-pinned `trivy-action` (`rust-tools.yml`) and version-pinned GitHub release with SHA256 verification (`trivy-scan.yml`).
+
 # v3.2.1.1-dev
 
 - Added FASTP JSON output to published DOWNSTREAM outputs for QC (short-read data only; ONT uses FILTLONG), using `CONCAT_JSON_BY_GROUP` to merge per-sample FASTP JSONs into per-group outputs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mgs-workflow"
-version = "3.2.1.1-dev"
+version = "3.2.1.2-dev"
 requires-python = ">=3.12"
 dependencies = [
     "biopython>=1.85",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mgs-workflow"
-version = "3.2.1.2-dev"
+version = "3.2.1.1-dev"
 requires-python = ">=3.12"
 dependencies = [
     "biopython>=1.85",


### PR DESCRIPTION
## Summary
- **rust-tools.yml:** Replace unpinned apt install + CLI with SHA-pinned `aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1` (v0.35.0)
- **trivy-scan.yml:** Replace unpinned apt install with version-pinned GitHub release download (v0.69.3) verified against a hardcoded SHA256 hash

Both changes address the [March 2026 trivy-action compromise](https://github.com/aquasecurity/trivy-action/issues/541) where force-pushed tags and a malicious binary release (v0.69.4) were used to exfiltrate CI secrets.

Closes COMP-1349

🤖 Generated with [Claude Code](https://claude.com/claude-code)