### PR TITLE
Temporarily ignore Trivy scan CVE-2026-41989 (libgcrypt20)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -71,6 +71,13 @@ CVE-2026-40192 exp:2026-06-30
 # Our containers don't perform attacker-controlled iconv conversions.
 CVE-2026-4046 exp:2026-06-30
 
+# libgcrypt20: heap overflow / DoS via crafted ECDH ciphertext to gcry_pk_decrypt
+# (no Debian fix available as of 2026-04-29; fixed in upstream libgcrypt >= 1.12.2)
+# Our pipeline containers never decrypt attacker-controlled ECDH ciphertext.
+# Check for a Debian fix at:
+#   https://security-tracker.debian.org/tracker/CVE-2026-41989
+CVE-2026-41989 exp:2026-06-30
+
 # ncurses: stack-based buffer overflow in infocmp CLI tool (no-dsa, low urgency)
 # Our containers never invoke infocmp. Fix only in sid (6.6+).
 CVE-2025-69720 exp:2026-06-30

--- a/.trivyignore
+++ b/.trivyignore
@@ -71,13 +71,6 @@ CVE-2026-40192 exp:2026-06-30
 # Our containers don't perform attacker-controlled iconv conversions.
 CVE-2026-4046 exp:2026-06-30
 
-# libgcrypt20: heap overflow / DoS via crafted ECDH ciphertext to gcry_pk_decrypt
-# (no Debian fix available as of 2026-04-29; fixed in upstream libgcrypt >= 1.12.2)
-# Our pipeline containers never decrypt attacker-controlled ECDH ciphertext.
-# Check for a Debian fix at:
-#   https://security-tracker.debian.org/tracker/CVE-2026-41989
-CVE-2026-41989 exp:2026-06-30
-
 # ncurses: stack-based buffer overflow in infocmp CLI tool (no-dsa, low urgency)
 # Our containers never invoke infocmp. Fix only in sid (6.6+).
 CVE-2025-69720 exp:2026-06-30
@@ -85,3 +78,10 @@ CVE-2025-69720 exp:2026-06-30
 # systemd: IPC API mishandling from unprivileged callers causing service freeze
 # Our containers don't run systemd services. Fix only in sid (260.1+).
 CVE-2026-29111 exp:2026-06-30
+
+# libgcrypt20: heap overflow / DoS via crafted ECDH ciphertext to gcry_pk_decrypt
+# (no Debian fix available as of 2026-04-29; fixed in upstream libgcrypt >= 1.12.2)
+# Our pipeline containers never decrypt attacker-controlled ECDH ciphertext.
+# Check for a Debian fix at:
+#   https://security-tracker.debian.org/tracker/CVE-2026-41989
+CVE-2026-41989 exp:2026-06-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v3.2.1.4-dev
 
+- Add CVE-2026-41989 (libgcrypt20) to `.trivyignore`; no Debian fix available and not exercised by our pipeline.
 - Prevent `MASK_FASTQ_READS` from running out of memory on merged ONT libraries larger than ~6 GB of gzipped FASTQ (#737).
     - Replaces `label "large"` with a new `label "bbmask_resources"` whose `memory` directive is an input-size-aware closure (32 / 64 / 128 GiB tiers, chosen from input byte size). The label and its closure live in `configs/resources.config` alongside other resource labels; the module itself stays label-only. CPU allocation unchanged at 16.
     - Tier-selection logic is a generic `ResourceTierUtils.pickMemoryTier(input, thresholds, memories)` helper declared at the top of `configs/resources.config`. The class lives in the config file (rather than `lib/*.groovy`) because Nextflow's `lib/` auto-loading puts classes on the script classpath but not the config classpath; config-scope `memory = { … }` closures can't resolve `lib/` classes.


### PR DESCRIPTION
Temporarily ignore [CVE-2026-41989](https://security-tracker.debian.org/tracker/CVE-2026-41989) in `libgcrypt20 1.10.1-3`, which affects the `debian-bookworm` build our `mambaorg/micromamba` base image is built on. No upstream fix currently exists and our pipeline containers never decrypt attacker-controlled ECDH ciphertext. Therefore, a temporary ignore is appropriate.

#738 is chained off this PR

Resolves COMP-1898. 

Generated with [Claude Code](https://claude.com/claude-code)