### PR TITLE
Add experimental output directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v3.2.1.3-dev
+
+- Add `experimental/` and `experimental_downstream/` output directories for staging new outputs that are not yet guaranteed to be stable across point releases.
+
 # v3.2.1.2
 
 - Add `nucleaze` to the rust-tools container and bump Rust toolchain from 1.83 to 1.88.

--- a/docs/output.md
+++ b/docs/output.md
@@ -2,12 +2,24 @@
 
 If the pipeline runs to completion, the following output files are expected. In the future, we will add more specific information about the outputs, including in-depth descriptions of the columns in the output files.
 
-All pipeline output can be found in the `output` directory, which is broken into four subdirectories:
+All pipeline output can be found in the `output` directory, which is broken into five subdirectories:
 
 - `input`: Directory containing saved input information (useful for trying to reproduce someone else's results)
 - `logging`: Log files containing meta-level information about the pipeline run itself.
 - `intermediates`: Intermediate files produced by key stages in the run workflow, saved for nonstandard downstream analysis.
 - `results`: Directory containing processed results files for standard downstream analysis.
+- `experimental`: Directory containing experimental outputs that are under active development and not yet guaranteed to be stable. See below for details.
+
+## Experimental outputs
+
+The `experimental/` (INDEX and RUN workflows) and `experimental_downstream/` (DOWNSTREAM workflow) directories contain outputs that are under active development. Files in these directories:
+
+- Are NOT tracked in the `expected-outputs-*` lists in `pyproject.toml`
+- Are NOT guaranteed to have schemas or complete documentation
+- May change or be removed in any release, including point (4th-number) releases
+- Should NOT be relied upon by downstream consumers until promoted to standard output directories
+
+These directories allow new output features to ship for early feedback without waiting for a stable release.
 
 ## Run workflow
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -17,9 +17,8 @@ The `experimental/` (INDEX and RUN workflows) and `experimental_downstream/` (DO
 - Are NOT tracked in the `expected-outputs-*` lists in `pyproject.toml`
 - Are NOT guaranteed to have schemas or complete documentation
 - May change or be removed in any release, including point (4th-number) releases
-- Should NOT be relied upon by downstream consumers until promoted to standard output directories
 
-These directories allow new output features to ship for early feedback without waiting for a stable release.
+Downstream consumers use experimental outputs at their own risk, and are responsible for keeping their code up to date with changes in the structure and contents of these files across releases. Once ready, experimental outputs are promoted into regular outputs and become subject to the standard output guarantees.
 
 ## Run workflow
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -7,6 +7,8 @@ From version 2.6.0.0 we're adopting a new 4-number versioning scheme, described 
 3. **Results:** The third number will be incremented each time the results are no longer directly comparable to previous versions.
 4. **Point:** The fourth number will be incremented any other time the pipeline code changes in a manner that doesn't meet the criteria above, such as changes that impact performance but not results; changes to documentation; options that are off by default; and new output files that don't interfere with existing outputs (including additions to the `expected-outputs-*` lists in `pyproject.toml`).
 
+**Experimental outputs:** The `experimental/` and `experimental_downstream/` output directories are exempt from the above guarantees. Files in these directories may change or be removed in any release, including point releases. See [output.md](output.md) for details.
+
 Users relying on pipeline outputs should take the following actions in response to pipeline changes:
 
 1. **Point change or higher:** Review changes for new outputs and options that could be relevant to user's application.

--- a/main.nf
+++ b/main.nf
@@ -18,6 +18,7 @@ workflow {
         logging_index = params.mode == 'index' ? INDEX.out.logging_index : Channel.empty()
         ref_dbs = params.mode == 'index' ? INDEX.out.ref_dbs : Channel.empty()
         alignment_indexes = params.mode == 'index' ? INDEX.out.alignment_indexes : Channel.empty()
+        experimental_index = params.mode == 'index' ? INDEX.out.experimental_index : Channel.empty()
         // RUN workflow publishing
         input_run = params.mode == 'run' ? RUN.out.input_run : Channel.empty()
         logging_run = params.mode == 'run' ? RUN.out.logging_run : Channel.empty()
@@ -26,11 +27,13 @@ workflow {
         reads_trimmed_viral = params.mode == 'run' ? RUN.out.reads_trimmed_viral : Channel.empty()
         qc_results_run = params.mode == 'run' ? RUN.out.qc_results_run : Channel.empty()
         other_results_run = params.mode == 'run' ? RUN.out.other_results_run : Channel.empty()
+        experimental_run = params.mode == 'run' ? RUN.out.experimental_run : Channel.empty()
         // DOWNSTREAM workflow publishing
         input_downstream = params.mode == 'downstream' ? DOWNSTREAM.out.input_downstream  : Channel.empty()
         logging_downstream = params.mode == 'downstream' ? DOWNSTREAM.out.logging_downstream  : Channel.empty()
         intermediates_downstream = params.mode == 'downstream' ? DOWNSTREAM.out.intermediates_downstream  : Channel.empty()
         results_downstream = params.mode == 'downstream' ? DOWNSTREAM.out.results_downstream  : Channel.empty()
+        experimental_downstream = params.mode == 'downstream' ? DOWNSTREAM.out.experimental_downstream  : Channel.empty()
 }
         
 output {
@@ -49,6 +52,10 @@ output {
     }
     alignment_indexes {
         path "results"
+        tags nextflow_file_class: "publish", "nextflow.io/temporary": "false"
+    }
+    experimental_index {
+        path "experimental"
         tags nextflow_file_class: "publish", "nextflow.io/temporary": "false"
     }
     // RUN workflow output
@@ -80,6 +87,10 @@ output {
         path "results"
         tags nextflow_file_class: "publish", "nextflow.io/temporary": "false"
     }
+    experimental_run {
+        path "experimental"
+        tags nextflow_file_class: "publish", "nextflow.io/temporary": "false"
+    }
     // DOWNSTREAM workflow output
     input_downstream {
         path "input_downstream"
@@ -95,6 +106,10 @@ output {
     }
     results_downstream {
         path "results_downstream"
+        tags nextflow_file_class: "publish", "nextflow.io/temporary": "false"
+    }
+    experimental_downstream {
+        path "experimental_downstream"
         tags nextflow_file_class: "publish", "nextflow.io/temporary": "false"
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mgs-workflow"
-version = "3.2.1.2"
+version = "3.2.1.3-dev"
 requires-python = ">=3.12"
 dependencies = [
     "biopython>=1.85",

--- a/tests/workflows/downstream.nf.test
+++ b/tests/workflows/downstream.nf.test
@@ -17,7 +17,7 @@ def getExpectedOutputs = { pyprojectPath, workflowKey, sampleOrGroupName ->
 
 // Get observed output files, excluding intermediates and trace files
 def getObservedOutputs = { outputDir ->
-    def excludePatterns = ["intermediates", "intermediates_downstream", "trace"]
+    def excludePatterns = ["intermediates", "intermediates_downstream", "trace", "experimental", "experimental_downstream"]
     def observedFiles = []
     outputDir.eachFileRecurse(FILES) { file ->
         def relPath = outputDir.relativize(file).toString()

--- a/tests/workflows/run.nf.test
+++ b/tests/workflows/run.nf.test
@@ -17,7 +17,7 @@ def getExpectedOutputs = { pyprojectPath, workflowKey, sampleOrGroupName ->
 
 // Get observed output files, excluding intermediates and trace files
 def getObservedOutputs = { outputDir ->
-    def excludePatterns = ["intermediates", "trace"]
+    def excludePatterns = ["intermediates", "trace", "experimental"]
     def observedFiles = []
     outputDir.eachFileRecurse(FILES) { file ->
         def relPath = outputDir.relativize(file).toString()

--- a/workflows/downstream.nf
+++ b/workflows/downstream.nf
@@ -81,4 +81,5 @@ workflow DOWNSTREAM {
                                 validate_ch.annotated_hits,
                                 concat_ch.other,
                                 concat_ch.fastp_json)
+        experimental_downstream = Channel.empty()
 }

--- a/workflows/index.nf
+++ b/workflows/index.nf
@@ -93,4 +93,5 @@ workflow INDEX {
             MAKE_RIBO_INDEX.out.mm2,
             MAKE_CONTAMINANT_INDEX.out.mm2
         )
+        experimental_index = Channel.empty()
 }

--- a/workflows/run.nf
+++ b/workflows/run.nf
@@ -128,4 +128,5 @@ workflow RUN {
         reads_trimmed_viral = bbduk_trimmed
         qc_results_run = COUNT_READS.out.output.mix(RUN_QC.out.pre_qc, RUN_QC.out.post_qc, SUBSET_TRIM.out.fastp_json)
         other_results_run = hits_final.mix(PROFILE.out.bracken, PROFILE.out.kraken)
+        experimental_run = Channel.empty()
 }


### PR DESCRIPTION
Add `experimental/` and `experimental_downstream/` output directories as a staging area for new outputs that are under active development. These directories are explicitly exempt from point-release stability guarantees, are not tracked in expected output lists, and do not require schemas — allowing new features to ship for early feedback without waiting for a full stable release.

**Changes:**
- Add empty `experimental_index`, `experimental_run`, and `experimental_downstream` channel emissions to INDEX, RUN, and DOWNSTREAM workflows respectively
- Wire up all three channels in `main.nf` publish and output blocks (INDEX and RUN map to `experimental/`, DOWNSTREAM maps to `experimental_downstream/`)
- Exclude experimental directories from output validation in workflow tests
- Document the experimental output concept in `docs/output.md` and clarify the versioning exemption in `docs/versioning.md`
- Bump version to `3.2.1.3-dev`

Generated with [Claude Code](https://claude.com/claude-code)