### PR TITLE
Tolerate empty viral taxa in DOWNLOAD_VIRAL_GENOMES

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -71,6 +71,13 @@ CVE-2026-40192 exp:2026-06-30
 # Our containers don't perform attacker-controlled iconv conversions.
 CVE-2026-4046 exp:2026-06-30
 
+# libgcrypt20: heap overflow / DoS via crafted ECDH ciphertext to gcry_pk_decrypt
+# (no Debian fix available as of 2026-04-29; fixed in upstream libgcrypt >= 1.12.2)
+# Our pipeline containers never decrypt attacker-controlled ECDH ciphertext.
+# Check for a Debian fix at:
+#   https://security-tracker.debian.org/tracker/CVE-2026-41989
+CVE-2026-41989 exp:2026-06-30
+
 # ncurses: stack-based buffer overflow in infocmp CLI tool (no-dsa, low urgency)
 # Our containers never invoke infocmp. Fix only in sid (6.6+).
 CVE-2025-69720 exp:2026-06-30

--- a/.trivyignore
+++ b/.trivyignore
@@ -71,13 +71,6 @@ CVE-2026-40192 exp:2026-06-30
 # Our containers don't perform attacker-controlled iconv conversions.
 CVE-2026-4046 exp:2026-06-30
 
-# libgcrypt20: heap overflow / DoS via crafted ECDH ciphertext to gcry_pk_decrypt
-# (no Debian fix available as of 2026-04-29; fixed in upstream libgcrypt >= 1.12.2)
-# Our pipeline containers never decrypt attacker-controlled ECDH ciphertext.
-# Check for a Debian fix at:
-#   https://security-tracker.debian.org/tracker/CVE-2026-41989
-CVE-2026-41989 exp:2026-06-30
-
 # ncurses: stack-based buffer overflow in infocmp CLI tool (no-dsa, low urgency)
 # Our containers never invoke infocmp. Fix only in sid (6.6+).
 CVE-2025-69720 exp:2026-06-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v3.2.1.4-dev
 
+- Tolerate viral taxa with no linked NCBI assemblies in `DOWNLOAD_VIRAL_GENOMES`. The module now detects the `datasets download genome taxon` "no genome data is currently available" error and emits an empty `${taxid}_genomes/` (declared `optional`) plus a header-only `${taxid}_metadata.tsv`, instead of failing the whole `MAKE_VIRUS_GENOME_DB` subworkflow whenever any single child taxon happens to have no assemblies. This covers the case where NCBI publishes a new viral family/genus to the taxonomy before assemblies are linked to it.
 - Add CVE-2026-41989 (libgcrypt20) to `.trivyignore`; no Debian fix available and not exercised by our pipeline.
 - Prevent `MASK_FASTQ_READS` from running out of memory on merged ONT libraries larger than ~6 GB of gzipped FASTQ (#737).
     - Replaces `label "large"` with a new `label "bbmask_resources"` whose `memory` directive is an input-size-aware closure (32 / 64 / 128 GiB tiers, chosen from input byte size). The label and its closure live in `configs/resources.config` alongside other resource labels; the module itself stays label-only. CPU allocation unchanged at 16.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -44,9 +44,9 @@ In cases where a module is a thin wrapper around a script in another language, c
 
 #### Stubbing containerized binaries
 
-When a process invokes a containerized CLI whose error path can't be reproduced reliably with live inputs (e.g. the NCBI `datasets` "no genome data" error, which depends on unstable taxonomy state), you can stub the binary by mounting a script over its container path. The pattern:
+When a process invokes a containerized CLI whose error path can't be reproduced reliably with live inputs (e.g. the NCBI `datasets` commands that depend on the live NCBI database state), you can stub the binary by mounting a script over its container path. The pattern:
 
-1. Place the stub script at `tests/modules/local/<process>/stub_bin/<binary>`, mark it executable, and exit with the same status codes / stderr signatures as the real binary for the cases under test. Force an explicit default arm so an unrecognized input fails loudly instead of silently producing the stubbed behavior.
+1. Place the stub script at `tests/modules/local/<process>/stub_bin/<binary>`, mark it executable, and exit with the same status codes / stderr signatures as the real binary for the cases under test.
 2. Add a config under `tests/configs/` that mounts the stub over the real binary path inside the container via `containerOptions`:
 
    ```groovy
@@ -59,7 +59,7 @@ When a process invokes a containerized CLI whose error path can't be reproduced 
 
 3. Reference the config from the relevant test with `config "tests/configs/<name>.config"`.
 
-`tests/modules/local/downloadViralGenomes/stub_bin/datasets` plus `tests/configs/empty_taxon.config` are a working example. Note the failure mode: if a future container image moves the binary, the mount silently misses and the real binary is invoked — document the expected container path in the config header so this is easy to diagnose.
+`tests/modules/local/downloadViralGenomes/stub_bin/datasets` plus `tests/configs/empty_taxon.config` are a working example. If a future container image moves the binary, the mount will silently fail to override it and the real binary will be invoked, so it's important to add a test that would catch this regression.
 
 ### Test datasets
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -42,6 +42,25 @@ In cases where a module is a thin wrapper around a script in another language, c
 
 `tests/modules/local/fastqc/main.nf.test` is an example of bare-minimum tests for a process, and `tests/modules/local/vsearch/main.nf.test` is an example of really good, comprehensive testing!
 
+#### Stubbing containerized binaries
+
+When a process invokes a containerized CLI whose error path can't be reproduced reliably with live inputs (e.g. the NCBI `datasets` "no genome data" error, which depends on unstable taxonomy state), you can stub the binary by mounting a script over its container path. The pattern:
+
+1. Place the stub script at `tests/modules/local/<process>/stub_bin/<binary>`, mark it executable, and exit with the same status codes / stderr signatures as the real binary for the cases under test. Force an explicit default arm so an unrecognized input fails loudly instead of silently producing the stubbed behavior.
+2. Add a config under `tests/configs/` that mounts the stub over the real binary path inside the container via `containerOptions`:
+
+   ```groovy
+   process {
+       withName: <PROCESS> {
+           containerOptions = "-v ${projectDir}/tests/modules/local/<process>/stub_bin/<binary>:<container-path>:ro"
+       }
+   }
+   ```
+
+3. Reference the config from the relevant test with `config "tests/configs/<name>.config"`.
+
+`tests/modules/local/downloadViralGenomes/stub_bin/datasets` plus `tests/configs/empty_taxon.config` are a working example. Note the failure mode: if a future container image moves the binary, the mount silently misses and the real binary is invoked — document the expected container path in the config header so this is easy to diagnose.
+
 ### Test datasets
 
 #### Current test data

--- a/modules/local/downloadViralGenomes/main.nf
+++ b/modules/local/downloadViralGenomes/main.nf
@@ -28,7 +28,7 @@ process DOWNLOAD_VIRAL_GENOMES {
             --filename output.zip 2> dl_err.txt
         then
             cat dl_err.txt >&2
-            if grep -qE 'no genome data is currently available for this taxon\\.' dl_err.txt; then
+            if grep -qE '^Error:.*no genome data is currently available for this taxon\\.\$' dl_err.txt; then
                 mkdir -p ${taxid}_genomes
                 printf '${metadata_header}\\n' > ${taxid}_metadata.tsv
                 echo "Taxon ${taxid} has no assemblies available; emitting empty outputs." >&2

--- a/modules/local/downloadViralGenomes/main.nf
+++ b/modules/local/downloadViralGenomes/main.nf
@@ -11,14 +11,12 @@ process DOWNLOAD_VIRAL_GENOMES {
         path("${taxid}_genomes/*.fna.gz"), optional: true, emit: genomes
         path("${taxid}_metadata.tsv"), emit: metadata
     script:
-        // Header schema for ${taxid}_metadata.tsv. Reused in the empty-taxon
-        // branch and the happy-path header rewrite below — keep them in sync.
+        // Header schema for ${taxid}_metadata.tsv
         def metadata_header = "assembly_accession\\ttaxid\\torganism_name\\tsource_database"
         """
         # 1. Download dehydrated package (metadata + manifest only).
-        # NCBI's taxonomy can include taxa whose assemblies haven't been linked
-        # yet (typical lag between ICTV publishing a new taxon and its genomes
-        # appearing). Tolerate that by emitting empty outputs instead of failing.
+        # NCBI's taxonomy can include taxa without assemblies,
+        # so catch and emit empty outputs instead of failing.
         if ! datasets download genome taxon ${taxid} \\
             --assembly-source ${assembly_source} \\
             --include genome \\

--- a/modules/local/downloadViralGenomes/main.nf
+++ b/modules/local/downloadViralGenomes/main.nf
@@ -8,18 +8,37 @@ process DOWNLOAD_VIRAL_GENOMES {
         val(extra_args)
         val(max_attempts)
     output:
-        path("${taxid}_genomes/*.fna.gz"), emit: genomes
+        path("${taxid}_genomes/*.fna.gz"), optional: true, emit: genomes
         path("${taxid}_metadata.tsv"), emit: metadata
     script:
         """
-        # 1. Download dehydrated package (metadata + manifest only)
+        # 1. Download dehydrated package (metadata + manifest only).
+        # NCBI's taxonomy can include taxa whose assemblies haven't been linked
+        # yet (typical lag between ICTV publishing a new taxon and its genomes
+        # appearing). Tolerate that by emitting empty outputs instead of failing.
+        set +e
         datasets download genome taxon ${taxid} \\
             --assembly-source ${assembly_source} \\
             --include genome \\
             --no-progressbar \\
             --dehydrated \\
             ${extra_args} \\
-            --filename output.zip
+            --filename output.zip 2> dl_err.txt
+        rc=\$?
+        set -e
+        cat dl_err.txt >&2
+        if [ \$rc -ne 0 ]; then
+            if grep -q "no genome data is currently available" dl_err.txt; then
+                mkdir -p ${taxid}_genomes
+                printf 'assembly_accession\\ttaxid\\torganism_name\\tsource_database\\n' > ${taxid}_metadata.tsv
+                echo "Taxon ${taxid} has no assemblies available; emitting empty outputs." >&2
+                rm -f dl_err.txt
+                exit 0
+            fi
+            rm -f dl_err.txt
+            exit \$rc
+        fi
+        rm -f dl_err.txt
         unzip -o output.zip -d output/
 
         # 2. Rehydrate: download actual genome files with retry and exponential backoff

--- a/modules/local/downloadViralGenomes/main.nf
+++ b/modules/local/downloadViralGenomes/main.nf
@@ -19,6 +19,11 @@ process DOWNLOAD_VIRAL_GENOMES {
         # 1. Download dehydrated package (metadata + manifest only).
         # NCBI's taxonomy can include taxa without assemblies,
         # so catch and emit empty outputs instead of failing.
+        # We capture stderr to grep for the empty-taxon signature; the
+        # post-call `cat dl_err.txt >&2` replays it for diagnostic visibility.
+        # This defers stderr (vs. streaming live to .command.err) but the
+        # `datasets download --dehydrated` step is short, so the trade-off
+        # is acceptable.
         if ! datasets download genome taxon ${taxid} \\
             --assembly-source ${assembly_source} \\
             --include genome \\

--- a/modules/local/downloadViralGenomes/main.nf
+++ b/modules/local/downloadViralGenomes/main.nf
@@ -11,33 +11,34 @@ process DOWNLOAD_VIRAL_GENOMES {
         path("${taxid}_genomes/*.fna.gz"), optional: true, emit: genomes
         path("${taxid}_metadata.tsv"), emit: metadata
     script:
+        // Header schema for ${taxid}_metadata.tsv. Reused in the empty-taxon
+        // branch and the happy-path header rewrite below — keep them in sync.
+        def metadata_header = "assembly_accession\\ttaxid\\torganism_name\\tsource_database"
         """
         # 1. Download dehydrated package (metadata + manifest only).
         # NCBI's taxonomy can include taxa whose assemblies haven't been linked
         # yet (typical lag between ICTV publishing a new taxon and its genomes
         # appearing). Tolerate that by emitting empty outputs instead of failing.
-        set +e
-        datasets download genome taxon ${taxid} \\
+        if ! datasets download genome taxon ${taxid} \\
             --assembly-source ${assembly_source} \\
             --include genome \\
             --no-progressbar \\
             --dehydrated \\
             ${extra_args} \\
             --filename output.zip 2> dl_err.txt
-        rc=\$?
-        set -e
-        cat dl_err.txt >&2
-        if [ \$rc -ne 0 ]; then
-            if grep -q "no genome data is currently available" dl_err.txt; then
+        then
+            cat dl_err.txt >&2
+            if grep -qE 'no genome data is currently available for this taxon\\.' dl_err.txt; then
                 mkdir -p ${taxid}_genomes
-                printf 'assembly_accession\\ttaxid\\torganism_name\\tsource_database\\n' > ${taxid}_metadata.tsv
+                printf '${metadata_header}\\n' > ${taxid}_metadata.tsv
                 echo "Taxon ${taxid} has no assemblies available; emitting empty outputs." >&2
                 rm -f dl_err.txt
                 exit 0
             fi
             rm -f dl_err.txt
-            exit \$rc
+            exit 1
         fi
+        cat dl_err.txt >&2
         rm -f dl_err.txt
         unzip -o output.zip -d output/
 
@@ -63,7 +64,7 @@ process DOWNLOAD_VIRAL_GENOMES {
             > raw_metadata.tsv
 
         # 4. Replace header with standardized column names
-        { echo -e "assembly_accession\\ttaxid\\torganism_name\\tsource_database"
+        { echo -e "${metadata_header}"
           tail -n +2 raw_metadata.tsv
         } > ${taxid}_metadata.tsv
 

--- a/modules/local/downloadViralGenomes/main.nf
+++ b/modules/local/downloadViralGenomes/main.nf
@@ -19,14 +19,6 @@ process DOWNLOAD_VIRAL_GENOMES {
         # 1. Download dehydrated package (metadata + manifest only).
         # NCBI's taxonomy can include taxa without assemblies,
         # so catch and emit empty outputs instead of failing.
-        # We capture stderr to grep for the empty-taxon signature; the
-        # post-call `cat dl_err.txt >&2` replays it for diagnostic visibility.
-        # This defers stderr (vs. streaming live to .command.err) but the
-        # `datasets download --dehydrated` step is short, so the trade-off
-        # is acceptable. The post-success replay is purely diagnostic and
-        # non-load-bearing: it surfaces any informational stderr but no
-        # downstream logic depends on it, so it is intentionally not covered
-        # by a dedicated success-path stderr test.
         if ! datasets download genome taxon ${taxid} \\
             --assembly-source ${assembly_source} \\
             --include genome \\
@@ -36,9 +28,6 @@ process DOWNLOAD_VIRAL_GENOMES {
             --filename output.zip 2> dl_err.txt
         then
             cat dl_err.txt >&2
-            # Anchored single-line match is intentional: it pins the dispatch
-            # to the exact `datasets` error string. If a future release wraps
-            # or splits the message, this regex must be revisited.
             if grep -qE '^Error:.*no genome data is currently available for this taxon\\.\$' dl_err.txt; then
                 echo -e "${metadata_header}" > ${taxid}_metadata.tsv
                 echo "Taxon ${taxid} has no assemblies available; emitting empty outputs." >&2

--- a/modules/local/downloadViralGenomes/main.nf
+++ b/modules/local/downloadViralGenomes/main.nf
@@ -23,7 +23,10 @@ process DOWNLOAD_VIRAL_GENOMES {
         # post-call `cat dl_err.txt >&2` replays it for diagnostic visibility.
         # This defers stderr (vs. streaming live to .command.err) but the
         # `datasets download --dehydrated` step is short, so the trade-off
-        # is acceptable.
+        # is acceptable. The post-success replay is purely diagnostic and
+        # non-load-bearing: it surfaces any informational stderr but no
+        # downstream logic depends on it, so it is intentionally not covered
+        # by a dedicated success-path stderr test.
         if ! datasets download genome taxon ${taxid} \\
             --assembly-source ${assembly_source} \\
             --include genome \\

--- a/modules/local/downloadViralGenomes/main.nf
+++ b/modules/local/downloadViralGenomes/main.nf
@@ -14,6 +14,8 @@ process DOWNLOAD_VIRAL_GENOMES {
         // Header schema for ${taxid}_metadata.tsv
         def metadata_header = "assembly_accession\\ttaxid\\torganism_name\\tsource_database"
         """
+        trap 'rm -f dl_err.txt' EXIT
+
         # 1. Download dehydrated package (metadata + manifest only).
         # NCBI's taxonomy can include taxa without assemblies,
         # so catch and emit empty outputs instead of failing.
@@ -26,18 +28,17 @@ process DOWNLOAD_VIRAL_GENOMES {
             --filename output.zip 2> dl_err.txt
         then
             cat dl_err.txt >&2
+            # Anchored single-line match is intentional: it pins the dispatch
+            # to the exact `datasets` error string. If a future release wraps
+            # or splits the message, this regex must be revisited.
             if grep -qE '^Error:.*no genome data is currently available for this taxon\\.\$' dl_err.txt; then
-                mkdir -p ${taxid}_genomes
-                printf '${metadata_header}\\n' > ${taxid}_metadata.tsv
+                echo -e "${metadata_header}" > ${taxid}_metadata.tsv
                 echo "Taxon ${taxid} has no assemblies available; emitting empty outputs." >&2
-                rm -f dl_err.txt
                 exit 0
             fi
-            rm -f dl_err.txt
             exit 1
         fi
         cat dl_err.txt >&2
-        rm -f dl_err.txt
         unzip -o output.zip -d output/
 
         # 2. Rehydrate: download actual genome files with retry and exponential backoff

--- a/tests/configs/empty_taxon.config
+++ b/tests/configs/empty_taxon.config
@@ -1,13 +1,13 @@
 /*
 ========================================================================================
     Test config for the empty-taxon success path of DOWNLOAD_VIRAL_GENOMES.
-    
+
     Mounts a stubbed `datasets` CLI into the container based on the `ncbi_datasets` image
     in `configs/containers.config`, replacing the real binary at /opt/conda/bin/datasets.
-    
+
     The stub exits non-zero with the same error that NCBI returns for a valid taxon with
     no linked assemblies.
-    
+
     If a future image changes the binary path, the `empty_taxon` test would fail because
     the stub would not replace the real `datasets` binary, which would fail with an error
     like `Error: The taxonomy name 'taxid-with-no-assemblies' is not recognized.`

--- a/tests/configs/empty_taxon.config
+++ b/tests/configs/empty_taxon.config
@@ -1,0 +1,22 @@
+/*
+========================================================================================
+    Test config for the empty-taxon path of DOWNLOAD_VIRAL_GENOMES.
+    Bind-mounts a stubbed `datasets` CLI into the container and prepends it
+    to PATH. The stub exits 1 with the same stderr signature NCBI emits
+    when a taxon has no assemblies linked, exercising the module's
+    "emit empty outputs" branch without depending on which taxa happen to
+    be empty in the live NCBI taxonomy.
+========================================================================================
+*/
+
+includeConfig "index.config"
+
+process {
+    withName: DOWNLOAD_VIRAL_GENOMES {
+        // Bind-mount the stub directly over the real `datasets` binary inside
+        // the container. We can't use beforeScript + PATH because beforeScript
+        // runs on the host (in the docker-launching wrapper), not inside the
+        // container.
+        containerOptions = "-v ${projectDir}/tests/modules/local/downloadViralGenomes/stub_bin/datasets:/opt/conda/bin/datasets:ro"
+    }
+}

--- a/tests/configs/empty_taxon.config
+++ b/tests/configs/empty_taxon.config
@@ -1,10 +1,9 @@
 /*
 ========================================================================================
-    Test config for failure paths of DOWNLOAD_VIRAL_GENOMES.
+    Test config for the empty-taxon success path of DOWNLOAD_VIRAL_GENOMES.
     Mounts a stubbed `datasets` CLI into the container, replacing the real
-    binary at /opt/conda/bin/datasets. The stub exists non-zero to simulate
-    a true process error as well as the handled special case where no assemblies
-    exist for a given taxon.
+    binary at /opt/conda/bin/datasets. The stub exits non-zero the same error
+    that NCBI returns for a valid taxon with no linked assemblies.
 ========================================================================================
 */
 
@@ -13,9 +12,9 @@ includeConfig "index.config"
 process {
     withName: DOWNLOAD_VIRAL_GENOMES {
         // Replace the real `datasets` binary in the container with the stub,
-        // based on the binary path in the `ncbi_datasets` image pinned in 
+        // based on the binary path in the `ncbi_datasets` image pinned in
         // `configs/containers.config`.
-        // If a future image changes the binary path, both `empty_taxon` tests
+        // If a future image changes the binary path, the `empty_taxon` test
         // would fail because the `datasets` command would fail with an error like
         // `Error: The taxonomy ID '99999999' does not match any existing taxids for 'genome'`
         containerOptions = "-v ${projectDir}/tests/modules/local/downloadViralGenomes/stub_bin/datasets:/opt/conda/bin/datasets:ro"

--- a/tests/configs/empty_taxon.config
+++ b/tests/configs/empty_taxon.config
@@ -14,11 +14,10 @@ process {
     withName: DOWNLOAD_VIRAL_GENOMES {
         // Replace the real `datasets` binary in the container with the stub,
         // based on the binary path in the `ncbi_datasets` image pinned in 
-        // `configs/containers.config`. If a future image changes the binary path,
-        // the real` datasets` binary will instead be used. However, this
-        // regression would cause the `Should emit empty outputs when taxon has
-        // no assemblies` test to fail with an error like `Error: The taxonomy ID
-        // '99999999' does not match any existing taxids for 'genome`
+        // `configs/containers.config`.
+        // If a future image changes the binary path, both `empty_taxon` tests
+        // would fail because the `datasets` command would fail with an error like
+        // `Error: The taxonomy ID '99999999' does not match any existing taxids for 'genome'`
         containerOptions = "-v ${projectDir}/tests/modules/local/downloadViralGenomes/stub_bin/datasets:/opt/conda/bin/datasets:ro"
     }
 }

--- a/tests/configs/empty_taxon.config
+++ b/tests/configs/empty_taxon.config
@@ -1,11 +1,10 @@
 /*
 ========================================================================================
     Test config for failure paths of DOWNLOAD_VIRAL_GENOMES.
-    Bind-mounts a stubbed `datasets` CLI into the container, replacing the
-    real binary at /opt/conda/bin/datasets. The stub exits non-zero with one
-    of two stderr signatures (selected by taxid) so we can exercise both the
-    caught "emit empty outputs" branch and the "true failure" branch without
-    depending on which taxa happen to be empty in the live NCBI taxonomy.
+    Mounts a stubbed `datasets` CLI into the container, replacing the real
+    binary at /opt/conda/bin/datasets. The stub exists non-zero to simulate
+    a true process error as well as the handled special case where no assemblies
+    exist for a given taxon.
 ========================================================================================
 */
 
@@ -13,15 +12,13 @@ includeConfig "index.config"
 
 process {
     withName: DOWNLOAD_VIRAL_GENOMES {
-        // Bind-mount the stub directly over the real `datasets` binary inside
-        // the container. We can't use beforeScript + PATH because beforeScript
-        // runs on the host (in the docker-launching wrapper), not inside the
-        // container. The target path matches the `ncbi_datasets` image pinned
-        // in `configs/containers.config`; if that image is rebuilt with
-        // `datasets` at a different path, this mount becomes a no-op and the
-        // test will silently exercise the real CLI. The stub guards against
-        // that by emitting a unique `STUB_DATASETS_ARGV:` marker on stderr
-        // (visible in .command.err) when it is actually invoked.
+        // Replace the real `datasets` binary in the container with the stub,
+        // based on the binary path in the `ncbi_datasets` image pinned in 
+        // `configs/containers.config`. If a future image changes the binary path,
+        // the real` datasets` binary will instead be used. However, this
+        // regression would cause the `Should emit empty outputs when taxon has
+        // no assemblies` test to fail with an error like `Error: The taxonomy ID
+        // '99999999' does not match any existing taxids for 'genome`
         containerOptions = "-v ${projectDir}/tests/modules/local/downloadViralGenomes/stub_bin/datasets:/opt/conda/bin/datasets:ro"
     }
 }

--- a/tests/configs/empty_taxon.config
+++ b/tests/configs/empty_taxon.config
@@ -1,9 +1,16 @@
 /*
 ========================================================================================
     Test config for the empty-taxon success path of DOWNLOAD_VIRAL_GENOMES.
-    Mounts a stubbed `datasets` CLI into the container, replacing the real
-    binary at /opt/conda/bin/datasets. The stub exits non-zero the same error
-    that NCBI returns for a valid taxon with no linked assemblies.
+    
+    Mounts a stubbed `datasets` CLI into the container based on the `ncbi_datasets` image
+    in `configs/containers.config`, replacing the real binary at /opt/conda/bin/datasets.
+    
+    The stub exits non-zero with the same error that NCBI returns for a valid taxon with
+    no linked assemblies.
+    
+    If a future image changes the binary path, the `empty_taxon` test would fail because
+    the stub would not replace the real `datasets` binary, which would fail with an error
+    like `Error: The taxonomy name 'taxid-with-no-assemblies' is not recognized.`
 ========================================================================================
 */
 
@@ -11,12 +18,7 @@ includeConfig "index.config"
 
 process {
     withName: DOWNLOAD_VIRAL_GENOMES {
-        // Replace the real `datasets` binary in the container with the stub,
-        // based on the binary path in the `ncbi_datasets` image pinned in
-        // `configs/containers.config`.
-        // If a future image changes the binary path, the `empty_taxon` test
-        // would fail because the `datasets` command would fail with an error like
-        // `Error: The taxonomy ID '99999999' does not match any existing taxids for 'genome'`
+        // Replace the real `datasets` binary in the container with the stub
         containerOptions = "-v ${projectDir}/tests/modules/local/downloadViralGenomes/stub_bin/datasets:/opt/conda/bin/datasets:ro"
     }
 }

--- a/tests/configs/empty_taxon.config
+++ b/tests/configs/empty_taxon.config
@@ -4,7 +4,7 @@
     Bind-mounts a stubbed `datasets` CLI into the container, replacing the
     real binary at /opt/conda/bin/datasets. The stub exits non-zero with one
     of two stderr signatures (selected by taxid) so we can exercise both the
-    "emit empty outputs" branch and the "fail loudly" branch without
+    caught "emit empty outputs" branch and the "true failure" branch without
     depending on which taxa happen to be empty in the live NCBI taxonomy.
 ========================================================================================
 */

--- a/tests/configs/empty_taxon.config
+++ b/tests/configs/empty_taxon.config
@@ -1,11 +1,11 @@
 /*
 ========================================================================================
-    Test config for the empty-taxon path of DOWNLOAD_VIRAL_GENOMES.
-    Bind-mounts a stubbed `datasets` CLI into the container and prepends it
-    to PATH. The stub exits 1 with the same stderr signature NCBI emits
-    when a taxon has no assemblies linked, exercising the module's
-    "emit empty outputs" branch without depending on which taxa happen to
-    be empty in the live NCBI taxonomy.
+    Test config for failure paths of DOWNLOAD_VIRAL_GENOMES.
+    Bind-mounts a stubbed `datasets` CLI into the container, replacing the
+    real binary at /opt/conda/bin/datasets. The stub exits non-zero with one
+    of two stderr signatures (selected by taxid) so we can exercise both the
+    "emit empty outputs" branch and the "fail loudly" branch without
+    depending on which taxa happen to be empty in the live NCBI taxonomy.
 ========================================================================================
 */
 
@@ -16,7 +16,12 @@ process {
         // Bind-mount the stub directly over the real `datasets` binary inside
         // the container. We can't use beforeScript + PATH because beforeScript
         // runs on the host (in the docker-launching wrapper), not inside the
-        // container.
+        // container. The target path matches the `ncbi_datasets` image pinned
+        // in `configs/containers.config`; if that image is rebuilt with
+        // `datasets` at a different path, this mount becomes a no-op and the
+        // test will silently exercise the real CLI. The stub guards against
+        // that by emitting a unique `STUB_DATASETS_ARGV:` marker on stderr
+        // (visible in .command.err) when it is actually invoked.
         containerOptions = "-v ${projectDir}/tests/modules/local/downloadViralGenomes/stub_bin/datasets:/opt/conda/bin/datasets:ro"
     }
 }

--- a/tests/modules/local/downloadViralGenomes/main.nf.test
+++ b/tests/modules/local/downloadViralGenomes/main.nf.test
@@ -31,13 +31,29 @@ nextflow_process {
         }
     }
 
-    // The two tests below share a stub `datasets` (see stub_bin/datasets) that
-    // selects its error message by the taxid it was invoked with:
-    //   - taxid 99999999 -> empty-taxon sentinel ("no genome data is currently
-    //                       available for this taxon.") that the module is
-    //                       expected to handle and then emit empty outputs for.
-    //   - taxid 88888888 -> generic "connection timeout" error that the module
-    //                       is expected to propagate as a failure.
+    test("Should fail on non-existent taxid") {
+        tag "expect_failed"
+        tag "empty_taxon"
+        config "tests/configs/index.config"
+        when {
+            params {}
+            process {
+                """
+                input[0] = "99999999"
+                input[1] = "refseq"
+                input[2] = ""
+                input[3] = 5
+                """
+            }
+        }
+        then {
+            assert process.failed
+            // Confirm the failure was the non-existent-taxid branch, not an
+            // unrelated failure.
+            assert process.errorReport.contains("does not match any existing taxids")
+        }
+    }
+
     test("Should emit empty outputs when taxon has no assemblies") {
         tag "expect_success"
         tag "empty_taxon"
@@ -50,7 +66,7 @@ nextflow_process {
             params {}
             process {
                 """
-                input[0] = "99999999"
+                input[0] = "taxid-with-no-assemblies"
                 input[1] = "refseq"
                 input[2] = ""
                 input[3] = 5
@@ -66,33 +82,6 @@ nextflow_process {
             def meta_lines = path(process.out.metadata[0]).readLines()
             assert meta_lines.size() == 1
             assert meta_lines[0].split("\t").toList() == ["assembly_accession", "taxid", "organism_name", "source_database"]
-        }
-    }
-
-    test("Should fail when datasets errors with a non-empty-taxon message") {
-        tag "expect_failed"
-        tag "empty_taxon"
-        // Same stubbed `datasets` as above, but invoked with a taxid that
-        // makes the stub emit a generic error instead of the empty-taxon
-        // sentinel. Guards against future loosening of the grep filter
-        // letting unrelated `datasets` failures slip through silently.
-        config "tests/configs/empty_taxon.config"
-        when {
-            params {}
-            process {
-                """
-                input[0] = "88888888"
-                input[1] = "refseq"
-                input[2] = ""
-                input[3] = 5
-                """
-            }
-        }
-        then {
-            assert process.failed
-            // Confirm the failure was the stub's generic-error branch, not an
-            // unrelated failure.
-            assert process.errorReport.contains("Error: connection timeout while contacting NCBI servers.")
         }
     }
 

--- a/tests/modules/local/downloadViralGenomes/main.nf.test
+++ b/tests/modules/local/downloadViralGenomes/main.nf.test
@@ -90,6 +90,9 @@ nextflow_process {
         }
         then {
             assert process.failed
+            // Confirm the failure was the stub's generic-error branch, not an
+            // unrelated failure.
+            assert process.errorReport.contains("Error: connection timeout while contacting NCBI servers.")
         }
     }
 

--- a/tests/modules/local/downloadViralGenomes/main.nf.test
+++ b/tests/modules/local/downloadViralGenomes/main.nf.test
@@ -62,4 +62,28 @@ nextflow_process {
         }
     }
 
+    test("Should fail when datasets errors with a non-empty-taxon message") {
+        tag "expect_failed"
+        tag "empty_taxon"
+        // Same stubbed `datasets` as above, but invoked with a taxid that
+        // makes the stub emit a generic error instead of the empty-taxon
+        // sentinel. Guards against future loosening of the grep filter
+        // letting unrelated `datasets` failures slip through silently.
+        config "tests/configs/empty_taxon.config"
+        when {
+            params {}
+            process {
+                """
+                input[0] = "88888888"
+                input[1] = "refseq"
+                input[2] = ""
+                input[3] = 5
+                """
+            }
+        }
+        then {
+            assert process.failed
+        }
+    }
+
 }

--- a/tests/modules/local/downloadViralGenomes/main.nf.test
+++ b/tests/modules/local/downloadViralGenomes/main.nf.test
@@ -33,7 +33,6 @@ nextflow_process {
 
     test("Should fail on non-existent taxid") {
         tag "expect_failed"
-        tag "empty_taxon"
         config "tests/configs/index.config"
         when {
             params {}

--- a/tests/modules/local/downloadViralGenomes/main.nf.test
+++ b/tests/modules/local/downloadViralGenomes/main.nf.test
@@ -35,7 +35,7 @@ nextflow_process {
     // selects its error message by the taxid it was invoked with:
     //   - taxid 99999999 -> empty-taxon sentinel ("no genome data is currently
     //                       available for this taxon.") that the module is
-    //                       expected to swallow into empty outputs.
+    //                       expected to handle and then emit empty outputs for.
     //   - taxid 88888888 -> generic "connection timeout" error that the module
     //                       is expected to propagate as a failure.
     test("Should emit empty outputs when taxon has no assemblies") {

--- a/tests/modules/local/downloadViralGenomes/main.nf.test
+++ b/tests/modules/local/downloadViralGenomes/main.nf.test
@@ -31,6 +31,13 @@ nextflow_process {
         }
     }
 
+    // The two tests below share a stub `datasets` (see stub_bin/datasets) that
+    // selects its error message by the taxid it was invoked with:
+    //   - taxid 99999999 -> empty-taxon sentinel ("no genome data is currently
+    //                       available for this taxon.") that the module is
+    //                       expected to swallow into empty outputs.
+    //   - taxid 88888888 -> generic "connection timeout" error that the module
+    //                       is expected to propagate as a failure.
     test("Should emit empty outputs when taxon has no assemblies") {
         tag "expect_success"
         tag "empty_taxon"

--- a/tests/modules/local/downloadViralGenomes/main.nf.test
+++ b/tests/modules/local/downloadViralGenomes/main.nf.test
@@ -73,6 +73,13 @@ nextflow_process {
             }
         }
         then {
+            // The stub returns the empty-taxon error string unconditionally,
+            // so the only way `process.success` can be true is via the
+            // dispatch branch that matches the regex and exits 0. Combined
+            // with the header-only metadata assertion below, this pins the
+            // test to the empty-taxon code path: any unrelated regression
+            // that produced no genomes would either fail (different exit)
+            // or emit a non-header-only metadata file.
             assert process.success
             // genomes is declared optional; no files should be emitted
             assert process.out.genomes.size() == 0

--- a/tests/modules/local/downloadViralGenomes/main.nf.test
+++ b/tests/modules/local/downloadViralGenomes/main.nf.test
@@ -31,4 +31,35 @@ nextflow_process {
         }
     }
 
+    test("Should emit empty outputs when taxon has no assemblies") {
+        tag "expect_success"
+        tag "empty_taxon"
+        // Uses a stubbed `datasets` (configured in empty_taxon.config) that
+        // emits the same stderr signature NCBI returns for a taxon with no
+        // linked assemblies. Avoids depending on a known-empty live taxid,
+        // which is unstable as NCBI propagates new taxonomy releases.
+        config "tests/configs/empty_taxon.config"
+        when {
+            params {}
+            process {
+                """
+                input[0] = "99999999"
+                input[1] = "refseq"
+                input[2] = ""
+                input[3] = 5
+                """
+            }
+        }
+        then {
+            assert process.success
+            // genomes is declared optional; no files should be emitted
+            assert process.out.genomes.size() == 0
+            // metadata should be header-only (TableWrapper reports empty when
+            // there are no data rows, so check lines directly)
+            def meta_lines = path(process.out.metadata[0]).readLines()
+            assert meta_lines.size() == 1
+            assert meta_lines[0].split("\t").toList() == ["assembly_accession", "taxid", "organism_name", "source_database"]
+        }
+    }
+
 }

--- a/tests/modules/local/downloadViralGenomes/stub_bin/datasets
+++ b/tests/modules/local/downloadViralGenomes/stub_bin/datasets
@@ -9,6 +9,9 @@
 #                 to propagate this as a process failure.
 # Argv is echoed back on stderr so a path drift (the bind mount missing the
 # real `datasets` binary) shows up in `.command.err` for debugging.
+# Additionally, the `Should emit empty outputs when taxon has no assemblies` test
+# would fail in that case since the stub will fail to overwrite the `datasets` binary
+# with an error like `Error: The taxonomy ID '99999999' does not match any existing taxids for 'genome`.
 
 echo "STUB_DATASETS_ARGV: $*" >&2
 

--- a/tests/modules/local/downloadViralGenomes/stub_bin/datasets
+++ b/tests/modules/local/downloadViralGenomes/stub_bin/datasets
@@ -8,13 +8,16 @@
 echo "STUB_DATASETS_ARGV: $*" >&2
 
 taxid=""
-prev=""
-for arg in "$@"; do
-    if [ "$prev" = "taxon" ]; then
-        taxid="$arg"
-        break
-    fi
-    prev="$arg"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        taxon)
+            taxid="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
 done
 
 case "$taxid" in

--- a/tests/modules/local/downloadViralGenomes/stub_bin/datasets
+++ b/tests/modules/local/downloadViralGenomes/stub_bin/datasets
@@ -1,5 +1,33 @@
 #!/bin/bash
-# Stub for testing the empty-taxon path of DOWNLOAD_VIRAL_GENOMES. Always exits
-# with the same stderr signature NCBI emits when a taxon has no assemblies.
-echo "Error: The taxonomy ID 'TEST' is valid for 'TestEmpty', but no genome data is currently available for this taxon." >&2
+# Stub for testing DOWNLOAD_VIRAL_GENOMES failure paths. Behavior is selected
+# by the taxid argument so a single config can drive both happy- and
+# negative-failure tests:
+#   - 99999999 -> emits the "no genome data" sentinel NCBI returns when a
+#                 taxon has no linked assemblies. The module is expected to
+#                 swallow this and emit empty outputs.
+#   - 88888888 -> emits a generic, non-sentinel error. The module is expected
+#                 to propagate this as a process failure.
+# Argv is echoed back on stderr so a path drift (the bind mount missing the
+# real `datasets` binary) shows up in `.command.err` for debugging.
+
+echo "STUB_DATASETS_ARGV: $*" >&2
+
+taxid=""
+prev=""
+for arg in "$@"; do
+    if [ "$prev" = "taxon" ]; then
+        taxid="$arg"
+        break
+    fi
+    prev="$arg"
+done
+
+case "$taxid" in
+    88888888)
+        echo "Error: connection timeout while contacting NCBI servers." >&2
+        ;;
+    *)
+        echo "Error: The taxonomy ID 'TEST' is valid for 'TestEmpty', but no genome data is currently available for this taxon." >&2
+        ;;
+esac
 exit 1

--- a/tests/modules/local/downloadViralGenomes/stub_bin/datasets
+++ b/tests/modules/local/downloadViralGenomes/stub_bin/datasets
@@ -1,12 +1,12 @@
 #!/bin/bash
-# Stub for testing DOWNLOAD_VIRAL_GENOMES failure paths. Behavior is selected
-# by the taxid argument so a single config can drive both happy- and
-# negative-failure tests:
-#   - 99999999 -> emits the "no genome data" sentinel NCBI returns when a
-#                 taxon has no linked assemblies. The module is expected to
-#                 handle this and emit empty outputs.
-#   - 88888888 -> emits a generic, non-sentinel error. The module is expected
-#                 to propagate this as a process failure.
+# Stub for testing the DOWNLOAD_VIRAL_GENOMES empty-taxon success path, since
+# reproducing the empty-taxon error ("no genome data is currently available
+# for this taxon.") with a real live taxid is unstable.
+#
+# Behavior is selected by the taxid argument:
+#   - 99999999 -> emits the empty-taxon "no genome data" error
+#                 NCBI returns when a taxon has no linked assemblies.
+#                 The module should handle this and emit empty outputs.
 
 # Echo argv to stderr changes to the `datasets` binary path are
 # visible in `.command.err` for debugging.
@@ -23,12 +23,8 @@ for arg in "$@"; do
 done
 
 case "$taxid" in
-    99999999)
-        echo "Error: The taxonomy ID 'TEST' is valid for 'TestEmpty', but no genome data is currently available for this taxon." >&2
-        exit 1
-        ;;
-    88888888)
-        echo "Error: connection timeout while contacting NCBI servers." >&2
+    taxid-with-no-assemblies)
+        echo "Error: The taxonomy ID 'taxid-with-no-assemblies' is valid for 'TestEmpty', but no genome data is currently available for this taxon." >&2
         exit 1
         ;;
     *)

--- a/tests/modules/local/downloadViralGenomes/stub_bin/datasets
+++ b/tests/modules/local/downloadViralGenomes/stub_bin/datasets
@@ -23,11 +23,18 @@ for arg in "$@"; do
 done
 
 case "$taxid" in
+    99999999)
+        echo "Error: The taxonomy ID 'TEST' is valid for 'TestEmpty', but no genome data is currently available for this taxon." >&2
+        exit 1
+        ;;
     88888888)
         echo "Error: connection timeout while contacting NCBI servers." >&2
+        exit 1
         ;;
     *)
-        echo "Error: The taxonomy ID 'TEST' is valid for 'TestEmpty', but no genome data is currently available for this taxon." >&2
+        # Force an explicit branch decision for any new test taxid: silently
+        # falling through to the empty-taxon sentinel would mis-cover tests.
+        echo "stub: unrecognized taxid '$taxid' — add an explicit case arm" >&2
+        exit 2
         ;;
 esac
-exit 1

--- a/tests/modules/local/downloadViralGenomes/stub_bin/datasets
+++ b/tests/modules/local/downloadViralGenomes/stub_bin/datasets
@@ -3,7 +3,7 @@
 # reproducing the empty-taxon error ("no genome data is currently available
 # for this taxon.") with a real live taxid is unstable.
 
-# Echo argv to stderr changes to the `datasets` binary path are
+# Echo argv to stderr so that changes to the `datasets` binary path are
 # visible in `.command.err` for debugging.
 echo "STUB_DATASETS_ARGV: $*" >&2
 
@@ -25,7 +25,7 @@ case "$taxid" in
     *)
         # Force an explicit branch decision for any new test taxid: silently
         # falling through to the empty-taxon sentinel would mis-cover tests.
-        echo "stub: unrecognized taxid '$taxid' — add an explicit case arm" >&2
+        echo "stub: unrecognized taxid '$taxid' -- add an explicit case arm" >&2
         exit 2
         ;;
 esac

--- a/tests/modules/local/downloadViralGenomes/stub_bin/datasets
+++ b/tests/modules/local/downloadViralGenomes/stub_bin/datasets
@@ -7,12 +7,9 @@
 #                 handle this and emit empty outputs.
 #   - 88888888 -> emits a generic, non-sentinel error. The module is expected
 #                 to propagate this as a process failure.
-# Argv is echoed back on stderr so a path drift (the bind mount missing the
-# real `datasets` binary) shows up in `.command.err` for debugging.
-# Additionally, the `Should emit empty outputs when taxon has no assemblies` test
-# would fail in that case since the stub will fail to overwrite the `datasets` binary
-# with an error like `Error: The taxonomy ID '99999999' does not match any existing taxids for 'genome`.
 
+# Echo argv to stderr changes to the `datasets` binary path are
+# visible in `.command.err` for debugging.
 echo "STUB_DATASETS_ARGV: $*" >&2
 
 taxid=""

--- a/tests/modules/local/downloadViralGenomes/stub_bin/datasets
+++ b/tests/modules/local/downloadViralGenomes/stub_bin/datasets
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Stub for testing the empty-taxon path of DOWNLOAD_VIRAL_GENOMES. Always exits
+# with the same stderr signature NCBI emits when a taxon has no assemblies.
+echo "Error: The taxonomy ID 'TEST' is valid for 'TestEmpty', but no genome data is currently available for this taxon." >&2
+exit 1

--- a/tests/modules/local/downloadViralGenomes/stub_bin/datasets
+++ b/tests/modules/local/downloadViralGenomes/stub_bin/datasets
@@ -2,11 +2,6 @@
 # Stub for testing the DOWNLOAD_VIRAL_GENOMES empty-taxon success path, since
 # reproducing the empty-taxon error ("no genome data is currently available
 # for this taxon.") with a real live taxid is unstable.
-#
-# Behavior is selected by the taxid argument:
-#   - 99999999 -> emits the empty-taxon "no genome data" error
-#                 NCBI returns when a taxon has no linked assemblies.
-#                 The module should handle this and emit empty outputs.
 
 # Echo argv to stderr changes to the `datasets` binary path are
 # visible in `.command.err` for debugging.

--- a/tests/modules/local/downloadViralGenomes/stub_bin/datasets
+++ b/tests/modules/local/downloadViralGenomes/stub_bin/datasets
@@ -4,7 +4,7 @@
 # negative-failure tests:
 #   - 99999999 -> emits the "no genome data" sentinel NCBI returns when a
 #                 taxon has no linked assemblies. The module is expected to
-#                 swallow this and emit empty outputs.
+#                 handle this and emit empty outputs.
 #   - 88888888 -> emits a generic, non-sentinel error. The module is expected
 #                 to propagate this as a process failure.
 # Argv is echoed back on stderr so a path drift (the bind mount missing the


### PR DESCRIPTION
Make `DOWNLOAD_VIRAL_GENOMES` robust to taxa rooted at Viruses (10239) without assemblies, emitting a header-only `${taxid}_metadata.tsv` and exiting 0. This requires declaring `${taxid}_genomes/` as an optional output.

Chained off #740 

Closes [COMP-1896](https://linear.app/securebio-nao/issue/COMP-1896/cd-index-fails-when-a-newly-published-viral-taxon-has-no-assemblies)

## Context
- In [makeVirusGenomeDB](https://github.com/securebio/nao-mgs-workflow/blob/main/subworkflows/local/makeVirusGenomeDB/main.nf), we enumerate all child taxa of the Viruses taxon (10239) and download all genomes for each in parallel. If any one of these child taxa has no assemblies, the process errors out.
- NCBI publishes new viral taxa to its taxonomy before assemblies are linked to them, causing `datasets download genome taxon <taxid>` to exit 1 with `Error: ... no genome data is currently available for this taxon.`
- Adding these taxa to [`viral_taxids_exclude_hard`](https://github.com/securebio/nao-mgs-workflow/blob/main/configs/index.config#L40) would not work since this parameter has no effect on which taxa get downloaded and is only passed to `MAKE_VIRUS_TAXONOMY_DB`.

## Reproducing example
- `datasets download genome taxon 3700704` fails with `Error: The taxonomy ID '3700704' is valid for 'Yamazakiviridae', but no genome data is currently available for this taxon.`
  - This taxon is rooted at Viruses.
  - As of 2026-04-29, this taxon and its children have no assemblies (but there are some GenBank nucleotide records like [PQ111734.1](https://www.ncbi.nlm.nih.gov/nuccore/PQ111734.1)).

## Detailed changes
- Added a new test for the empty-taxon path using a stub `datasets` that exits 1 with a hardcoded NCBI error string.
  - Spoofing the error message risks the test passing even if the `datasets` CLI message drifts, but it has been stable across all releases and a public nf-core repo [here](https://github.com/nf-core/pathogensurveillance/blob/master/modules/local/find_assemblies/main.nf#L28) greps on the same string.
  - If the `datasets` path changes in the container we're using and the stub no longer overrides it, the `empty_taxon`-tagged test should fail, catching any drift there.

Generated with [Claude Code](https://claude.com/claude-code)