### PR TITLE
Add authenticated ECR login to Trivy scan workflow

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -3,6 +3,10 @@ name: Trivy Container Vulnerability Scan
 on:
   pull_request: # Runs on all PRs
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   scan-containers:
     runs-on: ubuntu-latest
@@ -11,6 +15,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Login to ECR Public
+        run: |
+          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v3.2.1.3-dev
 
+- CI: Add authenticated ECR Public login to Trivy scan workflow to avoid anonymous pull rate limits
 - Add CVE-2026-32280, CVE-2026-32282 (Go stdlib in ncbi_datasets container) and CVE-2026-40192 (Pillow in multiqc container) to `.trivyignore`. No upstream fixes available; updated TODO with latest check results.
 - Add `experimental/` and `experimental_downstream/` output directories for staging new outputs that are not yet guaranteed to be stable across point releases.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v3.2.1.3-dev
 
-- CI: Add authenticated ECR Public login to Trivy scan workflow to avoid anonymous pull rate limits
+- Add authenticated ECR Public login to Trivy scan workflow to avoid anonymous pull rate limits
 - Add CVE-2026-32280, CVE-2026-32282 (Go stdlib in ncbi_datasets container) and CVE-2026-40192 (Pillow in multiqc container) to `.trivyignore`. No upstream fixes available; updated TODO with latest check results.
 - Add `experimental/` and `experimental_downstream/` output directories for staging new outputs that are not yet guaranteed to be stable across point releases.
 


### PR DESCRIPTION
The Trivy container scan pulls many images from public ECR without authentication, intermittently hitting the anonymous rate limit (`TOOMANYREQUESTS`), which crashes the scan ([example](https://github.com/securebio/nao-mgs-workflow/actions/runs/24402659562/job/71277258777)). This adds OIDC-authenticated ECR Public login, matching the existing pattern in `.github/actions/setup-nf-test/action.yml`.

Closes #721

Chained off #720, will rebase once that is merged into `dev`

Generated with [Claude Code](https://claude.com/claude-code)