### PR TITLE
Add new HIGH-severity CVEs to .trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -31,8 +31,10 @@ CVE-2025-68973 exp:2026-06-30
 # surface for these CVEs is minimal in our pipeline context.
 #
 # TODO: Remove these ignores when a newer ncbi-datasets-cli is available on
-# conda-forge built with Go >= 1.24.13. Check with:
+# conda-forge built with Go >= 1.25.9. Check with:
 #   conda search -c conda-forge ncbi-datasets-cli
+#   strings $(conda run -n <env> which datasets) | grep '^go1\.'
+# As of 2026-04-14, 18.23.0 still ships Go 1.23.4.
 #
 # crypto/tls: unexpected session resumption (CRITICAL)
 CVE-2025-68121 exp:2026-06-30
@@ -48,6 +50,17 @@ CVE-2025-61728 exp:2026-06-30
 CVE-2025-61729 exp:2026-06-30
 # net/url: incorrect parsing of IPv6 host literals (HIGH)
 CVE-2026-25679 exp:2026-06-30
+# crypto/x509: excessive CPU in certificate chain building (HIGH)
+CVE-2026-32280 exp:2026-06-30
+# internal/syscall/unix: Root.Chmod can follow symlinks out of the root (HIGH)
+CVE-2026-32282 exp:2026-06-30
+
+# ── Pillow in multiqc container (transitive dependency via matplotlib) ──
+# multiqc 1.33 (latest on bioconda) pulls Pillow 12.1.1; fix requires >= 12.2.0.
+# We cannot pin Pillow independently in the conda environment spec.
+# The vulnerability is a FITS GZIP decompression bomb — not a realistic attack
+# vector since multiqc only processes pipeline QC data, not untrusted FITS images.
+CVE-2026-40192 exp:2026-06-30
 
 # ── Debian bookworm base image: no fixes available ──
 # glibc: DoS via iconv() with specific character set conversions (fix_deferred)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v3.2.1.3-dev
+
+- Add CVE-2026-32280, CVE-2026-32282 (Go stdlib in ncbi_datasets container) and CVE-2026-40192 (Pillow in multiqc container) to `.trivyignore`. No upstream fixes available; updated TODO with latest check results.
+
 # v3.2.1.2
 
 - Add `nucleaze` to the rust-tools container and bump Rust toolchain from 1.83 to 1.88.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mgs-workflow"
-version = "3.2.1.2"
+version = "3.2.1.3-dev"
 requires-python = ">=3.12"
 dependencies = [
     "biopython>=1.85",


### PR DESCRIPTION
Three new HIGH-severity Trivy findings are failing CI with no upstream fix available. This PR adds them to `.trivyignore` with `exp:2026-06-30` to be reviewed alongside the existing batch.

**Changes:**
- CVE-2026-32280, CVE-2026-32282: Go stdlib vulnerabilities in `ncbi_datasets` container. The pre-compiled `ncbi-datasets-cli` binaries (latest 18.23.0 on conda-forge) still ship Go 1.23.4; fixes require Go >= 1.25.9. Only NCBI can rebuild these.
- CVE-2026-40192: Pillow FITS GZIP decompression bomb in `multiqc` container. multiqc 1.33 is the latest on bioconda and pulls Pillow 12.1.1; fix requires >= 12.2.0. Not a realistic attack vector (multiqc processes pipeline QC data, not untrusted FITS images).
- Updated the TODO comment in the Go stdlib block with latest version check results and a command to verify the embedded Go version.

Generated with [Claude Code](https://claude.com/claude-code)
