### PR TITLE
Ignore two new Go stdlib HIGH CVEs in ncbi_datasets container

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -54,6 +54,10 @@ CVE-2026-25679 exp:2026-06-30
 CVE-2026-32280 exp:2026-06-30
 # internal/syscall/unix: Root.Chmod can follow symlinks out of the root (HIGH)
 CVE-2026-32282 exp:2026-06-30
+# crypto/x509: DoS via inefficient certificate chain validation (HIGH)
+CVE-2026-32281 exp:2026-06-30
+# crypto/tls: TLS 1.3 post-handshake key-update deadlock DoS (HIGH)
+CVE-2026-32283 exp:2026-06-30
 
 # ── Pillow in multiqc container (transitive dependency via matplotlib) ──
 # multiqc 1.33 (latest on bioconda) pulls Pillow 12.1.1; fix requires >= 12.2.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Make `bin/run-nf-test.sh` and `bin/run_nf_test_parallel.py` symlink-safe for downstream repos.
 - Add authenticated ECR Public login to Trivy scan workflow to avoid anonymous pull rate limits
 - Add CVE-2026-32280, CVE-2026-32282 (Go stdlib in ncbi_datasets container) and CVE-2026-40192 (Pillow in multiqc container) to `.trivyignore`. No upstream fixes available; updated TODO with latest check results.
+- Add CVE-2026-32281, CVE-2026-32283 (Go stdlib HIGH CVEs in ncbi_datasets container) to `.trivyignore`. Not practically exploitable in our context (TLS client-only, no untrusted cert chains, no TLS 1.3 server); no upstream fix available.
 - Add `experimental/` and `experimental_downstream/` output directories for staging new outputs that are not yet guaranteed to be stable across point releases.
 - Add similarity-based duplicate marking to DOWNSTREAM as an experimental output via the new `MARK_SIMILARITY_DUPLICATES` module and `rust-tools/mark_duplicates_similarity` Rust library.
 - Refactor `CHECK_VERSION_COMPATIBILITY` subworkflow to derive pyproject paths internally from `ref_dir` and `pipeline_dir`, simplifying the interface in `workflows/run.nf`.


### PR DESCRIPTION
The `scan-containers` Trivy CI job on `dev` is failing because two newly-disclosed Go stdlib HIGH CVEs were detected in the NCBI `datasets` / `dataformat` binaries shipped inside the `ncbi_datasets` container. These binaries are pre-compiled Go executables distributed by NCBI via conda-forge, so only NCBI can fix them by rebuilding with a newer Go toolchain. Latest `ncbi-datasets-cli` (18.23.0, uploaded 2026-04-06) still ships Go 1.23.4 — fixes require Go ≥ 1.25.9 / ≥ 1.26.2 — so no upstream remedy is available yet. Both CVEs fall squarely in the same bucket as the nine Go-stdlib CVEs already accepted in the existing ignore block; extending that block keeps the standing TODO (upgrade once NCBI ships a newer Go toolchain) as the single cleanup point.

**Changes:**
- `.trivyignore`: append `CVE-2026-32281` (crypto/x509 cert-chain validation DoS) and `CVE-2026-32283` (crypto/tls 1.3 key-update deadlock DoS) to the existing `Go stdlib v1.23.4 in ncbi-datasets-cli 18.21.0` block with `exp:2026-06-30` — matches the neighboring entries' expiration so the whole block is re-reviewed at the same time.
- `CHANGELOG.md`: add a bullet under `v3.2.1.3-dev` noting the two new ignores and the risk-acceptance rationale (TLS-client-only usage, no untrusted cert chains, no TLS 1.3 server).

**Risk assessment:** neither CVE is practically exploitable in our pipeline. The binaries only run as TLS *clients* against NCBI's public API, don't validate attacker-controlled certificate chains, and never serve TLS 1.3 traffic — the preconditions for both DoS vectors.

**Not changed:** no `pyproject.toml` bump — per the repo's dev-stacking convention (`docs/versioning.md`), point-level PRs share the same `-dev` version during a dev cycle.

Generated with [Claude Code](https://claude.com/claude-code)
