### PR TITLE
Add AdapterRemoval container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v3.2.1.4-dev
+
+- Add AdapterRemoval v2.3.4 container (`containers/adapterremoval.yml`) and `withLabel: AdapterRemoval` block in `configs/containers.config`, making the image available for downstream pipelines to consume. No pipeline modules use this container yet.
+
 # v3.2.1.3
 
 ## New workflow outputs

--- a/configs/containers.config
+++ b/configs/containers.config
@@ -11,6 +11,9 @@ params {
 }
 
 process {
+    withLabel: AdapterRemoval {
+        container = "public.ecr.aws/q0n1c7g8/nao-mgs-workflow/adapterremoval:6447eb4de7fd294a"
+    }
     withLabel: BBTools {
         container = "public.ecr.aws/q0n1c7g8/nao-mgs-workflow/bbtools:57d91a4e389734c6"
     }

--- a/containers/adapterremoval.yml
+++ b/containers/adapterremoval.yml
@@ -1,0 +1,7 @@
+name: adapterremoval
+label: AdapterRemoval
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::adapterremoval=2.3.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mgs-workflow"
-version = "3.2.1.3"
+version = "3.2.1.4-dev"
 requires-python = ">=3.12"
 dependencies = [
     "biopython>=1.85",


### PR DESCRIPTION
Adds a slim `AdapterRemoval` v2.3.4 container and wires it into `configs/containers.config` for future use in this workflow or in downstream repos. No modules in `mgs-workflow` currently use this label.

Closes [COMP-1772](https://linear.app/securebio-nao/issue/COMP-1772).

## Test plan
- [x] Ran `docker run --rm public.ecr.aws/q0n1c7g8/nao-mgs-workflow/adapterremoval:6447eb4de7fd294a AdapterRemoval --version` and verified binary is on PATH

Generated with [Claude Code](https://claude.com/claude-code)