### PR TITLE
Clean up all Ruff violations across Python codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
     - Fix all ten `B904` violations by chaining (`raise ... from e`, 4 cases in ECR build error paths) or suppressing (`raise ... from None`, 6 cases in generic-sentinel wrappers) exceptions raised in `except` blocks. This slightly changes the formatting of tracebacks when these errors are raised.
     - Restructure `open_by_suffix` to silence `SIM115`, rename ambiguous loop var `l` to `line` (`E741`), and apply mechanical cleanups for nested `with`/`if` blocks and unused loop variables.
     - Fix a latent bug in `bin/prepare_tiny_test_data.py`: `s3_uri.lstrip("s3://")` (which treats the argument as a character set) replaced with `removeprefix("s3://")` (`B005`).
+    - Switch all `zip(..., strict=False)` calls (added by the `B905` autofix to preserve historical behaviour) to `strict=True` after auditing each site. All eight call sites zip iterables that are guaranteed equal-length by construction (paired R1/R2 FASTQ records, columns of a single DataFrame, statically-equal lists, etc.), so this converts a silent-truncation failure mode into a loud `ValueError` if the invariant ever drifts.
 
 # v3.2.1.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
     - Restructure helper closures in `loadDownstreamData` and `clusterViralAssignments` to avoid top-level statements: in `loadDownstreamData`, convert the local `resolvePath`/`resolveDir` closures into top-level `def fn(...)` functions taking `input_base_dir` as an explicit parameter; in `clusterViralAssignments`, move the `listFiles` helper inside the workflow's `main:` block as a local closure.
     - Drop the unused `start_time_str` parameter from `PREPARE_INPUT_LOGGING` (and its argument at the RUN call site); prefix the unused `sample` closure parameter in `splitViralTsvBySelectedTaxid` with `_`.
     - Use `sentinel_ch.sentinel` rather than `WRITE_SENTINEL_RUN.out.sentinel` in `workflows/run.nf:54` so the assigned variable is referenced.
+- Clean up Python code to satisfy the configured Ruff lint rules across `bin/`, `modules/local/**/resources/usr/bin/`, and `post-processing/tests/`, in preparation for enabling Ruff in CI in read-only mode. No behavioral changes to any pipeline module.
+    - Apply a one-time `ruff format` sweep and `ruff check --fix`/`--unsafe-fixes` autofixes across ~88 Python files (import sorting, quote normalization, line wrapping, dropping superfluous `else` after `return`, modernizing `Optional[X]` to `X | None`, `typing.List` to `list`, `datetime.timezone.utc` to `datetime.UTC`, etc.).
+    - Drop `COM` (trailing-comma) from `lint.select` in `pyproject.toml` for compatibility with `ruff format`, and add `.nf-test`, `tmp`, `.venv`, `post-processing/deps`, and `test-data/tiny-index/output/logging` to the Ruff exclude list.
+    - Fix all ten `B904` violations by chaining (`raise ... from e`, 4 cases in ECR build error paths) or suppressing (`raise ... from None`, 6 cases in generic-sentinel wrappers) exceptions raised in `except` blocks. This slightly changes the formatting of tracebacks when these errors are raised.
+    - Restructure `open_by_suffix` to silence `SIM115`, rename ambiguous loop var `l` to `line` (`E741`), and apply mechanical cleanups for nested `with`/`if` blocks and unused loop variables.
+    - Fix a latent bug in `bin/prepare_tiny_test_data.py`: `s3_uri.lstrip("s3://")` (which treats the argument as a character set) replaced with `removeprefix("s3://")` (`B005`).
 
 # v3.2.1.4
 

--- a/bin/analyze-pipeline.py
+++ b/bin/analyze-pipeline.py
@@ -143,7 +143,7 @@ class NextflowAnalyzer:
 
     def _analyze_dependencies(self) -> None:
         """Extract dependencies from workflows in pipeline."""
-        for workflow_name in self.workflows.keys():
+        for workflow_name in self.workflows:
             workflow = self.workflows[workflow_name]
             self.workflow_dependencies[workflow.name] = {
                 "modules": set(),
@@ -192,21 +192,17 @@ class NextflowAnalyzer:
         used_modules, used_processes, used_workflows = self._extract_dependencies(
             "main", set(), set(), set()
         )
-        unused_modules = {
-            name for name in self.modules.keys() if name not in used_modules
-        }
+        unused_modules = {name for name in self.modules if name not in used_modules}
         unused_workflows = {
-            name for name in self.workflows.keys() if name not in used_workflows
+            name for name in self.workflows if name not in used_workflows
         }
         unused_processes = {
-            name
-            for name in self.standalone_processes.keys()
-            if name not in used_processes
+            name for name in self.standalone_processes if name not in used_processes
         }
-        for module_name in self.modules.keys():
+        for module_name in self.modules:
             module = self.modules[module_name]
             unused_processes.update(
-                [name for name in module.processes.keys() if name not in used_processes]
+                [name for name in module.processes if name not in used_processes]
             )
         self.unused_components["modules"] = unused_modules
         self.unused_components["workflows"] = unused_workflows
@@ -326,7 +322,7 @@ def report_workflows(analyzer: NextflowAnalyzer, output_stream: TextIO) -> None:
         # Collate workflows that call this one
         called_by = [
             wf
-            for wf in analyzer.workflow_dependencies.keys()
+            for wf in analyzer.workflow_dependencies
             if name in analyzer.workflow_dependencies[wf]["workflows"]
         ]
         if called_by:
@@ -355,7 +351,7 @@ def report_modules(analyzer: NextflowAnalyzer, output_stream: TextIO) -> None:
         # Processes in module
         if module.processes:
             output_stream.write("Contains processes:\n")
-            for proc_name, process in sorted(module.processes.items()):
+            for proc_name, _process in sorted(module.processes.items()):
                 usage_status = (
                     " (UNUSED)"
                     if proc_name in analyzer.unused_components["processes"]
@@ -367,7 +363,7 @@ def report_modules(analyzer: NextflowAnalyzer, output_stream: TextIO) -> None:
         # Parent workflows
         called_by = [
             workflow
-            for workflow in analyzer.workflow_dependencies.keys()
+            for workflow in analyzer.workflow_dependencies
             if name in analyzer.workflow_dependencies[workflow]["modules"]
         ]
         if called_by:
@@ -398,7 +394,7 @@ def report_standalone_processes(
         # Parent workflows
         called_by = [
             workflow
-            for workflow in analyzer.workflow_dependencies.keys()
+            for workflow in analyzer.workflow_dependencies
             if name in analyzer.workflow_dependencies[workflow]["processes"]
         ]
         if called_by:

--- a/bin/analyze-pipeline.py
+++ b/bin/analyze-pipeline.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-#=============================================================================
+# =============================================================================
 # Imports
-#=============================================================================
+# =============================================================================
 
 import os
 import re
@@ -12,9 +12,10 @@ from pathlib import Path
 from typing import IO, TextIO
 from dataclasses import dataclass, field
 
-#=============================================================================
+# =============================================================================
 # Dataclasses
-#=============================================================================
+# =============================================================================
+
 
 @dataclass
 class Process:
@@ -24,11 +25,13 @@ class Process:
     module_name: str | None = None
     testing_only: bool = False
 
+
 @dataclass
 class Module:
     name: str
     path: Path
-    processes: dict[str, Process] = field(default_factory = dict)
+    processes: dict[str, Process] = field(default_factory=dict)
+
 
 @dataclass
 class Workflow:
@@ -36,12 +39,13 @@ class Workflow:
     file_path: Path
     is_anonymous: bool = False
 
-#=============================================================================
+
+# =============================================================================
 # Main class
-#=============================================================================
+# =============================================================================
+
 
 class NextflowAnalyzer:
-
     def __init__(self, pipeline_dir: str):
         # Directories
         self.pipeline_dir = Path(pipeline_dir)
@@ -70,23 +74,33 @@ class NextflowAnalyzer:
         # First check for main.nf in root directory
         main_nf = self.pipeline_dir / "main.nf"
         if main_nf.exists():
-            self.workflows["main"] = Workflow(name="main", file_path=main_nf, is_anonymous=True)
+            self.workflows["main"] = Workflow(
+                name="main", file_path=main_nf, is_anonymous=True
+            )
         # Scan workflows directory
         if self.workflow_dir.exists():
             for workflow_file in self.workflow_dir.rglob("*.nf"):
                 with open(workflow_file) as f:
                     content = f.read()
-                if re.search(r'workflow\s*{', content): # No anonymous workflows except main
-                    raise ValueError(f"Unexpected anonymous workflow in file: {workflow_file}")
-                workflow_matches = re.finditer(r'workflow\s+(\w+)\s*{', content)
+                if re.search(
+                    r"workflow\s*{", content
+                ):  # No anonymous workflows except main
+                    raise ValueError(
+                        f"Unexpected anonymous workflow in file: {workflow_file}"
+                    )
+                workflow_matches = re.finditer(r"workflow\s+(\w+)\s*{", content)
                 for match in workflow_matches:
                     workflow_name = match.group(1)
-                    self.workflows[workflow_name] = Workflow(name=workflow_name, file_path = workflow_file)
+                    self.workflows[workflow_name] = Workflow(
+                        name=workflow_name, file_path=workflow_file
+                    )
         # Scan subworkflows directory
         if self.subworkflow_dir.exists():
             for subworkflow_path in self.subworkflow_dir.glob("**/main.nf"):
                 subworkflow_name = subworkflow_path.parent.name
-                self.workflows[subworkflow_name] = Workflow(name=subworkflow_name, file_path = subworkflow_path)
+                self.workflows[subworkflow_name] = Workflow(
+                    name=subworkflow_name, file_path=subworkflow_path
+                )
         # Scan modules directory
         if self.module_dir.exists():
             for module_path in self.module_dir.glob("**/main.nf"):
@@ -95,12 +109,16 @@ class NextflowAnalyzer:
                 self._scan_file_for_processes(module_path, module_name)
         # Scan for standalone processes (excluding modules and workflows directories)
         for file_path in self.pipeline_dir.rglob("*.nf"):
-            if ("modules/local" not in str(file_path) and
-                "workflows" not in str(file_path) and
-                file_path != main_nf):
+            if (
+                "modules/local" not in str(file_path)
+                and "workflows" not in str(file_path)
+                and file_path != main_nf
+            ):
                 self._scan_file_for_processes(file_path)
 
-    def _scan_file_for_processes(self, file_path: Path, module_name: str | None = None) -> None:
+    def _scan_file_for_processes(
+        self, file_path: Path, module_name: str | None = None
+    ) -> None:
         """Scan a file for process definitions."""
         with open(file_path) as f:
             content = f.read()
@@ -108,12 +126,16 @@ class NextflowAnalyzer:
         has_testing_only = bool(re.search(r'label\s+"testing_only"', content))
 
         for line_num, line in enumerate(content.splitlines(), 1):
-            process_match = re.search(r'process\s+(\w+)\s*{', line)
+            process_match = re.search(r"process\s+(\w+)\s*{", line)
             if process_match:
                 process_name = process_match.group(1)
-                process = Process(name=process_name, file_path=file_path,
-                                  line_number=line_num, module_name=module_name,
-                                  testing_only=has_testing_only)
+                process = Process(
+                    name=process_name,
+                    file_path=file_path,
+                    line_number=line_num,
+                    module_name=module_name,
+                    testing_only=has_testing_only,
+                )
                 if module_name:
                     self.modules[module_name].processes[process_name] = process
                 else:
@@ -124,55 +146,87 @@ class NextflowAnalyzer:
         for workflow_name in self.workflows.keys():
             workflow = self.workflows[workflow_name]
             self.workflow_dependencies[workflow.name] = {
-                    "modules": set(),
-                    "processes": set(),
-                    "workflows": set()
-                    }
+                "modules": set(),
+                "processes": set(),
+                "workflows": set(),
+            }
             with open(workflow.file_path) as f:
                 content = f.read()
-                depend_matches = re.finditer(r'\s*include\s+{\s*(\S*).*}\s+from\s+[\'"](\S*)[\'"]\s*', content)
+                depend_matches = re.finditer(
+                    r'\s*include\s+{\s*(\S*).*}\s+from\s+[\'"](\S*)[\'"]\s*', content
+                )
                 for match in depend_matches:
                     item = match.group(1)
                     # Handle "FOO as BAR" - extract the original name before "as"
-                    original_name = item.split(' as ')[0].strip() if ' as ' in item else item
-                    full_path = match.group(2).rstrip('/')
+                    original_name = (
+                        item.split(" as ")[0].strip() if " as " in item else item
+                    )
+                    full_path = match.group(2).rstrip("/")
                     # Split into dirpath and parent
-                    parts = full_path.rsplit('/', 1)
+                    parts = full_path.rsplit("/", 1)
                     if len(parts) == 2:
                         dirpath, parent = parts
                     else:
-                        dirpath = ''
+                        dirpath = ""
                         parent = parts[0]
                     if re.search("/workflows", dirpath):
-                        self.workflow_dependencies[workflow_name]["workflows"].add(original_name)
+                        self.workflow_dependencies[workflow_name]["workflows"].add(
+                            original_name
+                        )
                     elif re.search("/subworkflows/local", dirpath):
-                        self.workflow_dependencies[workflow_name]["workflows"].add(parent)
+                        self.workflow_dependencies[workflow_name]["workflows"].add(
+                            parent
+                        )
                     elif re.search("/modules/local", dirpath):
                         self.workflow_dependencies[workflow_name]["modules"].add(parent)
-                        self.workflow_dependencies[workflow_name]["processes"].add(original_name)
+                        self.workflow_dependencies[workflow_name]["processes"].add(
+                            original_name
+                        )
                     else:
-                        self.workflow_dependencies[workflow_name]["processes"].add(original_name)
+                        self.workflow_dependencies[workflow_name]["processes"].add(
+                            original_name
+                        )
 
     def _find_unused_components(self) -> None:
         """Identify modules, processes and workflows that aren't called within the main workflow."""
-        used_modules, used_processes, used_workflows = self._extract_dependencies("main", set(), set(), set())
-        unused_modules   = {name for name in self.modules.keys() if name not in used_modules}
-        unused_workflows = {name for name in self.workflows.keys() if name not in used_workflows}
-        unused_processes = {name for name in self.standalone_processes.keys() if name not in used_processes}
+        used_modules, used_processes, used_workflows = self._extract_dependencies(
+            "main", set(), set(), set()
+        )
+        unused_modules = {
+            name for name in self.modules.keys() if name not in used_modules
+        }
+        unused_workflows = {
+            name for name in self.workflows.keys() if name not in used_workflows
+        }
+        unused_processes = {
+            name
+            for name in self.standalone_processes.keys()
+            if name not in used_processes
+        }
         for module_name in self.modules.keys():
             module = self.modules[module_name]
-            unused_processes.update([name for name in module.processes.keys() if name not in used_processes])
+            unused_processes.update(
+                [name for name in module.processes.keys() if name not in used_processes]
+            )
         self.unused_components["modules"] = unused_modules
         self.unused_components["workflows"] = unused_workflows
         self.unused_components["processes"] = unused_processes
 
-    def _extract_dependencies(self, workflow_name: str, modules: set[str], processes: set[str], workflows: set[str]) -> tuple[set[str], set[str], set[str]]:
+    def _extract_dependencies(
+        self,
+        workflow_name: str,
+        modules: set[str],
+        processes: set[str],
+        workflows: set[str],
+    ) -> tuple[set[str], set[str], set[str]]:
         workflows.add(workflow_name)
         processes.update(self.workflow_dependencies[workflow_name]["processes"])
         modules.update(self.workflow_dependencies[workflow_name]["modules"])
         dependent_workflows = self.workflow_dependencies[workflow_name]["workflows"]
         for dependent_workflow in dependent_workflows:
-            modules, processes, workflows = self._extract_dependencies(dependent_workflow, modules, processes, workflows)
+            modules, processes, workflows = self._extract_dependencies(
+                dependent_workflow, modules, processes, workflows
+            )
         return modules, processes, workflows
 
     def get_process_info(self, process_name: str) -> tuple[Process, Path]:
@@ -186,11 +240,14 @@ class NextflowAnalyzer:
             return process, self.modules[module_name].path
         else:
             # Process not found - should not happen in normal operation
-            raise KeyError(f"Process '{process_name}' not found in standalone processes or modules")
+            raise KeyError(
+                f"Process '{process_name}' not found in standalone processes or modules"
+            )
 
-#=============================================================================
+
+# =============================================================================
 # Report generation function
-#=============================================================================
+# =============================================================================
 
 
 def generate_nextflow_report(analyzer: NextflowAnalyzer, output_file: str) -> None:
@@ -223,6 +280,7 @@ def generate_nextflow_report(analyzer: NextflowAnalyzer, output_file: str) -> No
         # Unused components summary
         report_unused_components(analyzer, f)
 
+
 def report_workflows(analyzer: NextflowAnalyzer, output_stream: TextIO) -> None:
     """Write workflow section of Nextflow report."""
     output_stream.write("=================\n")
@@ -232,12 +290,16 @@ def report_workflows(analyzer: NextflowAnalyzer, output_stream: TextIO) -> None:
     workflow_order = []
     if "main" in analyzer.workflows:
         workflow_order.append("main")
-    workflow_order.extend(sorted(name for name in analyzer.workflows if name not in workflow_order))
+    workflow_order.extend(
+        sorted(name for name in analyzer.workflows if name not in workflow_order)
+    )
     for name in workflow_order:
         # Print basic workflow information
         workflow = analyzer.workflows[name]
         output_stream.write(f"Workflow: {name}\n")
-        output_stream.write(f"Location: {workflow.file_path.relative_to(analyzer.pipeline_dir)}\n")
+        output_stream.write(
+            f"Location: {workflow.file_path.relative_to(analyzer.pipeline_dir)}\n"
+        )
         # Print information about dependencies
         if name in analyzer.workflow_dependencies:
             deps = analyzer.workflow_dependencies[name]
@@ -264,9 +326,10 @@ def report_workflows(analyzer: NextflowAnalyzer, output_stream: TextIO) -> None:
                 output_stream.write("Uses no processes.\n")
         # Collate workflows that call this one
         called_by = [
-                wf for wf in analyzer.workflow_dependencies.keys()
-                if name in analyzer.workflow_dependencies[wf]["workflows"]
-                ]
+            wf
+            for wf in analyzer.workflow_dependencies.keys()
+            if name in analyzer.workflow_dependencies[wf]["workflows"]
+        ]
         if called_by:
             output_stream.write("Called by workflows:\n")
             for cb_name in sorted(called_by):
@@ -274,6 +337,7 @@ def report_workflows(analyzer: NextflowAnalyzer, output_stream: TextIO) -> None:
         elif name not in ["main"]:
             output_stream.write("Not called by any workflow.\n")
         output_stream.write("\n")
+
 
 def report_modules(analyzer: NextflowAnalyzer, output_stream: TextIO) -> None:
     """Write module section of Nextflow report."""
@@ -286,20 +350,27 @@ def report_modules(analyzer: NextflowAnalyzer, output_stream: TextIO) -> None:
         module = analyzer.modules[name]
         # Basic module information
         output_stream.write(f"Module: {name}\n")
-        output_stream.write(f"Location: {module.path.relative_to(analyzer.pipeline_dir)}\n")
+        output_stream.write(
+            f"Location: {module.path.relative_to(analyzer.pipeline_dir)}\n"
+        )
         # Processes in module
         if module.processes:
             output_stream.write("Contains processes:\n")
             for proc_name, process in sorted(module.processes.items()):
-                usage_status = " (UNUSED)" if proc_name in analyzer.unused_components['processes'] else ""
+                usage_status = (
+                    " (UNUSED)"
+                    if proc_name in analyzer.unused_components["processes"]
+                    else ""
+                )
                 output_stream.write(f"\t- {proc_name}{usage_status}\n")
         else:
             output_stream.write("Contains no processes.\n")
         # Parent workflows
         called_by = [
-            workflow for workflow in analyzer.workflow_dependencies.keys()
+            workflow
+            for workflow in analyzer.workflow_dependencies.keys()
             if name in analyzer.workflow_dependencies[workflow]["modules"]
-            ]
+        ]
         if called_by:
             output_stream.write("Used by workflows:\n")
             for workflow in sorted(called_by):
@@ -308,7 +379,10 @@ def report_modules(analyzer: NextflowAnalyzer, output_stream: TextIO) -> None:
             output_stream.write("Not used by any workflow.\n")
         output_stream.write("\n")
 
-def report_standalone_processes(analyzer: NextflowAnalyzer, output_stream: TextIO) -> None:
+
+def report_standalone_processes(
+    analyzer: NextflowAnalyzer, output_stream: TextIO
+) -> None:
     """Write standalone processes section of Nextflow report."""
     output_stream.write("============================\n")
     output_stream.write("=== Standalone Processes ===\n")
@@ -319,12 +393,15 @@ def report_standalone_processes(analyzer: NextflowAnalyzer, output_stream: TextI
         process = analyzer.standalone_processes[name]
         # Basic process information
         output_stream.write(f"Process: {name}\n")
-        output_stream.write(f"Location: {process.file_path.relative_to(analyzer.pipeline_dir)}\n")
+        output_stream.write(
+            f"Location: {process.file_path.relative_to(analyzer.pipeline_dir)}\n"
+        )
         # Parent workflows
         called_by = [
-            workflow for workflow in analyzer.workflow_dependencies.keys()
+            workflow
+            for workflow in analyzer.workflow_dependencies.keys()
             if name in analyzer.workflow_dependencies[workflow]["processes"]
-            ]
+        ]
         if called_by:
             output_stream.write("Used by workflows:\n")
             for workflow in sorted(called_by):
@@ -332,6 +409,7 @@ def report_standalone_processes(analyzer: NextflowAnalyzer, output_stream: TextI
         else:
             output_stream.write("Not used by any workflow.\n")
         output_stream.write("\n")
+
 
 def report_unused_components(analyzer: NextflowAnalyzer, output_stream: TextIO) -> None:
     """Write unused components section of Nextflow report."""
@@ -396,7 +474,9 @@ def report_unused_components(analyzer: NextflowAnalyzer, output_stream: TextIO) 
         output_stream.write("Unused processes:\n")
         for name in sorted(unused_processes_regular):
             _, path = analyzer.get_process_info(name)
-            output_stream.write(f"\t- {name} ({path.relative_to(analyzer.pipeline_dir)})\n")
+            output_stream.write(
+                f"\t- {name} ({path.relative_to(analyzer.pipeline_dir)})\n"
+            )
         output_stream.write("\n")
 
     # Report testing_only unused processes
@@ -404,27 +484,40 @@ def report_unused_components(analyzer: NextflowAnalyzer, output_stream: TextIO) 
         output_stream.write("Unused processes (testing only):\n")
         for name in sorted(unused_processes_testing):
             _, path = analyzer.get_process_info(name)
-            output_stream.write(f"\t- {name} ({path.relative_to(analyzer.pipeline_dir)})\n")
+            output_stream.write(
+                f"\t- {name} ({path.relative_to(analyzer.pipeline_dir)})\n"
+            )
         output_stream.write("\n")
 
     # Only report "no unused processes" if there are truly none
     if not unused_processes_regular and not unused_processes_testing:
         output_stream.write("No unused processes found.\n\n")
 
-#=============================================================================
+
+# =============================================================================
 # Run script
-#=============================================================================
+# =============================================================================
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description='Analyze Nextflow pipeline to find unused workflows, modules, and processes.',
-        formatter_class=argparse.RawDescriptionHelpFormatter
+        description="Analyze Nextflow pipeline to find unused workflows, modules, and processes.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument("-d", "--pipeline_dir", default=os.getcwd(),
-                        help="Path to the Nextflow pipeline directory (default: current working directory)")
-    parser.add_argument("-o", "--output_path", default="pipeline_report.txt",
-                        help="Path to output file for detailed report (default: pipeline_report.txt)")
+    parser.add_argument(
+        "-d",
+        "--pipeline_dir",
+        default=os.getcwd(),
+        help="Path to the Nextflow pipeline directory (default: current working directory)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output_path",
+        default="pipeline_report.txt",
+        help="Path to output file for detailed report (default: pipeline_report.txt)",
+    )
     return parser.parse_args()
+
 
 def main() -> None:
     # Parse arguments
@@ -439,6 +532,7 @@ def main() -> None:
     analyzer = NextflowAnalyzer(pipeline_dir)
     # Create report
     generate_nextflow_report(analyzer, output_path)
+
 
 if __name__ == "__main__":
     main()

--- a/bin/analyze-pipeline.py
+++ b/bin/analyze-pipeline.py
@@ -4,13 +4,13 @@
 # Imports
 # =============================================================================
 
+import argparse
 import os
 import re
 import sys
-import argparse
-from pathlib import Path
-from typing import IO, TextIO
 from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TextIO
 
 # =============================================================================
 # Dataclasses
@@ -234,15 +234,14 @@ class NextflowAnalyzer:
         if process_name in self.standalone_processes:
             process = self.standalone_processes[process_name]
             return process, process.file_path
-        elif process_name in self._process_to_module_map:
+        if process_name in self._process_to_module_map:
             module_name = self._process_to_module_map[process_name]
             process = self.modules[module_name].processes[process_name]
             return process, self.modules[module_name].path
-        else:
-            # Process not found - should not happen in normal operation
-            raise KeyError(
-                f"Process '{process_name}' not found in standalone processes or modules"
-            )
+        # Process not found - should not happen in normal operation
+        raise KeyError(
+            f"Process '{process_name}' not found in standalone processes or modules"
+        )
 
 
 # =============================================================================

--- a/bin/apply-lifecycle-rules.py
+++ b/bin/apply-lifecycle-rules.py
@@ -2,15 +2,16 @@
 
 import argparse
 import json
-import boto3
 import sys
 from typing import Any
+
+import boto3
 from botocore.exceptions import ClientError
 
 
 def load_lifecycle_config(config_path: str) -> dict[str, Any]:
     try:
-        with open(config_path, "r") as f:
+        with open(config_path) as f:
             result: dict[str, Any] = json.load(f)
             return result
     except json.JSONDecodeError:

--- a/bin/apply-lifecycle-rules.py
+++ b/bin/apply-lifecycle-rules.py
@@ -7,9 +7,10 @@ import sys
 from typing import Any
 from botocore.exceptions import ClientError
 
+
 def load_lifecycle_config(config_path: str) -> dict[str, Any]:
     try:
-        with open(config_path, 'r') as f:
+        with open(config_path, "r") as f:
             result: dict[str, Any] = json.load(f)
             return result
     except json.JSONDecodeError:
@@ -19,74 +20,79 @@ def load_lifecycle_config(config_path: str) -> dict[str, Any]:
         print(f"Error: Could not find file {config_path}")
         sys.exit(1)
 
+
 def print_lifecycle_rules(rules: list[dict[str, Any]]) -> None:
     if not rules:
         print("No lifecycle rules configured")
         return
-        
+
     for rule in rules:
         print(f"- {rule['ID']}")
         print(f"  Status: {rule['Status']}")
-        if 'Expiration' in rule:
+        if "Expiration" in rule:
             print(f"  Expiration: {rule['Expiration'].get('Days', 'N/A')} days")
         print()
+
 
 def get_current_rules(s3: Any, bucket_name: str) -> list[dict[str, Any]]:
     try:
         response = s3.get_bucket_lifecycle_configuration(Bucket=bucket_name)
-        rules: list[dict[str, Any]] = response.get('Rules', [])
+        rules: list[dict[str, Any]] = response.get("Rules", [])
         return rules
     except ClientError as e:
-        if e.response['Error']['Code'] == 'NoSuchLifecycleConfiguration':
+        if e.response["Error"]["Code"] == "NoSuchLifecycleConfiguration":
             return []
         raise
 
+
 def apply_lifecycle_rules(bucket_name: str, lifecycle_config: dict[str, Any]) -> None:
-    s3 = boto3.client('s3')
-    
+    s3 = boto3.client("s3")
+
     try:
         # First verify the bucket exists and we have access
         s3.head_bucket(Bucket=bucket_name)
-        
+
         # Show current configuration
         print(f"\nCurrent lifecycle rules for bucket {bucket_name}:")
         current_rules = get_current_rules(s3, bucket_name)
         print_lifecycle_rules(current_rules)
-        
+
         # Apply the new configuration
         s3.put_bucket_lifecycle_configuration(
             Bucket=bucket_name,
-            LifecycleConfiguration=lifecycle_config  # type: ignore[arg-type]
+            LifecycleConfiguration=lifecycle_config,  # type: ignore[arg-type]
         )
         print(f"\nSuccessfully applied new lifecycle rules to bucket: {bucket_name}")
-        
+
         # Show the updated configuration
         print("\nUpdated lifecycle rules:")
         new_rules = get_current_rules(s3, bucket_name)
         print_lifecycle_rules(new_rules)
-        
+
     except ClientError as e:
-        error_code = e.response.get('Error', {}).get('Code', 'Unknown')
-        if error_code == '404':
+        error_code = e.response.get("Error", {}).get("Code", "Unknown")
+        if error_code == "404":
             print(f"Error: Bucket {bucket_name} does not exist")
-        elif error_code == '403':
+        elif error_code == "403":
             print(f"Error: Permission denied for bucket {bucket_name}")
         else:
             print(f"Error applying lifecycle rules: {str(e)}")
         sys.exit(1)
 
+
 def main() -> None:
-    parser = argparse.ArgumentParser(description='Apply S3 lifecycle rules to a bucket')
-    parser.add_argument('config_file', help='Path to lifecycle configuration JSON file')
-    parser.add_argument('bucket_name', help='Name of the S3 bucket')
-    
+    parser = argparse.ArgumentParser(description="Apply S3 lifecycle rules to a bucket")
+    parser.add_argument("config_file", help="Path to lifecycle configuration JSON file")
+    parser.add_argument("bucket_name", help="Name of the S3 bucket")
+
     args = parser.parse_args()
-    
+
     # Load the configuration
     lifecycle_config = load_lifecycle_config(args.config_file)
-    
+
     # Apply the rules
     apply_lifecycle_rules(args.bucket_name, lifecycle_config)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/bin/build_ecr_container.py
+++ b/bin/build_ecr_container.py
@@ -209,7 +209,7 @@ def generate_dockerfile(spec_filename: str, pyproject_path: Path) -> str:
         str: Dockerfile text
     """
     base_image = get_base_image(pyproject_path)
-    dockerfile = f"""
+    return f"""
 FROM {base_image}
 USER root
 RUN apt-get update && apt-get install -y procps && rm -rf /var/lib/apt/lists/*
@@ -219,7 +219,6 @@ RUN micromamba install -y -n base -f /tmp/environment.yml && \\
     micromamba clean --all --yes
 ENV PATH=/opt/conda/bin:$PATH
 """
-    return dockerfile
 
 
 def build_docker_image_from_spec(
@@ -502,8 +501,7 @@ def parse_args() -> argparse.Namespace:
         default=Path("pyproject.toml"),
         help="Path to pyproject.toml for base image config (default: pyproject.toml)",
     )
-    args = parser.parse_args()
-    return args
+    return parser.parse_args()
 
 
 def main() -> None:

--- a/bin/build_ecr_container.py
+++ b/bin/build_ecr_container.py
@@ -32,6 +32,7 @@ from botocore.exceptions import ClientError
 # LOGGING #
 ###########
 
+
 class UTCFormatter(logging.Formatter):
     """
     Custom logging formatter that displays timestamps in UTC.
@@ -39,9 +40,7 @@ class UTCFormatter(logging.Formatter):
         Formatted log timestamps in UTC timezone
     """
 
-    def formatTime(
-        self, record: logging.LogRecord, datefmt: str | None = None
-    ) -> str:
+    def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
         """
         Format log timestamps in UTC timezone.
         Args:
@@ -52,6 +51,7 @@ class UTCFormatter(logging.Formatter):
         """
         dt = datetime.fromtimestamp(record.created, timezone.utc)
         return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger()
@@ -64,6 +64,7 @@ logger.addHandler(handler)
 ##########################
 # SPEC PARSING FUNCTIONS #
 ##########################
+
 
 def read_container_spec(spec_file: Path) -> dict[str, Any]:
     """
@@ -83,6 +84,7 @@ def read_container_spec(spec_file: Path) -> dict[str, Any]:
         raise ValueError(msg)
     return spec  # type: ignore[no-any-return]
 
+
 def compute_spec_hash(spec: dict[str, Any], dockerfile_content: str) -> str:
     """
     Compute a hash of the container specification and Dockerfile for tagging.
@@ -100,9 +102,11 @@ def compute_spec_hash(spec: dict[str, Any], dockerfile_content: str) -> str:
     hash_obj = hashlib.sha256(content_str.encode())
     return hash_obj.hexdigest()[:16]
 
+
 #######################
 # ECR SETUP FUNCTIONS #
 #######################
+
 
 def check_image_exists(
     ecr_client: Any,
@@ -120,8 +124,7 @@ def check_image_exists(
     """
     try:
         ecr_client.describe_images(
-            repositoryName=repo_name,
-            imageIds=[{"imageTag": image_tag}]
+            repositoryName=repo_name, imageIds=[{"imageTag": image_tag}]
         )
         return True
     except ClientError as e:
@@ -129,6 +132,7 @@ def check_image_exists(
             return False
         # For other errors (like RepositoryNotFoundException), let it propagate
         raise
+
 
 def setup_ecr_repository(
     label: str,
@@ -157,9 +161,7 @@ def setup_ecr_repository(
         if e.response["Error"]["Code"] == "RepositoryNotFoundException":
             logger.info("ECR repository does not exist; creating")
             try:
-                response = ecr_client.create_repository(
-                    repositoryName=repo_name
-                )
+                response = ecr_client.create_repository(repositoryName=repo_name)
                 repo = response["repository"]
                 logger.info(f"Created repository: {repo['repositoryUri']}")
             except ClientError as create_error:
@@ -181,9 +183,11 @@ def setup_ecr_repository(
 
     return image_tag, image_tag_latest, registry_url, image_exists
 
+
 ################################
 # LOCAL DOCKER BUILD FUNCTIONS #
 ################################
+
 
 def get_base_image(pyproject_path: Path) -> str:
     """Read the container base image from pyproject.toml.
@@ -218,6 +222,7 @@ ENV PATH=/opt/conda/bin:$PATH
 """
     return dockerfile
 
+
 def build_docker_image_from_spec(
     spec_file: Path,
     image_tag: str,
@@ -238,7 +243,15 @@ def build_docker_image_from_spec(
     logger.info(f"Building Docker image: {image_tag}")
     try:
         subprocess.run(
-            ["docker", "build", "--platform", "linux/amd64", "-t", image_tag, str(build_dir)],
+            [
+                "docker",
+                "build",
+                "--platform",
+                "linux/amd64",
+                "-t",
+                image_tag,
+                str(build_dir),
+            ],
             check=True,
         )
         logger.info(f"Built image: {image_tag}")
@@ -246,6 +259,7 @@ def build_docker_image_from_spec(
         msg = f"Error building Docker image: {e}"
         logger.error(msg)
         raise RuntimeError(msg) from e
+
 
 def tag_docker_image(source_tag: str, target_tag: str) -> None:
     """Tag a Docker image with an additional tag.
@@ -265,7 +279,9 @@ def tag_docker_image(source_tag: str, target_tag: str) -> None:
         logger.error(msg)
         raise RuntimeError(msg) from e
 
-def build_container(spec_file: Path,
+
+def build_container(
+    spec_file: Path,
     image_tag: str,
     image_tag_latest: str,
     pyproject_path: Path = Path("pyproject.toml"),
@@ -282,16 +298,20 @@ def build_container(spec_file: Path,
     with tempfile.TemporaryDirectory() as tmpdir:
         build_dir = Path(tmpdir)
         try:
-            build_docker_image_from_spec(spec_file, image_tag, build_dir, pyproject_path)
+            build_docker_image_from_spec(
+                spec_file, image_tag, build_dir, pyproject_path
+            )
             tag_docker_image(image_tag, image_tag_latest)
         except Exception as e:
             msg = f"Error building container: {e}"
             logger.error(msg)
             raise RuntimeError(msg)
 
+
 ######################
 # ECR PUSH FUNCTIONS #
 ######################
+
 
 def docker_login_ecr(registry_url: str) -> None:
     """Authenticate Docker with ECR Public.
@@ -317,10 +337,17 @@ def docker_login_ecr(registry_url: str) -> None:
         )
         logger.info("Authenticated with ECR Public")
     except subprocess.CalledProcessError as e:
-        error_output = e.stderr.strip() if e.stderr else e.stdout.strip() if e.stdout else "No error output"
+        error_output = (
+            e.stderr.strip()
+            if e.stderr
+            else e.stdout.strip()
+            if e.stdout
+            else "No error output"
+        )
         msg = f"Error authenticating with ECR Public: {error_output}"
         logger.error(msg)
         raise RuntimeError(msg)
+
 
 def push_docker_image(image_tag: str) -> None:
     """Push a Docker image to ECR.
@@ -338,6 +365,7 @@ def push_docker_image(image_tag: str) -> None:
         msg = f"Error pushing Docker image: {e}"
         logger.error(msg)
         raise RuntimeError(msg)
+
 
 def push_to_ecr(
     image_tag: str,
@@ -360,9 +388,11 @@ def push_to_ecr(
         logger.error(msg)
         raise RuntimeError(msg)
 
+
 ###########################
 # CONFIG UPDATE FUNCTIONS #
 ###########################
+
 
 def update_containers_config(
     config_file: Path,
@@ -396,9 +426,11 @@ def update_containers_config(
     logger.info(f"Updated {config_file}")
     return True
 
+
 ######################
 # MAIN ORCHESTRATION #
 ######################
+
 
 def build_and_push_container(
     spec_file: Path,
@@ -445,15 +477,15 @@ def build_and_push_container(
         logger.error(f"Error: {e}")
         raise
 
+
 ###################
 # CLI ENTRY POINT #
 ###################
 
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=DESC)
-    parser.add_argument(
-        "spec_file", type=Path, help="Path to container spec YAML file"
-    )
+    parser.add_argument("spec_file", type=Path, help="Path to container spec YAML file")
     parser.add_argument(
         "--prefix",
         default="nao-mgs-workflow",
@@ -474,11 +506,11 @@ def parse_args() -> argparse.Namespace:
     args = parser.parse_args()
     return args
 
+
 def main() -> None:
     args = parse_args()
-    build_and_push_container(
-        args.spec_file, args.prefix, args.config, args.pyproject
-    )
+    build_and_push_container(args.spec_file, args.prefix, args.config, args.pyproject)
+
 
 if __name__ == "__main__":
     main()

--- a/bin/build_ecr_container.py
+++ b/bin/build_ecr_container.py
@@ -303,7 +303,7 @@ def build_container(
         except Exception as e:
             msg = f"Error building container: {e}"
             logger.error(msg)
-            raise RuntimeError(msg)
+            raise RuntimeError(msg) from e
 
 
 ######################
@@ -344,7 +344,7 @@ def docker_login_ecr(registry_url: str) -> None:
         )
         msg = f"Error authenticating with ECR Public: {error_output}"
         logger.error(msg)
-        raise RuntimeError(msg)
+        raise RuntimeError(msg) from e
 
 
 def push_docker_image(image_tag: str) -> None:
@@ -362,7 +362,7 @@ def push_docker_image(image_tag: str) -> None:
     except subprocess.CalledProcessError as e:
         msg = f"Error pushing Docker image: {e}"
         logger.error(msg)
-        raise RuntimeError(msg)
+        raise RuntimeError(msg) from e
 
 
 def push_to_ecr(
@@ -384,7 +384,7 @@ def push_to_ecr(
     except Exception as e:
         msg = f"Error pushing to ECR Public: {e}"
         logger.error(msg)
-        raise RuntimeError(msg)
+        raise RuntimeError(msg) from e
 
 
 ###########################

--- a/bin/build_ecr_container.py
+++ b/bin/build_ecr_container.py
@@ -16,10 +16,9 @@ import logging
 import re
 import shutil
 import subprocess
-import sys
 import tempfile
 import tomllib
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -49,7 +48,7 @@ class UTCFormatter(logging.Formatter):
         Returns:
             Formatted timestamp string in UTC
         """
-        dt = datetime.fromtimestamp(record.created, timezone.utc)
+        dt = datetime.fromtimestamp(record.created, UTC)
         return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
@@ -462,7 +461,7 @@ def build_and_push_container(
         )
 
         if image_exists:
-            logger.info(f"Image already exists in ECR, skipping build")
+            logger.info("Image already exists in ECR, skipping build")
             # Still update config in case it's outdated
             config_updated = update_containers_config(config_file, label, image_tag)
             if not config_updated:

--- a/bin/build_ecr_containers.py
+++ b/bin/build_ecr_containers.py
@@ -2,6 +2,7 @@
 """
 Rebuild all ECR containers from specs in containers/ directory.
 """
+
 import argparse
 import logging
 import sys

--- a/bin/build_ecr_containers.py
+++ b/bin/build_ecr_containers.py
@@ -4,7 +4,6 @@ Rebuild all ECR containers from specs in containers/ directory.
 """
 
 import argparse
-import logging
 import sys
 from pathlib import Path
 
@@ -69,7 +68,7 @@ def main() -> None:
             failed.append(spec_file.name)
             logger.error(f"Failed to build {spec_file.name}: {e}")
             if not args.continue_on_error:
-                logger.error(f"\nStopping due to error")
+                logger.error("\nStopping due to error")
                 sys.exit(1)
             logger.info("")
 

--- a/bin/build_tiny_test_databases.py
+++ b/bin/build_tiny_test_databases.py
@@ -263,7 +263,7 @@ def build_blast_database(
     seq_id_to_taxid = {}
 
     with open(combined_fasta, "w") as outfile:
-        for filename, source, taxid in sequences:
+        for _filename, source, taxid in sequences:
             # Download or load the sequence
             if isinstance(source, Path):
                 with open_by_suffix(source) as f:
@@ -510,13 +510,13 @@ def run_build(args: argparse.Namespace) -> None:
             kraken_dir, blast_dir, args.taxonomy_nodes, args.taxonomy_names
         )
         logger.info("Step 5: Uploading to S3...")
-        kraken_url = upload_to_s3(
+        upload_to_s3(
             kraken_tarball, args.s3_bucket, f"{args.s3_prefix}/{kraken_tarball.name}"
         )
-        blast_url = upload_to_s3(
+        upload_to_s3(
             blast_tarball, args.s3_bucket, f"{args.s3_prefix}/{blast_tarball.name}"
         )
-        taxonomy_url = upload_to_s3(
+        upload_to_s3(
             taxonomy_zip, args.s3_bucket, f"{args.s3_prefix}/{taxonomy_zip.name}"
         )
 

--- a/bin/build_tiny_test_databases.py
+++ b/bin/build_tiny_test_databases.py
@@ -24,6 +24,7 @@ import boto3
 # LOGGING #
 ###########
 
+
 class UTCFormatter(logging.Formatter):
     """Custom logging formatter that displays timestamps in UTC."""
 
@@ -31,6 +32,7 @@ class UTCFormatter(logging.Formatter):
         """Format log timestamps in UTC timezone."""
         dt = datetime.fromtimestamp(record.created, timezone.utc)
         return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger()
@@ -43,6 +45,7 @@ logger.addHandler(handler)
 ##########################
 # KRAKEN2 DATABASE SETUP #
 ##########################
+
 
 def parse_config(config_path: Path) -> dict[str, str]:
     """
@@ -58,18 +61,21 @@ def parse_config(config_path: Path) -> dict[str, str]:
     # Extract human_url
     match = re.search(r'human_url\s*=\s*"([^"]+)"', content)
     if match:
-        urls['human'] = match.group(1)
+        urls["human"] = match.group(1)
     # Extract phage URL from genome_urls map
     match = re.search(r'phage:\s*"([^"]+)"', content)
     if match:
-        urls['phage'] = match.group(1)
+        urls["phage"] = match.group(1)
     # Extract SSU URL
     match = re.search(r'ssu_url\s*=\s*"([^"]+)"', content)
     if match:
-        urls['ssu'] = match.group(1)
+        urls["ssu"] = match.group(1)
     return urls
 
-def setup_kraken_taxonomy(output_dir: Path, taxonomy_nodes: Path, taxonomy_names: Path) -> None:
+
+def setup_kraken_taxonomy(
+    output_dir: Path, taxonomy_nodes: Path, taxonomy_names: Path
+) -> None:
     """
     Copy minimal taxonomy files to Kraken database directory.
     Args:
@@ -83,6 +89,7 @@ def setup_kraken_taxonomy(output_dir: Path, taxonomy_nodes: Path, taxonomy_names
     shutil.copy(taxonomy_nodes, taxonomy_dir / "nodes.dmp")
     shutil.copy(taxonomy_names, taxonomy_dir / "names.dmp")
 
+
 def add_kraken_taxid_tags(fasta_content: str, taxid: int) -> str:
     """
     Add Kraken taxid tags to FASTA headers.
@@ -92,12 +99,8 @@ def add_kraken_taxid_tags(fasta_content: str, taxid: int) -> str:
     Returns:
         str: FASTA content with kraken:taxid tags added
     """
-    return re.sub(
-        r'^>',
-        f'>kraken:taxid|{taxid}|',
-        fasta_content,
-        flags=re.MULTILINE
-    )
+    return re.sub(r"^>", f">kraken:taxid|{taxid}|", fasta_content, flags=re.MULTILINE)
+
 
 def download_sequence(url: str) -> str:
     """
@@ -108,8 +111,9 @@ def download_sequence(url: str) -> str:
         str: FASTA content as string
     """
     with urlopen(url) as response:
-        content: str = response.read().decode('utf-8')
+        content: str = response.read().decode("utf-8")
         return content
+
 
 def open_by_suffix(filename: str | Path, mode: str = "r") -> IO[str]:
     """
@@ -127,6 +131,7 @@ def open_by_suffix(filename: str | Path, mode: str = "r") -> IO[str]:
     else:
         return open(filename_str, mode)
 
+
 def add_sequence_to_kraken_library(fasta_path: Path, db_path: Path) -> None:
     """
     Add a FASTA file to Kraken2 library using kraken2-build.
@@ -137,16 +142,16 @@ def add_sequence_to_kraken_library(fasta_path: Path, db_path: Path) -> None:
     result = subprocess.run(
         ["kraken2-build", "--add-to-library", str(fasta_path), "--db", str(db_path)],
         capture_output=True,
-        text=True
+        text=True,
     )
     if result.returncode != 0:
         logger.error(f"Failed to add {fasta_path.name} to library")
         logger.error(result.stderr)
         raise subprocess.CalledProcessError(result.returncode, result.args)
 
+
 def add_sequences_to_kraken_library(
-    sequences: list[tuple[str, str | Path, int]],
-    output_dir: Path
+    sequences: list[tuple[str, str | Path, int]], output_dir: Path
 ) -> None:
     """
     Acquire sequences, tag them, and add to Kraken2 library.
@@ -167,9 +172,9 @@ def add_sequences_to_kraken_library(
             output_path.write_text(tagged_content)
             add_sequence_to_kraken_library(output_path, output_dir)
 
+
 def build_kraken_database(
-    output_dir: Path,
-    sequences: list[tuple[str, str | Path, int]]
+    output_dir: Path, sequences: list[tuple[str, str | Path, int]]
 ) -> None:
     """
     Build tiny Kraken2 database using provided sequences.
@@ -181,13 +186,24 @@ def build_kraken_database(
     library_dir = output_dir / "library" / "added"
     library_dir.mkdir(parents=True, exist_ok=True)
     add_sequences_to_kraken_library(sequences, output_dir)
-    result = subprocess.run([
-        "kraken2-build", "--build", "--db", str(output_dir),
-        "--threads", "4",
-        "--kmer-len", "25",
-        "--minimizer-len", "15",
-        "--minimizer-spaces", "3"
-    ], capture_output=True, text=True)
+    result = subprocess.run(
+        [
+            "kraken2-build",
+            "--build",
+            "--db",
+            str(output_dir),
+            "--threads",
+            "4",
+            "--kmer-len",
+            "25",
+            "--minimizer-len",
+            "15",
+            "--minimizer-spaces",
+            "3",
+        ],
+        capture_output=True,
+        text=True,
+    )
     if result.returncode != 0:
         logger.error("Failed to build Kraken2 database")
         logger.error(result.stderr)
@@ -196,15 +212,25 @@ def build_kraken_database(
     # Build Bracken k-mer distribution files (stored within Kraken2 database directory)
     logger.info("Building Bracken k-mer distribution files...")
     for read_len in [100, 150]:  # Common Illumina read lengths
-        result = subprocess.run([
-            "bracken-build",
-            "-d", str(output_dir),
-            "-t", "4",
-            "-k", "25",
-            "-l", str(read_len)
-        ], capture_output=True, text=True)
+        result = subprocess.run(
+            [
+                "bracken-build",
+                "-d",
+                str(output_dir),
+                "-t",
+                "4",
+                "-k",
+                "25",
+                "-l",
+                str(read_len),
+            ],
+            capture_output=True,
+            text=True,
+        )
         if result.returncode != 0:
-            logger.error(f"Failed to build Bracken distribution for read length {read_len}")
+            logger.error(
+                f"Failed to build Bracken distribution for read length {read_len}"
+            )
             logger.error(result.stderr)
             raise subprocess.CalledProcessError(result.returncode, result.args)
 
@@ -212,14 +238,18 @@ def build_kraken_database(
     subprocess.run(
         ["kraken2-build", "--clean", "--db", str(output_dir)],
         check=True,
-        capture_output=True
+        capture_output=True,
     )
+
 
 ##################
 # BLAST DATABASE #
 ##################
 
-def build_blast_database(output_dir: Path, sequences: list[tuple[str, str | Path, int]]) -> None:
+
+def build_blast_database(
+    output_dir: Path, sequences: list[tuple[str, str | Path, int]]
+) -> None:
     """
     Build tiny BLAST database using provided sequences.
     Args:
@@ -232,7 +262,7 @@ def build_blast_database(output_dir: Path, sequences: list[tuple[str, str | Path
 
     seq_id_to_taxid = {}
 
-    with open(combined_fasta, 'w') as outfile:
+    with open(combined_fasta, "w") as outfile:
         for filename, source, taxid in sequences:
             # Download or load the sequence
             if isinstance(source, Path):
@@ -242,59 +272,69 @@ def build_blast_database(output_dir: Path, sequences: list[tuple[str, str | Path
                 content = download_sequence(source)
 
             # Process FASTA content to simplify headers for BLAST
-            lines = content.split('\n')
+            lines = content.split("\n")
             for i, line in enumerate(lines):
-                if line.startswith('>'):
+                if line.startswith(">"):
                     # Extract simple sequence ID (e.g., "NC_000021.9" from ">NC_000021.9 ...")
                     # or "AB065370.1" from ">ENA|AB065370|AB065370.1 ..."
                     parts = line[1:].split()
                     if parts:
                         # Handle different formats
                         seq_id = parts[0]
-                        if '|' in seq_id:
+                        if "|" in seq_id:
                             # For formats like "ENA|AB065370|AB065370.1", take the last part
-                            seq_id = seq_id.split('|')[-1]
+                            seq_id = seq_id.split("|")[-1]
                         # Replace colons with underscores - BLAST has issues with colons in sequence IDs
-                        seq_id = seq_id.replace(':', '_')
+                        seq_id = seq_id.replace(":", "_")
                         seq_id_to_taxid[seq_id] = taxid
                         # Write simplified header
-                        lines[i] = f'>{seq_id}'
+                        lines[i] = f">{seq_id}"
 
             # Write modified content to combined file
-            outfile.write('\n'.join(lines))
-            if not content.endswith('\n'):
-                outfile.write('\n')
+            outfile.write("\n".join(lines))
+            if not content.endswith("\n"):
+                outfile.write("\n")
 
     # Write taxid mapping file for BLAST
-    with open(taxid_map_file, 'w') as mapfile:
+    with open(taxid_map_file, "w") as mapfile:
         for seq_id, taxid in seq_id_to_taxid.items():
             mapfile.write(f"{seq_id}\t{taxid}\n")
 
     # Build BLAST database with taxonomy information
     logger.info("Building BLAST database...")
-    result = subprocess.run([
-        "makeblastdb",
-        "-in", str(combined_fasta),
-        "-dbtype", "nucl",
-        "-out", str(output_dir / "tiny_blast_db"),
-        "-title", "Tiny BLAST Database",
-        "-parse_seqids",
-        "-taxid_map", str(taxid_map_file)
-    ], capture_output=True, text=True)
+    result = subprocess.run(
+        [
+            "makeblastdb",
+            "-in",
+            str(combined_fasta),
+            "-dbtype",
+            "nucl",
+            "-out",
+            str(output_dir / "tiny_blast_db"),
+            "-title",
+            "Tiny BLAST Database",
+            "-parse_seqids",
+            "-taxid_map",
+            str(taxid_map_file),
+        ],
+        capture_output=True,
+        text=True,
+    )
 
     if result.returncode != 0:
         logger.error("Failed to build BLAST database")
         logger.error(result.stderr)
         raise subprocess.CalledProcessError(result.returncode, result.args)
 
+
 ####################
 # ARCHIVE CREATION #
 ####################
 
-def create_archives(kraken_dir: Path,
-                    blast_dir: Path,
-                    taxonomy_nodes: Path,
-                    taxonomy_names: Path) -> tuple[Path, Path, Path]:
+
+def create_archives(
+    kraken_dir: Path, blast_dir: Path, taxonomy_nodes: Path, taxonomy_names: Path
+) -> tuple[Path, Path, Path]:
     """
     Create tarball and zip archives for distribution.
     Args:
@@ -306,32 +346,44 @@ def create_archives(kraken_dir: Path,
         tuple[Path, Path, Path]: Tuple of (kraken_tarball_path, blast_tarball_path, taxonomy_zip_path)
     """
     # Create Kraken tarball with files at root level (no wrapper directory)
-    kraken_tarball = kraken_dir.with_suffix('.tar.gz')
-    subprocess.run([
-        "tar", "-czf", str(kraken_tarball),
-        "-C", str(kraken_dir),
-        "."
-    ], check=True)
+    kraken_tarball = kraken_dir.with_suffix(".tar.gz")
+    subprocess.run(
+        ["tar", "-czf", str(kraken_tarball), "-C", str(kraken_dir), "."], check=True
+    )
 
     # Create BLAST tarball with directory wrapper (BLAST expects -db path/to/db_prefix)
-    blast_tarball = blast_dir.with_suffix('.tar.gz')
-    subprocess.run([
-        "tar", "-czf", str(blast_tarball),
-        "-C", str(blast_dir.parent),
-        blast_dir.name
-    ], check=True)
+    blast_tarball = blast_dir.with_suffix(".tar.gz")
+    subprocess.run(
+        [
+            "tar",
+            "-czf",
+            str(blast_tarball),
+            "-C",
+            str(blast_dir.parent),
+            blast_dir.name,
+        ],
+        check=True,
+    )
 
     taxonomy_zip = kraken_dir.parent / "tiny-taxonomy.zip"
-    subprocess.run([
-        "zip", "-q", "-j", str(taxonomy_zip),
-        str(taxonomy_nodes),
-        str(taxonomy_names)
-    ], check=True)
+    subprocess.run(
+        [
+            "zip",
+            "-q",
+            "-j",
+            str(taxonomy_zip),
+            str(taxonomy_nodes),
+            str(taxonomy_names),
+        ],
+        check=True,
+    )
     return kraken_tarball, blast_tarball, taxonomy_zip
+
 
 ################
 # S3 UPLOAD    #
 ################
+
 
 def upload_to_s3(local_file: Path, bucket: str, key: str) -> str:
     """
@@ -350,9 +402,11 @@ def upload_to_s3(local_file: Path, bucket: str, key: str) -> str:
     logger.info(f"  Uploaded to {https_url}")
     return https_url
 
+
 ########
 # MAIN #
 ########
+
 
 def parse_arguments() -> argparse.Namespace:
     """
@@ -370,39 +424,40 @@ def parse_arguments() -> argparse.Namespace:
         "--viral-genome",
         type=Path,
         help=f"Path to HDV genome FASTA file (default: {default_genomes_dir / 'hdv.fasta'})",
-        default=default_genomes_dir / "hdv.fasta"
+        default=default_genomes_dir / "hdv.fasta",
     )
     parser.add_argument(
         "--config-file",
         type=Path,
         default=repo_root / "configs" / "index-for-run-test.config",
-        help="Path to config file containing reference URLs (default: configs/index-for-run-test.config)"
+        help="Path to config file containing reference URLs (default: configs/index-for-run-test.config)",
     )
     parser.add_argument(
         "--taxonomy-nodes",
         type=Path,
         default=default_taxonomy_dir / "nodes.dmp",
-        help=f"Path to taxonomy nodes.dmp file (default: {default_taxonomy_dir / 'nodes.dmp'})"
+        help=f"Path to taxonomy nodes.dmp file (default: {default_taxonomy_dir / 'nodes.dmp'})",
     )
     parser.add_argument(
         "--taxonomy-names",
         type=Path,
         default=default_taxonomy_dir / "names.dmp",
-        help=f"Path to taxonomy names.dmp file (default: {default_taxonomy_dir / 'names.dmp'})"
+        help=f"Path to taxonomy names.dmp file (default: {default_taxonomy_dir / 'names.dmp'})",
     )
     parser.add_argument(
         "--s3-bucket",
         type=str,
         default="nao-testing",
-        help="S3 bucket for upload (default: nao-testing)"
+        help="S3 bucket for upload (default: nao-testing)",
     )
     parser.add_argument(
         "--s3-prefix",
         type=str,
         default="test-databases",
-        help="S3 key prefix for uploaded files (default: test-databases)"
+        help="S3 key prefix for uploaded files (default: test-databases)",
     )
     return parser.parse_args()
+
 
 def validate_inputs(args: argparse.Namespace) -> None:
     """
@@ -419,6 +474,7 @@ def validate_inputs(args: argparse.Namespace) -> None:
     for file_desc, file_path in required_files.items():
         if not file_path.exists():
             raise FileNotFoundError(f"{file_desc} not found: {file_path}")
+
 
 def run_build(args: argparse.Namespace) -> None:
     """
@@ -437,9 +493,9 @@ def run_build(args: argparse.Namespace) -> None:
         blast_dir.mkdir(parents=True, exist_ok=True)
 
         sequences = [
-            ("human_chr21.fna", urls['human'], 9606),
-            ("t4_phage.fna", urls['phage'], 10665),
-            ("bsubtilis_rrna.fna", urls['ssu'], 1423),
+            ("human_chr21.fna", urls["human"], 9606),
+            ("t4_phage.fna", urls["phage"], 10665),
+            ("bsubtilis_rrna.fna", urls["ssu"], 1423),
             ("hdv.fna", args.viral_genome, 12475),
         ]
 
@@ -455,26 +511,22 @@ def run_build(args: argparse.Namespace) -> None:
         )
         logger.info("Step 5: Uploading to S3...")
         kraken_url = upload_to_s3(
-            kraken_tarball,
-            args.s3_bucket,
-            f"{args.s3_prefix}/{kraken_tarball.name}"
+            kraken_tarball, args.s3_bucket, f"{args.s3_prefix}/{kraken_tarball.name}"
         )
         blast_url = upload_to_s3(
-            blast_tarball,
-            args.s3_bucket,
-            f"{args.s3_prefix}/{blast_tarball.name}"
+            blast_tarball, args.s3_bucket, f"{args.s3_prefix}/{blast_tarball.name}"
         )
         taxonomy_url = upload_to_s3(
-            taxonomy_zip,
-            args.s3_bucket,
-            f"{args.s3_prefix}/{taxonomy_zip.name}"
+            taxonomy_zip, args.s3_bucket, f"{args.s3_prefix}/{taxonomy_zip.name}"
         )
+
 
 def main() -> None:
     """Main entry point for the script."""
     args = parse_arguments()
     validate_inputs(args)
     run_build(args)
+
 
 if __name__ == "__main__":
     main()

--- a/bin/build_tiny_test_databases.py
+++ b/bin/build_tiny_test_databases.py
@@ -11,13 +11,14 @@ import argparse
 import gzip
 import logging
 import re
+import shutil
 import subprocess
 import tempfile
-import shutil
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import IO
 from urllib.request import urlopen
+
 import boto3
 
 ###########
@@ -30,7 +31,7 @@ class UTCFormatter(logging.Formatter):
 
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
         """Format log timestamps in UTC timezone."""
-        dt = datetime.fromtimestamp(record.created, timezone.utc)
+        dt = datetime.fromtimestamp(record.created, UTC)
         return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
@@ -128,8 +129,7 @@ def open_by_suffix(filename: str | Path, mode: str = "r") -> IO[str]:
     filename_str = str(filename)
     if filename_str.endswith(".gz"):
         return gzip.open(filename_str, mode + "t")  # type: ignore[return-value]
-    else:
-        return open(filename_str, mode)
+    return open(filename_str, mode)
 
 
 def add_sequence_to_kraken_library(fasta_path: Path, db_path: Path) -> None:

--- a/bin/chain_workflows.py
+++ b/bin/chain_workflows.py
@@ -236,7 +236,7 @@ def parse_arguments() -> argparse.Namespace:
         type=str,
         default=None,
         help="S3 path to an existing index directory (s3://.../output) to use instead of running INDEX workflow. "
-             "When provided, --skip-index is implied and this path is used as ref_dir for RUN and DOWNSTREAM."
+        "When provided, --skip-index is implied and this path is used as ref_dir for RUN and DOWNSTREAM.",
     )
     parser.add_argument(
         "--skip-index",
@@ -294,7 +294,9 @@ def main() -> None:
         )
     else:
         if args.ref_dir:
-            logger.info(f"Skipping INDEX workflow (using provided ref_dir: {args.ref_dir})")
+            logger.info(
+                f"Skipping INDEX workflow (using provided ref_dir: {args.ref_dir})"
+            )
         else:
             logger.info("Skipping INDEX workflow")
 
@@ -302,7 +304,9 @@ def main() -> None:
     run_base_dir = args.base_dir.rstrip("/") + "/run"
     # Use provided ref_dir if specified, otherwise use the INDEX output directory
     ref_dir = args.ref_dir.rstrip("/") if args.ref_dir else f"{index_base_dir}/output"
-    samplesheet_path = resolve_samplesheet_path(args.samplesheet, launch_dirs['run'], repo_root)
+    samplesheet_path = resolve_samplesheet_path(
+        args.samplesheet, launch_dirs["run"], repo_root
+    )
     if not args.skip_run:
         execute_nextflow(
             launch_dir=launch_dirs["run"],

--- a/bin/check_index_age.py
+++ b/bin/check_index_age.py
@@ -21,6 +21,7 @@ import boto3
 # LOGGING #
 ###########
 
+
 class UTCFormatter(logging.Formatter):
     """Custom logging formatter that displays timestamps in UTC."""
 
@@ -35,6 +36,7 @@ class UTCFormatter(logging.Formatter):
         dt = datetime.fromtimestamp(record.created, UTC)
         return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
 
+
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 handler = logging.StreamHandler()
@@ -47,6 +49,7 @@ logger.addHandler(handler)
 # INDEX AGE CHECKS  #
 #####################
 
+
 def get_max_index_age_days(pyproject_path: str = "pyproject.toml") -> int:
     """Read max-stable-index-age-days from pyproject.toml.
     Args:
@@ -57,6 +60,7 @@ def get_max_index_age_days(pyproject_path: str = "pyproject.toml") -> int:
     with open(pyproject_path, "rb") as f:
         data = tomllib.load(f)
     return int(data["tool"]["mgs-workflow"]["max-stable-index-age-days"])
+
 
 def parse_index_date(time_text: str) -> date:
     """Extract the date from an INDEX workflow time.txt timestamp.
@@ -71,6 +75,7 @@ def parse_index_date(time_text: str) -> date:
     text = time_text.strip().replace("(", "").replace(")", "")
     return datetime.strptime(text, "%Y-%m-%d %H:%M:%S %Z %z").date()
 
+
 def fetch_time_txt_from_s3(s3_uri: str) -> str:
     """Download and return the contents of time.txt from S3.
     Args:
@@ -84,6 +89,7 @@ def fetch_time_txt_from_s3(s3_uri: str) -> str:
     response = s3_client.get_object(Bucket=bucket, Key=key)
     content: str = response["Body"].read().decode("utf-8")
     return content
+
 
 def check_index_age(
     index_date: date,
@@ -103,9 +109,11 @@ def check_index_age(
     age_days = (today - index_date).days
     return age_days <= max_age_days, age_days
 
+
 ##############
 # MAIN LOGIC #
 ##############
+
 
 def parse_arguments() -> argparse.Namespace:
     """Parse command-line arguments.
@@ -128,6 +136,7 @@ def parse_arguments() -> argparse.Namespace:
     )
     return parser.parse_args()
 
+
 def main() -> None:
     """Check benchmark index age and raise an error if it is too old."""
     args = parse_arguments()
@@ -149,6 +158,7 @@ def main() -> None:
         age_days,
         max_age_days,
     )
+
 
 if __name__ == "__main__":
     main()

--- a/bin/check_nextflow_version.py
+++ b/bin/check_nextflow_version.py
@@ -4,9 +4,9 @@ Check that the pinned Nextflow version is the latest release by
 comparing against the latest release from GitHub.
 """
 
-#=============================================================================
+# =============================================================================
 # Imports
-#=============================================================================
+# =============================================================================
 
 import argparse
 import json
@@ -14,17 +14,15 @@ import re
 import urllib.request
 from pathlib import Path
 
-#=============================================================================
+# =============================================================================
 # Constants
-#=============================================================================
+# =============================================================================
 
 DEFAULT_CONFIG_PATH = Path(__file__).parent.parent / "configs" / "profiles.config"
 DEFAULT_GITHUB_API_URL = (
     "https://api.github.com/repos/nextflow-io/nextflow/releases/latest"
 )
-GITHUB_RELEASES_URL = (
-    "https://api.github.com/repos/nextflow-io/nextflow/releases"
-)
+GITHUB_RELEASES_URL = "https://api.github.com/repos/nextflow-io/nextflow/releases"
 
 # Known broken Nextflow versions that should be excluded from version checks.
 # Add versions here when they have critical bugs that affect the pipeline.
@@ -40,9 +38,10 @@ NEXTFLOW_VERSION_PATTERN = re.compile(
 # Pattern to validate semantic version (X.Y.Z)
 SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
 
-#=============================================================================
+# =============================================================================
 # Helper functions
-#=============================================================================
+# =============================================================================
+
 
 def validate_semver(version: str, source: str) -> str:
     """
@@ -62,6 +61,7 @@ def validate_semver(version: str, source: str) -> str:
         )
     return version
 
+
 def get_pinned_version(config_path: Path) -> str:
     """
     Extract the pinned Nextflow version from a config file.
@@ -80,6 +80,7 @@ def get_pinned_version(config_path: Path) -> str:
             "Expected format: nextflowVersion = '!>=X.Y.Z'"
         )
     return validate_semver(match.group(1), str(config_path))
+
 
 def get_latest_version(api_url: str) -> str:
     """
@@ -129,9 +130,8 @@ def get_latest_non_excluded_version(excluded: set[str]) -> str:
         if version not in excluded:
             return version
 
-    raise ValueError(
-        f"Could not find any non-excluded release. Excluded: {excluded}"
-    )
+    raise ValueError(f"Could not find any non-excluded release. Excluded: {excluded}")
+
 
 def compare_versions(version1: str, version2: str) -> None:
     """
@@ -143,9 +143,8 @@ def compare_versions(version1: str, version2: str) -> None:
         version2 (str): The second version string to compare.
     """
     if version1 != version2:
-        raise ValueError(
-            f"Version mismatch: {version1} != {version2}"
-        )
+        raise ValueError(f"Version mismatch: {version1} != {version2}")
+
 
 def parse_args() -> argparse.Namespace:
     """
@@ -156,9 +155,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--api-url", default=DEFAULT_GITHUB_API_URL)
     return parser.parse_args()
 
-#=============================================================================
+
+# =============================================================================
 # Main function
-#=============================================================================
+# =============================================================================
+
 
 def main() -> None:
     """
@@ -179,6 +180,7 @@ def main() -> None:
 
     compare_versions(pinned, target)
     print("OK: Pinned version matches target release")
+
 
 if __name__ == "__main__":
     main()

--- a/bin/check_version.py
+++ b/bin/check_version.py
@@ -74,16 +74,16 @@ def main() -> int:
     # If branch info provided, check dev suffix rules
     if args.base_branch:
         is_dev_version = pyproject_version.endswith("-dev")
-        is_release_branch = (
-            args.head_branch and args.head_branch.startswith("release/")
-        )
+        is_release_branch = args.head_branch and args.head_branch.startswith("release/")
 
         print(f"Base branch: {args.base_branch}")
         print(f"Head branch: {args.head_branch}")
 
         # Rule 1: PRs to main/stable, or release PRs to dev, must NOT have -dev suffix
         if args.base_branch in ("main", "stable") or is_release_branch:
-            msg_base = "release PRs" if is_release_branch else f"PRs to {args.base_branch}"
+            msg_base = (
+                "release PRs" if is_release_branch else f"PRs to {args.base_branch}"
+            )
             if is_dev_version:
                 msg = f"ERROR: {msg_base} must not have -dev version suffix"
                 print(msg, file=sys.stderr)

--- a/bin/download_db.py
+++ b/bin/download_db.py
@@ -32,7 +32,7 @@ import subprocess
 import time
 from collections.abc import Generator
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 ###########
@@ -44,7 +44,7 @@ class UTCFormatter(logging.Formatter):
     """Custom logging formatter that displays timestamps in UTC."""
 
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
-        dt = datetime.fromtimestamp(record.created, timezone.utc)
+        dt = datetime.fromtimestamp(record.created, UTC)
         return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
 
 

--- a/bin/download_db.py
+++ b/bin/download_db.py
@@ -72,7 +72,7 @@ def parse_source_path(path: str) -> tuple[str, bool]:
     # Collapse consecutive slashes
     normalized = re.sub(r"//+", "/", path)
     # Check if S3 path and restore proper s3:// prefix
-    if normalized.startswith("s3:/") or normalized.startswith("s3:"):
+    if normalized.startswith(("s3:/", "s3:")):
         path_without_prefix = re.sub(r"^s3:/*", "", normalized)
         return f"s3://{path_without_prefix}", True
     return normalized, False

--- a/bin/download_db.py
+++ b/bin/download_db.py
@@ -113,7 +113,7 @@ def file_lock(
                     if time.time() - start_time >= timeout_seconds:
                         raise TimeoutError(
                             f"Timed out waiting for lock after {timeout_seconds} seconds"
-                        )
+                        ) from None
                     time.sleep(0.1)
         else:
             fcntl.flock(f, fcntl.LOCK_EX)

--- a/bin/download_db.py
+++ b/bin/download_db.py
@@ -39,11 +39,14 @@ from pathlib import Path
 # LOGGING #
 ###########
 
+
 class UTCFormatter(logging.Formatter):
     """Custom logging formatter that displays timestamps in UTC."""
+
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
         dt = datetime.fromtimestamp(record.created, timezone.utc)
         return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+
 
 logger = logging.getLogger(__name__)
 handler = logging.StreamHandler()
@@ -55,6 +58,7 @@ logger.setLevel(logging.INFO)
 ####################
 # HELPER FUNCTIONS #
 ####################
+
 
 def parse_source_path(path: str) -> tuple[str, bool]:
     """
@@ -73,6 +77,7 @@ def parse_source_path(path: str) -> tuple[str, bool]:
         return f"s3://{path_without_prefix}", True
     return normalized, False
 
+
 def get_cache_name(source_path: str) -> str:
     """
     Generate a unique cache directory name from source path.
@@ -83,8 +88,11 @@ def get_cache_name(source_path: str) -> str:
     path_hash = hashlib.sha256(source_path.encode()).hexdigest()[:8]
     return f"{basename}_{path_hash}"
 
+
 @contextmanager
-def file_lock(lock_file: Path, timeout_seconds: float | None = None) -> Generator[None, None, None]:
+def file_lock(
+    lock_file: Path, timeout_seconds: float | None = None
+) -> Generator[None, None, None]:
     """
     Context manager for exclusive file locking.
     Args:
@@ -114,9 +122,11 @@ def file_lock(lock_file: Path, timeout_seconds: float | None = None) -> Generato
     # Lock is released when file is closed
     logger.info("Released lock")
 
+
 #####################
 # DATABASE TRANSFER #
 #####################
+
 
 def configure_aws_s3_transfer() -> None:
     """Configure AWS CLI settings for optimal S3 transfer performance."""
@@ -131,6 +141,7 @@ def configure_aws_s3_transfer() -> None:
             check=True,
             capture_output=True,
         )
+
 
 def sync_from_s3(source_path: str, local_path: Path) -> None:
     """
@@ -148,6 +159,7 @@ def sync_from_s3(source_path: str, local_path: Path) -> None:
     )
     logger.info("S3 sync completed")
 
+
 def sync_from_local(source_path: str, local_path: Path) -> None:
     """
     Sync a database from a local path using 'rsync -a --delete'.
@@ -162,9 +174,11 @@ def sync_from_local(source_path: str, local_path: Path) -> None:
     )
     logger.info("Local sync completed")
 
+
 ##############
 # MAIN LOGIC #
 ##############
+
 
 def download_database(
     source_path: str,
@@ -200,6 +214,7 @@ def download_database(
         logger.info(f"Database available at: {local_path}")
         return local_path
 
+
 def parse_arguments() -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(
@@ -219,6 +234,7 @@ def parse_arguments() -> argparse.Namespace:
     )
     return parser.parse_args()
 
+
 def main() -> None:
     """Main entry point."""
     logger.info("Initializing script.")
@@ -231,6 +247,7 @@ def main() -> None:
     finally:
         elapsed = time.time() - start_time
         logger.info(f"Total time elapsed: {elapsed:.2f} seconds")
+
 
 if __name__ == "__main__":
     main()

--- a/bin/extract_changelog.py
+++ b/bin/extract_changelog.py
@@ -79,10 +79,9 @@ def extract_changelog(
                     # Found the next version header, we're done
                     break
 
-            if in_section:
-                # Collect non-empty lines from the target version section
-                if line.strip():
-                    content_lines.append(line)
+            # Collect non-empty lines from the target version section
+            if in_section and line.strip():
+                content_lines.append(line)
 
     if not found_version:
         raise ValueError(

--- a/bin/extract_changelog.py
+++ b/bin/extract_changelog.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
 """Extract changelog section for a specific version from CHANGELOG.md."""
 
-#=============================================================================
+# =============================================================================
 # Imports
-#=============================================================================
+# =============================================================================
 
 import argparse
 import re
 import sys
 from pathlib import Path
 
-#=============================================================================
+# =============================================================================
 # Constants
-#=============================================================================
+# =============================================================================
 
 DEFAULT_CHANGELOG_PATH = Path("CHANGELOG.md")
 
@@ -20,9 +20,10 @@ DEFAULT_CHANGELOG_PATH = Path("CHANGELOG.md")
 # Also tolerates no space after # (e.g., "#v1.2.3.4")
 VERSION_HEADER_PATTERN = re.compile(r"^#\s*v?(\d+\.\d+\.\d+\.\d+(?:-dev)?)$")
 
-#=============================================================================
+# =============================================================================
 # Helper functions
-#=============================================================================
+# =============================================================================
+
 
 def parse_version_header(line: str) -> str | None:
     """
@@ -40,7 +41,9 @@ def parse_version_header(line: str) -> str | None:
     return None
 
 
-def extract_changelog(version: str, changelog_path: Path = DEFAULT_CHANGELOG_PATH) -> str:
+def extract_changelog(
+    version: str, changelog_path: Path = DEFAULT_CHANGELOG_PATH
+) -> str:
     """
     Extract the changelog content for a specific version by streaming the file.
 
@@ -86,11 +89,13 @@ def extract_changelog(version: str, changelog_path: Path = DEFAULT_CHANGELOG_PAT
             f"Version {version} not found in {changelog_path}. "
             f"Expected header format: '# v{version}' or '# {version}'"
         )
-    
+
     # Raise an error if the content is empty / contains only whitespace
     has_content = any(line.strip() for line in content_lines)
     if not has_content:
-        raise ValueError(f"Version {version} found in {changelog_path.name} but contains no content")
+        raise ValueError(
+            f"Version {version} found in {changelog_path.name} but contains no content"
+        )
 
     return "".join(content_lines)
 
@@ -123,9 +128,11 @@ Examples:
 
     return parser.parse_args()
 
-#=============================================================================
+
+# =============================================================================
 # Main function
-#=============================================================================
+# =============================================================================
+
 
 def main() -> None:
     """

--- a/bin/extract_changelog.py
+++ b/bin/extract_changelog.py
@@ -75,7 +75,7 @@ def extract_changelog(
                     found_version = True
                     in_section = True
                     continue  # Skip the header line itself
-                elif in_section:
+                if in_section:
                     # Found the next version header, we're done
                     break
 

--- a/bin/prepare_tiny_test_data.py
+++ b/bin/prepare_tiny_test_data.py
@@ -351,7 +351,7 @@ def upload_to_s3(local_file: Path, s3_uri: str) -> None:
     # Parse S3 URI
     if not s3_uri.startswith("s3://"):
         raise ValueError(f"Invalid S3 URI: {s3_uri}")
-    parts = s3_uri.lstrip("s3://").rstrip("/").split("/", 1)
+    parts = s3_uri.removeprefix("s3://").rstrip("/").split("/", 1)
     bucket = parts[0]
     key = parts[1] if len(parts) > 1 else local_file.name
     s3_client = boto3.client("s3")

--- a/bin/prepare_tiny_test_data.py
+++ b/bin/prepare_tiny_test_data.py
@@ -301,7 +301,7 @@ def interleave_paired_reads(
         r2_records = SeqIO.parse(f2, file_format)
 
         interleaved_records = []
-        for rec1, rec2 in zip(r1_records, r2_records):
+        for rec1, rec2 in zip(r1_records, r2_records, strict=False):
             interleaved_records.append(rec1)
             interleaved_records.append(rec2)
 

--- a/bin/prepare_tiny_test_data.py
+++ b/bin/prepare_tiny_test_data.py
@@ -301,7 +301,7 @@ def interleave_paired_reads(
         r2_records = SeqIO.parse(f2, file_format)
 
         interleaved_records = []
-        for rec1, rec2 in zip(r1_records, r2_records, strict=False):
+        for rec1, rec2 in zip(r1_records, r2_records, strict=True):
             interleaved_records.append(rec1)
             interleaved_records.append(rec2)
 

--- a/bin/prepare_tiny_test_data.py
+++ b/bin/prepare_tiny_test_data.py
@@ -341,6 +341,26 @@ def gzip_file(local_file: Path, gzip_file: Path) -> None:
     logger.info(f"Gzipped {local_file.name} to {gzip_file.name}.")
 
 
+def parse_s3_uri(s3_uri: str, default_key: str) -> tuple[str, str]:
+    """
+    Parse an `s3://bucket/key` URI into its (bucket, key) parts.
+    If the URI has no key portion, returns ``default_key`` as the key.
+    Args:
+        s3_uri (str): Full S3 URI (must start with `s3://`).
+        default_key (str): Key to use when the URI omits one.
+    Returns:
+        tuple[str, str]: (bucket, key)
+    Raises:
+        ValueError: If ``s3_uri`` does not start with `s3://`.
+    """
+    if not s3_uri.startswith("s3://"):
+        raise ValueError(f"Invalid S3 URI: {s3_uri}")
+    parts = s3_uri.removeprefix("s3://").rstrip("/").split("/", 1)
+    bucket = parts[0]
+    key = parts[1] if len(parts) > 1 else default_key
+    return bucket, key
+
+
 def upload_to_s3(local_file: Path, s3_uri: str) -> None:
     """
     Upload a file to S3.
@@ -348,12 +368,7 @@ def upload_to_s3(local_file: Path, s3_uri: str) -> None:
         local_file (Path): Path to local file to upload
         s3_uri (str): Full S3 URI (e.g., s3://bucket/key)
     """
-    # Parse S3 URI
-    if not s3_uri.startswith("s3://"):
-        raise ValueError(f"Invalid S3 URI: {s3_uri}")
-    parts = s3_uri.removeprefix("s3://").rstrip("/").split("/", 1)
-    bucket = parts[0]
-    key = parts[1] if len(parts) > 1 else local_file.name
+    bucket, key = parse_s3_uri(s3_uri, default_key=local_file.name)
     s3_client = boto3.client("s3")
     try:
         logger.info(f"Uploading {local_file.name} to {s3_uri}...")

--- a/bin/prepare_tiny_test_data.py
+++ b/bin/prepare_tiny_test_data.py
@@ -10,16 +10,15 @@ Generate tiny Illumina and ONT test datasets from reference genomes using InSili
 import argparse
 import gzip
 import logging
+import shutil
 import subprocess
 import tempfile
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Optional, Tuple, List
+
 import boto3
-from botocore.exceptions import ClientError, NoCredentialsError
-import shutil
 from Bio import SeqIO
-import os
+from botocore.exceptions import ClientError, NoCredentialsError
 
 ###########
 # LOGGING #
@@ -29,11 +28,9 @@ import os
 class UTCFormatter(logging.Formatter):
     """Custom logging formatter that displays timestamps in UTC."""
 
-    def formatTime(
-        self, record: logging.LogRecord, datefmt: Optional[str] = None
-    ) -> str:
+    def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
         """Format log timestamps in UTC timezone."""
-        dt = datetime.fromtimestamp(record.created, timezone.utc)
+        dt = datetime.fromtimestamp(record.created, UTC)
         return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
@@ -74,9 +71,9 @@ def generate_illumina(
     output_prefix: Path,
     n_read_pairs: int,
     seed: int,
-    fragment_length: Optional[int] = None,
+    fragment_length: int | None = None,
     model: str = "NovaSeq",
-) -> Tuple[Path, Path]:
+) -> tuple[Path, Path]:
     """
     Generate paired-end Illumina reads from a FASTA file using InSilicoSeq.
     Args:
@@ -234,7 +231,7 @@ def generate_ont(
     return fastq_file
 
 
-def concatenate_files(paths: List[Path], output: Path) -> None:
+def concatenate_files(paths: list[Path], output: Path) -> None:
     """
     Concatenate multiple files with matching extensions into a single file.
     Args:
@@ -296,8 +293,8 @@ def interleave_paired_reads(
     logger.info(f"Interleaving {r1_file.name} and {r2_file.name}...")
 
     with (
-        open(r1_file, "r") as f1,
-        open(r2_file, "r") as f2,
+        open(r1_file) as f1,
+        open(r2_file) as f2,
         open(output_file, "w") as out,
     ):
         r1_records = SeqIO.parse(f1, file_format)
@@ -321,9 +318,8 @@ def fastq_to_fasta(fastq_file: Path, fasta_file: Path) -> None:
         fasta_file (Path): Output FASTA file
     """
     logger.info(f"Converting {fastq_file.name} to FASTA...")
-    with open(fastq_file, "r") as f_in:
-        with open(fasta_file, "w") as f_out:
-            SeqIO.convert(f_in, "fastq", f_out, "fasta")
+    with open(fastq_file) as f_in, open(fasta_file, "w") as f_out:
+        SeqIO.convert(f_in, "fastq", f_out, "fasta")
     logger.info(f"Converted to {fasta_file.name}.")
 
 
@@ -340,9 +336,8 @@ def gzip_file(local_file: Path, gzip_file: Path) -> None:
         gzip_file (Path): Path to gzipped file
     """
     logger.info(f"Gzipping {local_file.name}...")
-    with open(local_file, "rb") as f_in:
-        with gzip.open(gzip_file, "wb") as f_out:
-            f_out.write(f_in.read())
+    with open(local_file, "rb") as f_in, gzip.open(gzip_file, "wb") as f_out:
+        f_out.write(f_in.read())
     logger.info(f"Gzipped {local_file.name} to {gzip_file.name}.")
 
 
@@ -379,7 +374,7 @@ def upload_to_s3(local_file: Path, s3_uri: str) -> None:
 
 def generate_illumina_data(
     fasta_viral: Path,
-    fasta_other: List[Path],
+    fasta_other: list[Path],
     read_pairs_per_genome: int,
     output_prefix_local: str,
     output_prefix_s3: str,
@@ -403,15 +398,13 @@ def generate_illumina_data(
         tmpdir = Path(tmpdir_str)
         r1_files = []
         r2_files = []
-        logger.info(f"Generating Illumina test data from each input file...")
+        logger.info("Generating Illumina test data from each input file...")
         for fasta in [fasta_viral] + fasta_other:
             prefix = tmpdir / f"{fasta.stem}"
             r1, r2 = generate_illumina(fasta, prefix, read_pairs_per_genome, seed)
             r1_files.append(r1)
             r2_files.append(r2)
-        logger.info(
-            f"Generating extra overlapping Illumina reads from viral genomes..."
-        )
+        logger.info("Generating extra overlapping Illumina reads from viral genomes...")
         # Create a modified copy of the viral FASTA to avoid duplicate read IDs
         viral_modified = tmpdir / "viral_overlap.fasta"
         modify_fasta_headers(fasta_viral, viral_modified, "_overlap")
@@ -421,25 +414,25 @@ def generate_illumina_data(
         )
         r1_files.append(r1)
         r2_files.append(r2)
-        logger.info(f"Concatenating all Illumina reads...")
+        logger.info("Concatenating all Illumina reads...")
         concat_r1_raw = tmpdir / "R1_raw.fastq"
         concat_r2_raw = tmpdir / "R2_raw.fastq"
         concatenate_files(r1_files, concat_r1_raw)
         concatenate_files(r2_files, concat_r2_raw)
-        logger.info(f"Fixing read IDs to use space-delimited format...")
+        logger.info("Fixing read IDs to use space-delimited format...")
         concat_r1 = tmpdir / "R1.fastq"
         concat_r2 = tmpdir / "R2.fastq"
         fix_fastq_read_ids(concat_r1_raw, concat_r1)
         fix_fastq_read_ids(concat_r2_raw, concat_r2)
-        logger.info(f"Generating gzipped copies of the concatenated Illumina reads...")
+        logger.info("Generating gzipped copies of the concatenated Illumina reads...")
         gzip_r1 = concat_r1.with_suffix(".gz")
         gzip_r2 = concat_r2.with_suffix(".gz")
         gzip_file(concat_r1, gzip_r1)
         gzip_file(concat_r2, gzip_r2)
-        logger.info(f"Uploading Illumina reads to S3...")
+        logger.info("Uploading Illumina reads to S3...")
         upload_to_s3(gzip_r1, output_prefix_s3 + "R1.fastq.gz")
         upload_to_s3(gzip_r2, output_prefix_s3 + "R2.fastq.gz")
-        logger.info(f"Creating unzipped local copies of the Illumina reads...")
+        logger.info("Creating unzipped local copies of the Illumina reads...")
         # Convert string prefix to Path - handle both directory paths and file prefixes
         output_prefix_path = Path(output_prefix_local)
         # Create parent directory
@@ -453,33 +446,33 @@ def generate_illumina_data(
         dest_r2 = Path(output_prefix_local + "R2.fastq")
         shutil.copy2(str(concat_r1), str(dest_r1))
         shutil.copy2(str(concat_r2), str(dest_r2))
-        logger.info(f"Converting Illumina FASTQs to FASTA format...")
+        logger.info("Converting Illumina FASTQs to FASTA format...")
         fasta_r1 = Path(output_prefix_local + "R1.fasta")
         fasta_r2 = Path(output_prefix_local + "R2.fasta")
         fastq_to_fasta(dest_r1, fasta_r1)
         fastq_to_fasta(dest_r2, fasta_r2)
 
-        logger.info(f"Creating interleaved FASTQ file...")
+        logger.info("Creating interleaved FASTQ file...")
         interleaved_fastq = tmpdir / "interleaved.fastq"
         interleave_paired_reads(concat_r1, concat_r2, interleaved_fastq, "fastq")
         dest_interleaved_fastq = Path(output_prefix_local + "interleaved.fastq")
         shutil.copy2(str(interleaved_fastq), str(dest_interleaved_fastq))
 
-        logger.info(f"Creating interleaved FASTA file...")
+        logger.info("Creating interleaved FASTA file...")
         interleaved_fasta = Path(output_prefix_local + "interleaved.fasta")
         interleave_paired_reads(fasta_r1, fasta_r2, interleaved_fasta, "fasta")
 
-        logger.info(f"Gzipping and uploading interleaved FASTQ...")
+        logger.info("Gzipping and uploading interleaved FASTQ...")
         gzip_interleaved = interleaved_fastq.with_suffix(".fastq.gz")
         gzip_file(interleaved_fastq, gzip_interleaved)
         upload_to_s3(gzip_interleaved, output_prefix_s3 + "interleaved.fastq.gz")
 
-        logger.info(f"Done.")
+        logger.info("Done.")
 
 
 def generate_ont_data(
     fasta_viral: Path,
-    fasta_other: List[Path],
+    fasta_other: list[Path],
     reads_per_genome: int,
     output_prefix_local: str,
     output_prefix_s3: str,
@@ -510,7 +503,7 @@ def generate_ont_data(
         logger.info("Downloading NanoSim model...")
         model_dir = download_nanosim_model(tmpdir, nanosim_model_url)
 
-        logger.info(f"Generating ONT reads from each input file...")
+        logger.info("Generating ONT reads from each input file...")
         # Use different seeds for each genome to ensure unique read IDs
 
         # Generate double reads from viral genome
@@ -530,18 +523,18 @@ def generate_ont_data(
             )
             fastq_files.append(fastq)
 
-        logger.info(f"Concatenating all ONT reads...")
+        logger.info("Concatenating all ONT reads...")
         concat_fastq = tmpdir / "ont.fastq"
         concatenate_files(fastq_files, concat_fastq)
 
-        logger.info(f"Generating gzipped copy of the concatenated ONT reads...")
+        logger.info("Generating gzipped copy of the concatenated ONT reads...")
         gzip_fastq = concat_fastq.with_suffix(".fastq.gz")
         gzip_file(concat_fastq, gzip_fastq)
 
-        logger.info(f"Uploading ONT reads to S3...")
+        logger.info("Uploading ONT reads to S3...")
         upload_to_s3(gzip_fastq, output_prefix_s3 + "ont.fastq.gz")
 
-        logger.info(f"Creating unzipped local copy of the ONT reads...")
+        logger.info("Creating unzipped local copy of the ONT reads...")
         # Convert string prefix to Path - handle both directory paths and file prefixes
         output_prefix_path = Path(output_prefix_local)
         # Create parent directory
@@ -554,11 +547,11 @@ def generate_ont_data(
         dest_fastq = Path(output_prefix_local + "ont.fastq")
         shutil.copy2(str(concat_fastq), str(dest_fastq))
 
-        logger.info(f"Converting ONT FASTQ to FASTA format...")
+        logger.info("Converting ONT FASTQ to FASTA format...")
         fasta_file = Path(output_prefix_local + "ont.fasta")
         fastq_to_fasta(dest_fastq, fasta_file)
 
-        logger.info(f"Done.")
+        logger.info("Done.")
 
 
 def parse_arguments() -> argparse.Namespace:

--- a/bin/prepare_tiny_test_data.py
+++ b/bin/prepare_tiny_test_data.py
@@ -25,13 +25,17 @@ import os
 # LOGGING #
 ###########
 
+
 class UTCFormatter(logging.Formatter):
     """Custom logging formatter that displays timestamps in UTC."""
 
-    def formatTime(self, record: logging.LogRecord, datefmt: Optional[str] = None) -> str:
+    def formatTime(
+        self, record: logging.LogRecord, datefmt: Optional[str] = None
+    ) -> str:
         """Format log timestamps in UTC timezone."""
         dt = datetime.fromtimestamp(record.created, timezone.utc)
         return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger()
@@ -46,6 +50,7 @@ logger.addHandler(handler)
 ########################
 
 NANOSIM_MODEL_URL = "https://raw.githubusercontent.com/bcgsc/NanoSim/master/pre-trained_models/human_giab_hg002_sub1M_kitv14_dorado_v3.2.1.tar.gz"
+
 
 def modify_fasta_headers(input_fasta: Path, output_fasta: Path, suffix: str) -> None:
     """
@@ -63,12 +68,15 @@ def modify_fasta_headers(input_fasta: Path, output_fasta: Path, suffix: str) -> 
         records.append(record)
     SeqIO.write(records, output_fasta, "fasta")
 
-def generate_illumina(fasta_file: Path,
-                   output_prefix: Path,
-                   n_read_pairs: int,
-                   seed: int,
-                   fragment_length: Optional[int] = None,
-                   model: str = "NovaSeq") -> Tuple[Path, Path]:
+
+def generate_illumina(
+    fasta_file: Path,
+    output_prefix: Path,
+    n_read_pairs: int,
+    seed: int,
+    fragment_length: Optional[int] = None,
+    model: str = "NovaSeq",
+) -> Tuple[Path, Path]:
     """
     Generate paired-end Illumina reads from a FASTA file using InSilicoSeq.
     Args:
@@ -83,16 +91,23 @@ def generate_illumina(fasta_file: Path,
     """
     logger.info(f"Generating {n_read_pairs} read pairs from {fasta_file.name}...")
     cmd = [
-        "iss", "generate",
-        "--genomes", str(fasta_file),
-        "--n_reads", str(n_read_pairs * 2),
-        "--model", model,
-        "--output", str(output_prefix),
-        "--seed", str(seed),
+        "iss",
+        "generate",
+        "--genomes",
+        str(fasta_file),
+        "--n_reads",
+        str(n_read_pairs * 2),
+        "--model",
+        model,
+        "--output",
+        str(output_prefix),
+        "--seed",
+        str(seed),
     ]
     if fragment_length is not None:
-        cmd.extend(["--fragment-length", str(fragment_length),
-                    "--fragment-length-sd", "0"])
+        cmd.extend(
+            ["--fragment-length", str(fragment_length), "--fragment-length-sd", "0"]
+        )
     result = subprocess.run(cmd, capture_output=True, text=True)
     if result.returncode != 0:
         logger.error(f"Failed to generate reads from {fasta_file}")
@@ -101,9 +116,12 @@ def generate_illumina(fasta_file: Path,
     r1_file = Path(f"{output_prefix}_R1.fastq")
     r2_file = Path(f"{output_prefix}_R2.fastq")
     if not r1_file.exists() or not r2_file.exists():
-        raise FileNotFoundError(f"Expected output files not found: {r1_file}, {r2_file}")
+        raise FileNotFoundError(
+            f"Expected output files not found: {r1_file}, {r2_file}"
+        )
     logger.info(f"  Generated {r1_file.name} and {r2_file.name}")
     return r1_file, r2_file
+
 
 def download_nanosim_model(tmpdir: Path, model_url: str) -> Path:
     """
@@ -119,9 +137,9 @@ def download_nanosim_model(tmpdir: Path, model_url: str) -> Path:
     model_tarball = tmpdir / "nanosim_model.tar.gz"
     model_dir = tmpdir / "nanosim_model"
     logger.info(f"Downloading NanoSim model from {model_url}...")
-    result = subprocess.run([
-        "wget", model_url, "-O", str(model_tarball)
-    ], capture_output=True, text=True)
+    result = subprocess.run(
+        ["wget", model_url, "-O", str(model_tarball)], capture_output=True, text=True
+    )
 
     if result.returncode != 0:
         logger.error("Failed to download NanoSim model")
@@ -130,9 +148,18 @@ def download_nanosim_model(tmpdir: Path, model_url: str) -> Path:
 
     logger.info("Extracting NanoSim model...")
     model_dir.mkdir(exist_ok=True)
-    result = subprocess.run([
-        "tar", "-xzf", str(model_tarball), "-C", str(model_dir), "--strip-components=1"
-    ], capture_output=True, text=True)
+    result = subprocess.run(
+        [
+            "tar",
+            "-xzf",
+            str(model_tarball),
+            "-C",
+            str(model_dir),
+            "--strip-components=1",
+        ],
+        capture_output=True,
+        text=True,
+    )
 
     if result.returncode != 0:
         logger.error("Failed to extract NanoSim model")
@@ -144,11 +171,10 @@ def download_nanosim_model(tmpdir: Path, model_url: str) -> Path:
 
     return model_dir
 
-def generate_ont(fasta_file: Path,
-                 output_prefix: Path,
-                 n_reads: int,
-                 model_dir: Path,
-                 seed: int = 0) -> Path:
+
+def generate_ont(
+    fasta_file: Path, output_prefix: Path, n_reads: int, model_dir: Path, seed: int = 0
+) -> Path:
     """
     Generate ONT reads from a FASTA file using NanoSim.
 
@@ -167,16 +193,28 @@ def generate_ont(fasta_file: Path,
     # NanoSim expects the model path to point to the training prefix
     model_prefix = model_dir / "training"
 
-    result = subprocess.run([
-        "simulator.py", "genome",
-        "-rg", str(fasta_file.resolve()),  # Use absolute path
-        "-n", str(n_reads),
-        "-s", "0.5",  # Strandedness (0.5 = equal forward/reverse)
-        "-c", str(model_prefix),
-        "-o", str(output_prefix),
-        "--seed", str(seed),
-        "--fastq"
-    ], capture_output=True, text=True, cwd=output_prefix.parent)
+    result = subprocess.run(
+        [
+            "simulator.py",
+            "genome",
+            "-rg",
+            str(fasta_file.resolve()),  # Use absolute path
+            "-n",
+            str(n_reads),
+            "-s",
+            "0.5",  # Strandedness (0.5 = equal forward/reverse)
+            "-c",
+            str(model_prefix),
+            "-o",
+            str(output_prefix),
+            "--seed",
+            str(seed),
+            "--fastq",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=output_prefix.parent,
+    )
 
     if result.returncode != 0:
         logger.error(f"Failed to generate ONT reads from {fasta_file}")
@@ -195,6 +233,7 @@ def generate_ont(fasta_file: Path,
     logger.info(f"  Generated {fastq_file.name}")
     return fastq_file
 
+
 def concatenate_files(paths: List[Path], output: Path) -> None:
     """
     Concatenate multiple files with matching extensions into a single file.
@@ -207,11 +246,12 @@ def concatenate_files(paths: List[Path], output: Path) -> None:
     if len(set(extensions)) != 1:
         raise ValueError(f"Input files have different extensions: {extensions}")
     logger.info(f"Concatenating {len(paths)} files into {output.name}...")
-    with open(output, 'wb') as outf:
+    with open(output, "wb") as outf:
         for path in paths:
-            with open(path, 'rb') as inf:
+            with open(path, "rb") as inf:
                 outf.write(inf.read())
     logger.info(f"Concatenated files into {output}.")
+
 
 def fix_fastq_read_ids(input_fastq: Path, output_fastq: Path) -> None:
     """
@@ -240,7 +280,10 @@ def fix_fastq_read_ids(input_fastq: Path, output_fastq: Path) -> None:
     SeqIO.write(records, output_fastq, "fastq")
     logger.info(f"Fixed {len(records)} read IDs in {output_fastq.name}")
 
-def interleave_paired_reads(r1_file: Path, r2_file: Path, output_file: Path, file_format: str = "fastq") -> None:
+
+def interleave_paired_reads(
+    r1_file: Path, r2_file: Path, output_file: Path, file_format: str = "fastq"
+) -> None:
     """
     Interleave paired-end reads from R1 and R2 files into a single file.
 
@@ -252,7 +295,11 @@ def interleave_paired_reads(r1_file: Path, r2_file: Path, output_file: Path, fil
     """
     logger.info(f"Interleaving {r1_file.name} and {r2_file.name}...")
 
-    with open(r1_file, 'r') as f1, open(r2_file, 'r') as f2, open(output_file, 'w') as out:
+    with (
+        open(r1_file, "r") as f1,
+        open(r2_file, "r") as f2,
+        open(output_file, "w") as out,
+    ):
         r1_records = SeqIO.parse(f1, file_format)
         r2_records = SeqIO.parse(f2, file_format)
 
@@ -265,6 +312,7 @@ def interleave_paired_reads(r1_file: Path, r2_file: Path, output_file: Path, fil
 
     logger.info(f"Created interleaved file: {output_file.name}")
 
+
 def fastq_to_fasta(fastq_file: Path, fasta_file: Path) -> None:
     """
     Convert FASTQ file to FASTA format.
@@ -273,14 +321,16 @@ def fastq_to_fasta(fastq_file: Path, fasta_file: Path) -> None:
         fasta_file (Path): Output FASTA file
     """
     logger.info(f"Converting {fastq_file.name} to FASTA...")
-    with open(fastq_file, 'r') as f_in:
-        with open(fasta_file, 'w') as f_out:
+    with open(fastq_file, "r") as f_in:
+        with open(fasta_file, "w") as f_out:
             SeqIO.convert(f_in, "fastq", f_out, "fasta")
     logger.info(f"Converted to {fasta_file.name}.")
+
 
 #############
 # S3 UPLOAD #
 #############
+
 
 def gzip_file(local_file: Path, gzip_file: Path) -> None:
     """
@@ -290,10 +340,11 @@ def gzip_file(local_file: Path, gzip_file: Path) -> None:
         gzip_file (Path): Path to gzipped file
     """
     logger.info(f"Gzipping {local_file.name}...")
-    with open(local_file, 'rb') as f_in:
-        with gzip.open(gzip_file, 'wb') as f_out:
+    with open(local_file, "rb") as f_in:
+        with gzip.open(gzip_file, "wb") as f_out:
             f_out.write(f_in.read())
     logger.info(f"Gzipped {local_file.name} to {gzip_file.name}.")
+
 
 def upload_to_s3(local_file: Path, s3_uri: str) -> None:
     """
@@ -308,7 +359,7 @@ def upload_to_s3(local_file: Path, s3_uri: str) -> None:
     parts = s3_uri.lstrip("s3://").rstrip("/").split("/", 1)
     bucket = parts[0]
     key = parts[1] if len(parts) > 1 else local_file.name
-    s3_client = boto3.client('s3')
+    s3_client = boto3.client("s3")
     try:
         logger.info(f"Uploading {local_file.name} to {s3_uri}...")
         s3_client.upload_file(str(local_file), bucket, key)
@@ -320,16 +371,20 @@ def upload_to_s3(local_file: Path, s3_uri: str) -> None:
         logger.error(f"Failed to upload to S3: {e}.")
         raise
 
+
 #################
 # MAIN WORKFLOW #
 #################
 
-def generate_illumina_data(fasta_viral: Path,
-                           fasta_other: List[Path],
-                           read_pairs_per_genome: int,
-                           output_prefix_local: str,
-                           output_prefix_s3: str,
-                           seed: int) -> None:
+
+def generate_illumina_data(
+    fasta_viral: Path,
+    fasta_other: List[Path],
+    read_pairs_per_genome: int,
+    output_prefix_local: str,
+    output_prefix_s3: str,
+    seed: int,
+) -> None:
     """
     Generate test read data from reference genomes and upload to S3.
 
@@ -354,12 +409,16 @@ def generate_illumina_data(fasta_viral: Path,
             r1, r2 = generate_illumina(fasta, prefix, read_pairs_per_genome, seed)
             r1_files.append(r1)
             r2_files.append(r2)
-        logger.info(f"Generating extra overlapping Illumina reads from viral genomes...")
+        logger.info(
+            f"Generating extra overlapping Illumina reads from viral genomes..."
+        )
         # Create a modified copy of the viral FASTA to avoid duplicate read IDs
         viral_modified = tmpdir / "viral_overlap.fasta"
         modify_fasta_headers(fasta_viral, viral_modified, "_overlap")
         prefix = tmpdir / "viral_overlap"
-        r1, r2 = generate_illumina(viral_modified, prefix, read_pairs_per_genome, seed, 200)
+        r1, r2 = generate_illumina(
+            viral_modified, prefix, read_pairs_per_genome, seed, 200
+        )
         r1_files.append(r1)
         r2_files.append(r2)
         logger.info(f"Concatenating all Illumina reads...")
@@ -384,7 +443,7 @@ def generate_illumina_data(fasta_viral: Path,
         # Convert string prefix to Path - handle both directory paths and file prefixes
         output_prefix_path = Path(output_prefix_local)
         # Create parent directory
-        if str(output_prefix_local).endswith('/'):
+        if str(output_prefix_local).endswith("/"):
             # It's a directory path, create it
             output_prefix_path.mkdir(parents=True, exist_ok=True)
         else:
@@ -417,13 +476,16 @@ def generate_illumina_data(fasta_viral: Path,
 
         logger.info(f"Done.")
 
-def generate_ont_data(fasta_viral: Path,
-                      fasta_other: List[Path],
-                      reads_per_genome: int,
-                      output_prefix_local: str,
-                      output_prefix_s3: str,
-                      nanosim_model_url: str,
-                      seed: int) -> None:
+
+def generate_ont_data(
+    fasta_viral: Path,
+    fasta_other: List[Path],
+    reads_per_genome: int,
+    output_prefix_local: str,
+    output_prefix_s3: str,
+    nanosim_model_url: str,
+    seed: int,
+) -> None:
     """
     Generate ONT test read data from reference genomes and upload to S3.
 
@@ -454,14 +516,18 @@ def generate_ont_data(fasta_viral: Path,
         # Generate double reads from viral genome
         prefix = tmpdir / fasta_viral.stem
         viral_seed = seed
-        fastq = generate_ont(fasta_viral, prefix, reads_per_genome * 2, model_dir, viral_seed)
+        fastq = generate_ont(
+            fasta_viral, prefix, reads_per_genome * 2, model_dir, viral_seed
+        )
         fastq_files.append(fastq)
 
         # Generate reads from other genomes
         for i, fasta in enumerate(fasta_other):
             prefix = tmpdir / fasta.stem
             genome_seed = seed + i + 1
-            fastq = generate_ont(fasta, prefix, reads_per_genome, model_dir, genome_seed)
+            fastq = generate_ont(
+                fasta, prefix, reads_per_genome, model_dir, genome_seed
+            )
             fastq_files.append(fastq)
 
         logger.info(f"Concatenating all ONT reads...")
@@ -479,7 +545,7 @@ def generate_ont_data(fasta_viral: Path,
         # Convert string prefix to Path - handle both directory paths and file prefixes
         output_prefix_path = Path(output_prefix_local)
         # Create parent directory
-        if str(output_prefix_local).endswith('/'):
+        if str(output_prefix_local).endswith("/"):
             # It's a directory path, create it
             output_prefix_path.mkdir(parents=True, exist_ok=True)
         else:
@@ -494,55 +560,65 @@ def generate_ont_data(fasta_viral: Path,
 
         logger.info(f"Done.")
 
+
 def parse_arguments() -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(
-        description=DESC,
-        formatter_class=argparse.RawDescriptionHelpFormatter
+        description=DESC, formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument(
-        "--fasta-viral", "-v",
+        "--fasta-viral",
+        "-v",
         type=Path,
         default=Path("./test-data/tiny-index/genomes/hdv.fasta"),
-        help="Plaintext FASTA file for viral genomes"
+        help="Plaintext FASTA file for viral genomes",
     )
     parser.add_argument(
-        "--fasta-other", "-f",
+        "--fasta-other",
+        "-f",
         help="List of plaintext FASTA files for other genomes, provided as a comma-separated list of paths",
         type=lambda s: [Path(p) for p in s.split(",")],
-        default=[Path(f"./test-data/tiny-index/genomes/{name}.fasta") for name in ["human", "phage", "rrna"]],
+        default=[
+            Path(f"./test-data/tiny-index/genomes/{name}.fasta")
+            for name in ["human", "phage", "rrna"]
+        ],
     )
     parser.add_argument(
-        "--n-reads", "-n",
+        "--n-reads",
+        "-n",
         type=int,
         default=5,
-        help="Number of reads (Illumina pairs, ONT single reads) to generate per input file (default: 5)"
+        help="Number of reads (Illumina pairs, ONT single reads) to generate per input file (default: 5)",
     )
     parser.add_argument(
-        "--output-prefix-local", "-o",
+        "--output-prefix-local",
+        "-o",
         type=str,
         default="./test-data/tiny-index/reads/",
-        help="Local path prefix for output files (default: ./test-data/tiny-index/reads/)"
+        help="Local path prefix for output files (default: ./test-data/tiny-index/reads/)",
     )
     parser.add_argument(
-        "--output-prefix-s3", "-s",
+        "--output-prefix-s3",
+        "-s",
         type=str,
         default="s3://nao-testing/tiny-test/raw/tiny-test_",
-        help="S3 URI prefix for output files (default: s3://nao-testing/tiny-test/raw)"
+        help="S3 URI prefix for output files (default: s3://nao-testing/tiny-test/raw)",
     )
     parser.add_argument(
-        "--seed", "-e",
+        "--seed",
+        "-e",
         type=int,
         default=827100,
-        help="Seed for random number generators (default: 827100)"
+        help="Seed for random number generators (default: 827100)",
     )
     parser.add_argument(
         "--nanosim-model-url",
         type=str,
         default=NANOSIM_MODEL_URL,
-        help=f"URL to NanoSim pre-trained model tarball (default: {NANOSIM_MODEL_URL})"
+        help=f"URL to NanoSim pre-trained model tarball (default: {NANOSIM_MODEL_URL})",
     )
     return parser.parse_args()
+
 
 def main() -> None:
     """Main entry point for the script."""
@@ -553,7 +629,7 @@ def main() -> None:
         read_pairs_per_genome=args.n_reads,
         output_prefix_local=args.output_prefix_local,
         output_prefix_s3=args.output_prefix_s3,
-        seed=args.seed
+        seed=args.seed,
     )
     generate_ont_data(
         fasta_viral=args.fasta_viral,
@@ -562,8 +638,9 @@ def main() -> None:
         output_prefix_local=args.output_prefix_local,
         output_prefix_s3=args.output_prefix_s3,
         nanosim_model_url=args.nanosim_model_url,
-        seed=args.seed
+        seed=args.seed,
     )
+
 
 if __name__ == "__main__":
     main()

--- a/bin/run_nf_test_parallel.py
+++ b/bin/run_nf_test_parallel.py
@@ -29,13 +29,17 @@ import sys
 # LOGGING #
 ###########
 
+
 class UTCFormatter(logging.Formatter):
     """Custom logging formatter that displays timestamps in UTC."""
 
-    def formatTime(self, record: logging.LogRecord, datefmt: Optional[str] = None) -> str:
+    def formatTime(
+        self, record: logging.LogRecord, datefmt: Optional[str] = None
+    ) -> str:
         """Format log timestamps in UTC timezone."""
         dt = datetime.fromtimestamp(record.created, timezone.utc)
         return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger()
@@ -49,6 +53,7 @@ logger.addHandler(handler)
 # HELPER FUNCTIONS #
 ####################
 
+
 def strip_ansi_codes(text: str) -> str:
     """
     Remove ANSI escape codes from text.
@@ -57,8 +62,9 @@ def strip_ansi_codes(text: str) -> str:
     Returns:
         Text with ANSI codes removed
     """
-    ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
-    return ansi_escape.sub('', text)
+    ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+    return ansi_escape.sub("", text)
+
 
 def find_test_files(paths: List[str]) -> List[Path]:
     """
@@ -76,11 +82,12 @@ def find_test_files(paths: List[str]) -> List[Path]:
             logger.warning(f"Path does not exist: {path}")
             continue
         if path.is_file():
-            if path.name.endswith('.nf.test'):
+            if path.name.endswith(".nf.test"):
                 test_files.append(path)
         elif path.is_dir():
-            test_files.extend(path.rglob('*.nf.test'))
+            test_files.extend(path.rglob("*.nf.test"))
     return sorted(set(test_files))
+
 
 def divide_test_files(test_files: List[Path], n_workers: int) -> List[List[Path]]:
     """
@@ -98,6 +105,7 @@ def divide_test_files(test_files: List[Path], n_workers: int) -> List[List[Path]
         worker_files[i % n_workers].append(test_file)
     return worker_files
 
+
 def execute_subprocess(cmd: List[str]) -> Tuple[int, str, str]:
     """
     Execute a subprocess and capture output.
@@ -109,12 +117,15 @@ def execute_subprocess(cmd: List[str]) -> Tuple[int, str, str]:
     result = subprocess.run(cmd, capture_output=True, text=True)
     return (result.returncode, result.stdout, result.stderr)
 
-def run_nf_test_worker(worker_id: int,
-                       test_files: List[Path],
-                       total_workers: int,
-                       debug: bool,
-                       ci: bool,
-                       profile: Optional[str] = None) -> Tuple[int, int, str, str, str]:
+
+def run_nf_test_worker(
+    worker_id: int,
+    test_files: List[Path],
+    total_workers: int,
+    debug: bool,
+    ci: bool,
+    profile: Optional[str] = None,
+) -> Tuple[int, int, str, str, str]:
     """
     Run nf-test on a specific set of test files.
     Args:
@@ -130,7 +141,9 @@ def run_nf_test_worker(worker_id: int,
     if not test_files:
         logger.info(f"Worker {worker_id}/{total_workers}: No test files assigned")
         return (worker_id, 0, "", "", "")
-    logger.info(f"Worker {worker_id}/{total_workers}: Running {len(test_files)} test file(s)")
+    logger.info(
+        f"Worker {worker_id}/{total_workers}: Running {len(test_files)} test file(s)"
+    )
 
     cmd = ["nf-test", "test"]
     if debug:
@@ -147,10 +160,13 @@ def run_nf_test_worker(worker_id: int,
     stdout = strip_ansi_codes(stdout)
     stderr = strip_ansi_codes(stderr)
     if exit_code != 0:
-        logger.error(f"Worker {worker_id}/{total_workers} failed with exit code {exit_code}")
+        logger.error(
+            f"Worker {worker_id}/{total_workers} failed with exit code {exit_code}"
+        )
     else:
         logger.info(f"Worker {worker_id}/{total_workers} completed successfully")
     return (worker_id, exit_code, stdout, stderr, cmd_str)
+
 
 def extract_failures_from_output(output: str) -> List[str]:
     """
@@ -166,11 +182,14 @@ def extract_failures_from_output(output: str) -> List[str]:
             failures.append(line.strip())
     return failures
 
-def write_test_log(all_workers: List[Tuple[int, int, str, str, str]],
-                   failed_workers: List[Tuple[int, int, str, str, str]],
-                   n_workers: int,
-                   output_log: Path,
-                   test_files: List[Path]) -> None:
+
+def write_test_log(
+    all_workers: List[Tuple[int, int, str, str, str]],
+    failed_workers: List[Tuple[int, int, str, str, str]],
+    n_workers: int,
+    output_log: Path,
+    test_files: List[Path],
+) -> None:
     """
     Write comprehensive test log with all results and failure summary.
 
@@ -181,14 +200,16 @@ def write_test_log(all_workers: List[Tuple[int, int, str, str, str]],
         output_log: Path to consolidated log file
         test_files: List of test files that were run
     """
-    with open(output_log, 'w') as out:
+    with open(output_log, "w") as out:
         out.write("=" * 80 + "\n")
         out.write(f"NF-TEST PARALLEL RESULTS\n")
         out.write(f"Total workers: {n_workers}\n")
         out.write(f"Passed workers: {n_workers - len(failed_workers)}\n")
         out.write(f"Failed workers: {len(failed_workers)}\n")
         out.write(f"Working directory: {os.getcwd()}\n")
-        out.write(f"Completed at: {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')}\n")
+        out.write(
+            f"Completed at: {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')}\n"
+        )
         out.write("=" * 80 + "\n\n")
         out.write("=" * 80 + "\n")
         out.write(f"TEST FILES ({len(test_files)} total)\n")
@@ -229,6 +250,7 @@ def write_test_log(all_workers: List[Tuple[int, int, str, str, str]],
                 out.write("\n")
     logger.info(f"Test results written to: {output_log}")
 
+
 def update_plugins() -> None:
     """
     Update nf-test plugins before running parallel tests.
@@ -237,10 +259,7 @@ def update_plugins() -> None:
     logger.info("Updating nf-test plugins...")
     try:
         result = subprocess.run(
-            ["nf-test", "update-plugins"],
-            capture_output=True,
-            text=True,
-            timeout=120
+            ["nf-test", "update-plugins"], capture_output=True, text=True, timeout=120
         )
         if result.returncode != 0:
             raise RuntimeError(f"Failed to update plugins: {result.stderr}")
@@ -248,16 +267,20 @@ def update_plugins() -> None:
     except subprocess.TimeoutExpired as e:
         raise RuntimeError("Plugin update timed out after 120 seconds") from e
 
+
 ##############
 # MAIN LOGIC #
 ##############
 
-def run_parallel_tests(n_workers: int,
-                       test_paths: List[str],
-                       output_log: Path,
-                       debug: bool,
-                       ci: bool,
-                       profile: Optional[str] = None) -> int:
+
+def run_parallel_tests(
+    n_workers: int,
+    test_paths: List[str],
+    output_log: Path,
+    debug: bool,
+    ci: bool,
+    profile: Optional[str] = None,
+) -> int:
     """
     Run nf-test in parallel by distributing test files across workers.
     Args:
@@ -276,15 +299,22 @@ def run_parallel_tests(n_workers: int,
         raise RuntimeError("No test files found.")
     logger.info(f"Found {len(test_files)} test file(s); see {output_log} for details.")
     if n_workers > len(test_files):
-        logger.warning(f"Number of workers ({n_workers}) exceeds number of test files ({len(test_files)}). Reducing to {len(test_files)} workers.")
+        logger.warning(
+            f"Number of workers ({n_workers}) exceeds number of test files ({len(test_files)}). Reducing to {len(test_files)} workers."
+        )
         n_workers = len(test_files)
     update_plugins()
     worker_test_files = divide_test_files(test_files, n_workers)
     logger.info(f"Assigned test files to {n_workers} workers.")
-    worker_args = [(i, worker_test_files[i - 1], n_workers, debug, ci, profile) for i in range(1, n_workers + 1)]
+    worker_args = [
+        (i, worker_test_files[i - 1], n_workers, debug, ci, profile)
+        for i in range(1, n_workers + 1)
+    ]
     with multiprocessing.Pool(processes=n_workers) as pool:
         results = pool.starmap(run_nf_test_worker, worker_args)
-    failed_workers = [(wid, code, out, err, cmd) for wid, code, out, err, cmd in results if code != 0]
+    failed_workers = [
+        (wid, code, out, err, cmd) for wid, code, out, err, cmd in results if code != 0
+    ]
     write_test_log(results, failed_workers, n_workers, output_log, test_files)
     if failed_workers:
         logger.error(f"{len(failed_workers)} worker(s) failed:")
@@ -294,6 +324,7 @@ def run_parallel_tests(n_workers: int,
     else:
         logger.info(f"All {n_workers} workers completed successfully.")
         return 0
+
 
 def parse_arguments() -> argparse.Namespace:
     """Parse command-line arguments."""
@@ -305,39 +336,36 @@ def parse_arguments() -> argparse.Namespace:
         "--num-workers",
         type=int,
         required=True,
-        help="Number of parallel workers to run (recommended: number of CPU cores)"
+        help="Number of parallel workers to run (recommended: number of CPU cores)",
     )
     parser.add_argument(
         "test_paths",
         nargs="+",
-        help="Paths to test files or directories containing tests"
+        help="Paths to test files or directories containing tests",
     )
     parser.add_argument(
         "--output-log",
         type=Path,
         default=Path("test-logs.txt"),
-        help="Path to consolidated log file (default: test-logs.txt)"
+        help="Path to consolidated log file (default: test-logs.txt)",
     )
     parser.add_argument(
         "--debug",
         action="store_true",
-        help="Run in debug mode (produces additional logging)"
+        help="Run in debug mode (produces additional logging)",
     )
-    parser.add_argument(
-        "--ci",
-        action="store_true",
-        help="Run nf-test in CI mode"
-    )
+    parser.add_argument("--ci", action="store_true", help="Run nf-test in CI mode")
     parser.add_argument(
         "--profile",
         type=str,
         default=None,
-        help="Nextflow profile to use (passed to nf-test as --profile=<value>)"
+        help="Nextflow profile to use (passed to nf-test as --profile=<value>)",
     )
     args = parser.parse_args()
     if args.num_workers < 1:
         parser.error("--num-workers must be at least 1")
     return args
+
 
 def main() -> None:
     """Main entry point."""
@@ -362,6 +390,7 @@ def main() -> None:
         os.chdir(original_cwd)
         end_time = time.time()
         logger.info(f"Total time elapsed: {end_time - start_time:.2f} seconds")
+
 
 if __name__ == "__main__":
     main()

--- a/bin/run_nf_test_parallel.py
+++ b/bin/run_nf_test_parallel.py
@@ -238,7 +238,9 @@ def write_test_log(
             out.write("=" * 80 + "\n")
             out.write("FAILURE SUMMARY\n")
             out.write("=" * 80 + "\n\n")
-            for worker_id, exit_code, stdout, stderr, cmd_str in sorted(failed_workers):
+            for worker_id, exit_code, stdout, stderr, _cmd_str in sorted(
+                failed_workers
+            ):
                 out.write(f"Worker {worker_id} (exit code: {exit_code}):\n")
                 failures = extract_failures_from_output(stdout + "\n" + stderr)
                 if failures:

--- a/bin/run_nf_test_parallel.py
+++ b/bin/run_nf_test_parallel.py
@@ -15,15 +15,14 @@ the --num-workers flag, which handles sudo and environment variable passing.
 
 import argparse
 import logging
+import multiprocessing
 import os
 import re
 import subprocess
-from datetime import datetime, timezone
-from pathlib import Path
-from typing import List, Tuple, Optional
-import multiprocessing
-import time
 import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
 
 ###########
 # LOGGING #
@@ -33,11 +32,9 @@ import sys
 class UTCFormatter(logging.Formatter):
     """Custom logging formatter that displays timestamps in UTC."""
 
-    def formatTime(
-        self, record: logging.LogRecord, datefmt: Optional[str] = None
-    ) -> str:
+    def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
         """Format log timestamps in UTC timezone."""
-        dt = datetime.fromtimestamp(record.created, timezone.utc)
+        dt = datetime.fromtimestamp(record.created, UTC)
         return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
@@ -66,7 +63,7 @@ def strip_ansi_codes(text: str) -> str:
     return ansi_escape.sub("", text)
 
 
-def find_test_files(paths: List[str]) -> List[Path]:
+def find_test_files(paths: list[str]) -> list[Path]:
     """
     Find all *.nf.test files in the specified paths.
 
@@ -89,7 +86,7 @@ def find_test_files(paths: List[str]) -> List[Path]:
     return sorted(set(test_files))
 
 
-def divide_test_files(test_files: List[Path], n_workers: int) -> List[List[Path]]:
+def divide_test_files(test_files: list[Path], n_workers: int) -> list[list[Path]]:
     """
     Divide test files evenly among workers using round-robin distribution.
     Args:
@@ -106,7 +103,7 @@ def divide_test_files(test_files: List[Path], n_workers: int) -> List[List[Path]
     return worker_files
 
 
-def execute_subprocess(cmd: List[str]) -> Tuple[int, str, str]:
+def execute_subprocess(cmd: list[str]) -> tuple[int, str, str]:
     """
     Execute a subprocess and capture output.
     Args:
@@ -120,12 +117,12 @@ def execute_subprocess(cmd: List[str]) -> Tuple[int, str, str]:
 
 def run_nf_test_worker(
     worker_id: int,
-    test_files: List[Path],
+    test_files: list[Path],
     total_workers: int,
     debug: bool,
     ci: bool,
-    profile: Optional[str] = None,
-) -> Tuple[int, int, str, str, str]:
+    profile: str | None = None,
+) -> tuple[int, int, str, str, str]:
     """
     Run nf-test on a specific set of test files.
     Args:
@@ -168,7 +165,7 @@ def run_nf_test_worker(
     return (worker_id, exit_code, stdout, stderr, cmd_str)
 
 
-def extract_failures_from_output(output: str) -> List[str]:
+def extract_failures_from_output(output: str) -> list[str]:
     """
     Extract FAILED test names from test output.
     Args:
@@ -184,11 +181,11 @@ def extract_failures_from_output(output: str) -> List[str]:
 
 
 def write_test_log(
-    all_workers: List[Tuple[int, int, str, str, str]],
-    failed_workers: List[Tuple[int, int, str, str, str]],
+    all_workers: list[tuple[int, int, str, str, str]],
+    failed_workers: list[tuple[int, int, str, str, str]],
     n_workers: int,
     output_log: Path,
-    test_files: List[Path],
+    test_files: list[Path],
 ) -> None:
     """
     Write comprehensive test log with all results and failure summary.
@@ -202,13 +199,13 @@ def write_test_log(
     """
     with open(output_log, "w") as out:
         out.write("=" * 80 + "\n")
-        out.write(f"NF-TEST PARALLEL RESULTS\n")
+        out.write("NF-TEST PARALLEL RESULTS\n")
         out.write(f"Total workers: {n_workers}\n")
         out.write(f"Passed workers: {n_workers - len(failed_workers)}\n")
         out.write(f"Failed workers: {len(failed_workers)}\n")
         out.write(f"Working directory: {os.getcwd()}\n")
         out.write(
-            f"Completed at: {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')}\n"
+            f"Completed at: {datetime.now(UTC).strftime('%Y-%m-%d %H:%M:%S UTC')}\n"
         )
         out.write("=" * 80 + "\n\n")
         out.write("=" * 80 + "\n")
@@ -223,7 +220,7 @@ def write_test_log(
             out.write(f"Worker {worker_id}/{n_workers}: {status}\n")
             out.write("=" * 80 + "\n\n")
             out.write("-" * 80 + "\n")
-            out.write(f"COMMAND STRING\n")
+            out.write("COMMAND STRING\n")
             out.write("-" * 80 + "\n\n")
             out.write(f"{cmd_str}\n\n")
             out.write("-" * 80 + "\n")
@@ -275,11 +272,11 @@ def update_plugins() -> None:
 
 def run_parallel_tests(
     n_workers: int,
-    test_paths: List[str],
+    test_paths: list[str],
     output_log: Path,
     debug: bool,
     ci: bool,
-    profile: Optional[str] = None,
+    profile: str | None = None,
 ) -> int:
     """
     Run nf-test in parallel by distributing test files across workers.
@@ -321,9 +318,8 @@ def run_parallel_tests(
         for worker_id, exit_code, _, _, _ in failed_workers:
             logger.error(f"\t- Worker {worker_id} failed with exit code {exit_code}")
         return 1
-    else:
-        logger.info(f"All {n_workers} workers completed successfully.")
-        return 0
+    logger.info(f"All {n_workers} workers completed successfully.")
+    return 0
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -369,7 +365,7 @@ def parse_arguments() -> argparse.Namespace:
 
 def main() -> None:
     """Main entry point."""
-    logger.info(f"Initializing script.")
+    logger.info("Initializing script.")
     start_time = time.time()
     args = parse_arguments()
     logger.info(f"Arguments: {args}")

--- a/bin/scan_containers.py
+++ b/bin/scan_containers.py
@@ -2,6 +2,7 @@
 """
 Scan container images from Nextflow config with Trivy.
 """
+
 import argparse
 import json
 import re
@@ -36,7 +37,16 @@ def scan_container(container: str, output_dir: Path) -> Path:
     output_file = output_dir / f"{container_safe}.json"
     print(f"Scanning {container}...")
     ignorefile = Path(__file__).resolve().parent.parent / ".trivyignore"
-    cmd = ["trivy", "image", "--scanners", "vuln", "--format", "json", "--output", str(output_file)]
+    cmd = [
+        "trivy",
+        "image",
+        "--scanners",
+        "vuln",
+        "--format",
+        "json",
+        "--output",
+        str(output_file),
+    ]
     if ignorefile.exists():
         cmd.extend(["--ignorefile", str(ignorefile)])
     cmd.append(container)
@@ -60,20 +70,25 @@ def aggregate_results(output_dir: Path) -> tuple[dict, dict, bool]:
         os_info = metadata.get("OS", {})
         os_family = os_info.get("Family", "unknown")
         os_name = os_info.get("Name", "unknown")
-        severity_counts = {"CRITICAL": 0, "HIGH": 0, "MEDIUM": 0, "LOW": 0, "UNKNOWN": 0}
+        severity_counts = {
+            "CRITICAL": 0,
+            "HIGH": 0,
+            "MEDIUM": 0,
+            "LOW": 0,
+            "UNKNOWN": 0,
+        }
         for result in data.get("Results", []):
             for vuln in result.get("Vulnerabilities", []):
                 severity = vuln.get("Severity", "UNKNOWN")
                 severity_counts[severity] = severity_counts.get(severity, 0) + 1
                 total_counts[severity] = total_counts.get(severity, 0) + 1
-        summary["containers"].append({
-            "name": container_name,
-            "os": {
-                "family": os_family,
-                "name": os_name
-            },
-            "vulnerabilities": severity_counts
-        })
+        summary["containers"].append(
+            {
+                "name": container_name,
+                "os": {"family": os_family, "name": os_name},
+                "vulnerabilities": severity_counts,
+            }
+        )
         if severity_counts["CRITICAL"] > 0 or severity_counts["HIGH"] > 0:
             has_critical_or_high = True
     summary_file = output_dir / "summary.json"
@@ -83,8 +98,14 @@ def aggregate_results(output_dir: Path) -> tuple[dict, dict, bool]:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Scan container images with Trivy")
-    parser.add_argument("--config", default="configs/containers.config", help="Path to Nextflow config file")
-    parser.add_argument("--output-dir", default="trivy_results", help="Directory for scan results")
+    parser.add_argument(
+        "--config",
+        default="configs/containers.config",
+        help="Path to Nextflow config file",
+    )
+    parser.add_argument(
+        "--output-dir", default="trivy_results", help="Directory for scan results"
+    )
     args = parser.parse_args()
     config_file = Path(args.config)
     output_dir = Path(args.output_dir)

--- a/bin/test_chain_workflows.py
+++ b/bin/test_chain_workflows.py
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from botocore.exceptions import ClientError
-
 from chain_workflows import (
     create_launch_directories,
     execute_nextflow,

--- a/bin/test_chain_workflows.py
+++ b/bin/test_chain_workflows.py
@@ -36,11 +36,17 @@ class TestResolveSamplesheetPath:
     ) -> None:
         repo_root = tmp_path / "repo"
         result = resolve_samplesheet_path(samplesheet_arg, tmp_path, repo_root)
-        expected = repo_root / samplesheet_arg if resolve_against_repo else Path(samplesheet_arg)
+        expected = (
+            repo_root / samplesheet_arg
+            if resolve_against_repo
+            else Path(samplesheet_arg)
+        )
         assert result == expected
 
     @patch("chain_workflows.boto3")
-    def test_downloads_s3_samplesheet(self, mock_boto3: MagicMock, tmp_path: Path) -> None:
+    def test_downloads_s3_samplesheet(
+        self, mock_boto3: MagicMock, tmp_path: Path
+    ) -> None:
         run_launch_dir = tmp_path / "run"
         run_launch_dir.mkdir()
         result = resolve_samplesheet_path(
@@ -61,7 +67,9 @@ class TestResolveSamplesheetPath:
             {"Error": {"Code": "404", "Message": "Not Found"}}, "GetObject"
         )
         with pytest.raises(RuntimeError, match="Failed to download"):
-            resolve_samplesheet_path("s3://bucket/missing.csv", run_launch_dir, tmp_path)
+            resolve_samplesheet_path(
+                "s3://bucket/missing.csv", run_launch_dir, tmp_path
+            )
 
 
 #################################
@@ -79,6 +87,7 @@ class TestGenerateDownstreamInput:
     @pytest.fixture
     def make_samplesheet(self, tmp_path: Path) -> Callable[[list[str]], Path]:
         """Factory fixture that writes a samplesheet CSV and returns its path."""
+
         def _make(samples: list[str]) -> Path:
             path = tmp_path / "samplesheet.csv"
             with open(path, "w") as f:
@@ -87,6 +96,7 @@ class TestGenerateDownstreamInput:
                 for s in samples:
                     writer.writerow([s])
             return path
+
         return _make
 
     @pytest.mark.parametrize(
@@ -95,7 +105,10 @@ class TestGenerateDownstreamInput:
         ids=["single_sample", "multiple_samples"],
     )
     def test_generates_correct_files(
-        self, launch_dir: Path, make_samplesheet: Callable[[list[str]], Path], samples: list[str]
+        self,
+        launch_dir: Path,
+        make_samplesheet: Callable[[list[str]], Path],
+        samples: list[str],
     ) -> None:
         sheet = make_samplesheet(samples)
         run_results_dir = "s3://bucket/run/output/results"
@@ -210,7 +223,9 @@ class TestExecuteNextflow:
 
 class TestMain:
     @pytest.fixture
-    def mock_deps(self, tmp_path: Path) -> Generator[dict[str, MagicMock | dict[str, Path] | Path], None, None]:
+    def mock_deps(
+        self, tmp_path: Path
+    ) -> Generator[dict[str, MagicMock | dict[str, Path] | Path], None, None]:
         """Mock all external dependencies of main(), yielding them for assertions."""
         mock_args = MagicMock()
         mock_args.launch_dir = tmp_path / "launch"
@@ -236,7 +251,9 @@ class TestMain:
 
         with (
             patch("chain_workflows.parse_arguments", return_value=mock_args),
-            patch("chain_workflows.create_launch_directories", return_value=launch_dirs),
+            patch(
+                "chain_workflows.create_launch_directories", return_value=launch_dirs
+            ),
             patch("chain_workflows.execute_nextflow") as mock_execute,
             patch(
                 "chain_workflows.resolve_samplesheet_path",

--- a/bin/test_check_index_age.py
+++ b/bin/test_check_index_age.py
@@ -63,7 +63,14 @@ class TestCheckIndexAge:
         ],
         ids=["within-limit", "exactly-at-limit", "one-over", "well-over"],
     )
-    def test_age_check(self, index_date: date, max_age: int, today: date, expected_ok: bool, expected_days: int) -> None:
+    def test_age_check(
+        self,
+        index_date: date,
+        max_age: int,
+        today: date,
+        expected_ok: bool,
+        expected_days: int,
+    ) -> None:
         is_ok, age_days = check_index_age(index_date, max_age, today=today)
         assert is_ok is expected_ok
         assert age_days == expected_days
@@ -76,7 +83,9 @@ class TestCheckIndexAge:
 
 class TestFetchTimeTxtFromS3:
     @patch("check_index_age.boto3.client")
-    def test_parses_s3_uri_and_returns_content(self, mock_boto_client: MagicMock) -> None:
+    def test_parses_s3_uri_and_returns_content(
+        self, mock_boto_client: MagicMock
+    ) -> None:
         mock_body = MagicMock()
         mock_body.read.return_value = b"2025-01-15 14:30:00 UTC (+0000)\n"
         mock_client = mock_boto_client.return_value
@@ -99,7 +108,11 @@ class TestMain:
         )
 
     def test_passes_when_index_is_fresh(
-        self, mock_parse_args: MagicMock, mock_fetch: MagicMock, mock_date: MagicMock, tmp_path: Path
+        self,
+        mock_parse_args: MagicMock,
+        mock_fetch: MagicMock,
+        mock_date: MagicMock,
+        tmp_path: Path,
     ) -> None:
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text("[tool.mgs-workflow]\nmax-stable-index-age-days = 90\n")
@@ -110,7 +123,11 @@ class TestMain:
         main()  # should not raise
 
     def test_raises_when_index_is_stale(
-        self, mock_parse_args: MagicMock, mock_fetch: MagicMock, mock_date: MagicMock, tmp_path: Path
+        self,
+        mock_parse_args: MagicMock,
+        mock_fetch: MagicMock,
+        mock_date: MagicMock,
+        tmp_path: Path,
     ) -> None:
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text("[tool.mgs-workflow]\nmax-stable-index-age-days = 90\n")

--- a/bin/test_check_nextflow_version.py
+++ b/bin/test_check_nextflow_version.py
@@ -90,9 +90,11 @@ class TestGetLatestVersion:
         mock_response.__enter__ = MagicMock(return_value=mock_response)
         mock_response.__exit__ = MagicMock(return_value=False)
 
-        with patch("urllib.request.urlopen", return_value=mock_response):
-            with pytest.raises(ValueError, match="Invalid version format"):
-                get_latest_version("https://api.example.com")
+        with (
+            patch("urllib.request.urlopen", return_value=mock_response),
+            pytest.raises(ValueError, match="Invalid version format"),
+        ):
+            get_latest_version("https://api.example.com")
 
 
 class TestGetLatestNonExcludedVersion:
@@ -241,9 +243,11 @@ class TestMain:
         config = tmp_path / "profiles.config"
         config.write_text("manifest {}")
 
-        with patch("sys.argv", ["check_nextflow_version.py", "--config", str(config)]):
-            with pytest.raises(ValueError, match="Could not find nextflowVersion"):
-                main()
+        with (
+            patch("sys.argv", ["check_nextflow_version.py", "--config", str(config)]),
+            pytest.raises(ValueError, match="Could not find nextflowVersion"),
+        ):
+            main()
 
     @pytest.mark.parametrize(
         "pinned_version,should_match,expected_error",

--- a/bin/test_check_nextflow_version.py
+++ b/bin/test_check_nextflow_version.py
@@ -173,14 +173,14 @@ class TestGetLatestNonExcludedVersion:
             {"tag_name": "v25.10.2", "prerelease": False, "draft": False},
             {"tag_name": "v25.10.1", "prerelease": False, "draft": False},
         ]
-        with patch(
-            "urllib.request.urlopen",
-            return_value=self._mock_releases_response(releases_data),
+        with (
+            patch(
+                "urllib.request.urlopen",
+                return_value=self._mock_releases_response(releases_data),
+            ),
+            pytest.raises(ValueError, match="Could not find any non-excluded release"),
         ):
-            with pytest.raises(
-                ValueError, match="Could not find any non-excluded release"
-            ):
-                get_latest_non_excluded_version({"25.10.2", "25.10.1"})
+            get_latest_non_excluded_version({"25.10.2", "25.10.1"})
 
 
 class TestCompareVersions:
@@ -209,13 +209,14 @@ class TestMain:
         config = tmp_path / "profiles.config"
         config.write_text("manifest {\n    nextflowVersion = '!>=25.10.0'\n}")
 
-        with patch(
-            "urllib.request.urlopen", return_value=self._mock_api_response("25.10.0")
+        with (
+            patch(
+                "urllib.request.urlopen",
+                return_value=self._mock_api_response("25.10.0"),
+            ),
+            patch("sys.argv", ["check_nextflow_version.py", "--config", str(config)]),
         ):
-            with patch(
-                "sys.argv", ["check_nextflow_version.py", "--config", str(config)]
-            ):
-                main()
+            main()
 
         captured = capsys.readouterr()
         assert "Pinned Nextflow version: 25.10.0" in captured.out
@@ -226,16 +227,15 @@ class TestMain:
         config = tmp_path / "profiles.config"
         config.write_text("manifest {\n    nextflowVersion = '!>=25.10.0'\n}")
 
-        with patch(
-            "urllib.request.urlopen", return_value=self._mock_api_response("25.10.1")
+        with (
+            patch(
+                "urllib.request.urlopen",
+                return_value=self._mock_api_response("25.10.1"),
+            ),
+            patch("sys.argv", ["check_nextflow_version.py", "--config", str(config)]),
+            pytest.raises(ValueError, match="Version mismatch: 25.10.0 != 25.10.1"),
         ):
-            with patch(
-                "sys.argv", ["check_nextflow_version.py", "--config", str(config)]
-            ):
-                with pytest.raises(
-                    ValueError, match="Version mismatch: 25.10.0 != 25.10.1"
-                ):
-                    main()
+            main()
 
     def test_invalid_config(self, tmp_path: Path) -> None:
         config = tmp_path / "profiles.config"
@@ -286,26 +286,21 @@ class TestMain:
                 return mock_latest
             return mock_releases
 
-        with patch("urllib.request.urlopen", side_effect=mock_urlopen):
-            with patch(
-                "sys.argv", ["check_nextflow_version.py", "--config", str(config)]
-            ):
-                with patch("check_nextflow_version.EXCLUDED_VERSIONS", {"25.10.3"}):
-                    if should_match:
-                        main()
-                        captured = capsys.readouterr()
-                        assert (
-                            f"Pinned Nextflow version: {pinned_version}" in captured.out
-                        )
-                        assert "Latest Nextflow version: 25.10.3" in captured.out
-                        assert (
-                            "Latest version 25.10.3 is excluded (known issues)"
-                            in captured.out
-                        )
-                        assert "Latest non-excluded version: 25.10.2" in captured.out
-                        assert (
-                            "OK: Pinned version matches target release" in captured.out
-                        )
-                    else:
-                        with pytest.raises(ValueError, match=expected_error):
-                            main()
+        with (
+            patch("urllib.request.urlopen", side_effect=mock_urlopen),
+            patch("sys.argv", ["check_nextflow_version.py", "--config", str(config)]),
+            patch("check_nextflow_version.EXCLUDED_VERSIONS", {"25.10.3"}),
+        ):
+            if should_match:
+                main()
+                captured = capsys.readouterr()
+                assert f"Pinned Nextflow version: {pinned_version}" in captured.out
+                assert "Latest Nextflow version: 25.10.3" in captured.out
+                assert (
+                    "Latest version 25.10.3 is excluded (known issues)" in captured.out
+                )
+                assert "Latest non-excluded version: 25.10.2" in captured.out
+                assert "OK: Pinned version matches target release" in captured.out
+            else:
+                with pytest.raises(ValueError, match=expected_error):
+                    main()

--- a/bin/test_check_nextflow_version.py
+++ b/bin/test_check_nextflow_version.py
@@ -43,7 +43,10 @@ class TestGetPinnedVersion:
         [
             ("manifest {\n    nextflowVersion = '!>=25.10.0'\n}", "25.10.0"),
             ('manifest {\n    nextflowVersion = "!>=1.0.0"\n}', "1.0.0"),
-            ("// Comment\nmanifest {\n    nextflowVersion = '!>=99.99.99'\n}\ndocker.enabled = true", "99.99.99"),
+            (
+                "// Comment\nmanifest {\n    nextflowVersion = '!>=99.99.99'\n}\ndocker.enabled = true",
+                "99.99.99",
+            ),
         ],
     )
     def test_valid(self, tmp_path: Path, content: str, expected: str) -> None:
@@ -69,7 +72,9 @@ class TestGetPinnedVersion:
 
 
 class TestGetLatestVersion:
-    @pytest.mark.parametrize("tag_name,expected", [("v25.10.0", "25.10.0"), ("25.10.0", "25.10.0")])
+    @pytest.mark.parametrize(
+        "tag_name,expected", [("v25.10.0", "25.10.0"), ("25.10.0", "25.10.0")]
+    )
     def test_valid(self, tag_name: str, expected: str) -> None:
         mock_response = MagicMock()
         mock_response.read.return_value = json.dumps({"tag_name": tag_name}).encode()
@@ -91,7 +96,9 @@ class TestGetLatestVersion:
 
 
 class TestGetLatestNonExcludedVersion:
-    def _mock_releases_response(self, releases_data: list[dict[str, object]]) -> MagicMock:
+    def _mock_releases_response(
+        self, releases_data: list[dict[str, object]]
+    ) -> MagicMock:
         """Create a mock response returning the given releases list."""
         mock_response = MagicMock()
         mock_response.read.return_value = json.dumps(releases_data).encode()
@@ -106,7 +113,10 @@ class TestGetLatestNonExcludedVersion:
             {"tag_name": "v25.10.2", "prerelease": False, "draft": False},
             {"tag_name": "v25.10.1", "prerelease": False, "draft": False},
         ]
-        with patch("urllib.request.urlopen", return_value=self._mock_releases_response(releases_data)):
+        with patch(
+            "urllib.request.urlopen",
+            return_value=self._mock_releases_response(releases_data),
+        ):
             result = get_latest_non_excluded_version({"25.10.3"})
             assert result == "25.10.2"
 
@@ -117,13 +127,15 @@ class TestGetLatestNonExcludedVersion:
             {"tag_name": "v25.10.2", "prerelease": False, "draft": False},
             {"tag_name": "v25.10.1", "prerelease": False, "draft": False},
         ]
-        with patch("urllib.request.urlopen", return_value=self._mock_releases_response(releases_data)):
+        with patch(
+            "urllib.request.urlopen",
+            return_value=self._mock_releases_response(releases_data),
+        ):
             result = get_latest_non_excluded_version({"25.10.3", "25.10.2"})
             assert result == "25.10.1"
 
     @pytest.mark.parametrize(
-        "prerelease,draft",
-        [(True, False), (False, True), (True, True)]
+        "prerelease,draft", [(True, False), (False, True), (True, True)]
     )
     def test_skips_prerelease_and_draft(self, prerelease: bool, draft: bool) -> None:
         """Test that prerelease and draft releases are skipped."""
@@ -131,17 +143,27 @@ class TestGetLatestNonExcludedVersion:
             {"tag_name": "v25.10.3", "prerelease": prerelease, "draft": draft},
             {"tag_name": "v25.10.2", "prerelease": False, "draft": False},
         ]
-        with patch("urllib.request.urlopen", return_value=self._mock_releases_response(releases_data)):
+        with patch(
+            "urllib.request.urlopen",
+            return_value=self._mock_releases_response(releases_data),
+        ):
             result = get_latest_non_excluded_version(set())
             assert result == "25.10.2"
 
     def test_skips_invalid_version_format(self) -> None:
         """Test that releases with invalid version formats are skipped."""
         releases_data = [
-            {"tag_name": "v25.10", "prerelease": False, "draft": False},  # Invalid: only 2 parts
+            {
+                "tag_name": "v25.10",
+                "prerelease": False,
+                "draft": False,
+            },  # Invalid: only 2 parts
             {"tag_name": "25.10.2", "prerelease": False, "draft": False},  # Valid
         ]
-        with patch("urllib.request.urlopen", return_value=self._mock_releases_response(releases_data)):
+        with patch(
+            "urllib.request.urlopen",
+            return_value=self._mock_releases_response(releases_data),
+        ):
             result = get_latest_non_excluded_version(set())
             assert result == "25.10.2"
 
@@ -151,8 +173,13 @@ class TestGetLatestNonExcludedVersion:
             {"tag_name": "v25.10.2", "prerelease": False, "draft": False},
             {"tag_name": "v25.10.1", "prerelease": False, "draft": False},
         ]
-        with patch("urllib.request.urlopen", return_value=self._mock_releases_response(releases_data)):
-            with pytest.raises(ValueError, match="Could not find any non-excluded release"):
+        with patch(
+            "urllib.request.urlopen",
+            return_value=self._mock_releases_response(releases_data),
+        ):
+            with pytest.raises(
+                ValueError, match="Could not find any non-excluded release"
+            ):
                 get_latest_non_excluded_version({"25.10.2", "25.10.1"})
 
 
@@ -169,17 +196,25 @@ class TestMain:
     def _mock_api_response(self, version: str) -> MagicMock:
         """Create a mock response returning the given version."""
         mock_response = MagicMock()
-        mock_response.read.return_value = json.dumps({"tag_name": f"v{version}"}).encode()
+        mock_response.read.return_value = json.dumps(
+            {"tag_name": f"v{version}"}
+        ).encode()
         mock_response.__enter__ = MagicMock(return_value=mock_response)
         mock_response.__exit__ = MagicMock(return_value=False)
         return mock_response
 
-    def test_versions_match(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_versions_match(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         config = tmp_path / "profiles.config"
         config.write_text("manifest {\n    nextflowVersion = '!>=25.10.0'\n}")
 
-        with patch("urllib.request.urlopen", return_value=self._mock_api_response("25.10.0")):
-            with patch("sys.argv", ["check_nextflow_version.py", "--config", str(config)]):
+        with patch(
+            "urllib.request.urlopen", return_value=self._mock_api_response("25.10.0")
+        ):
+            with patch(
+                "sys.argv", ["check_nextflow_version.py", "--config", str(config)]
+            ):
                 main()
 
         captured = capsys.readouterr()
@@ -191,9 +226,15 @@ class TestMain:
         config = tmp_path / "profiles.config"
         config.write_text("manifest {\n    nextflowVersion = '!>=25.10.0'\n}")
 
-        with patch("urllib.request.urlopen", return_value=self._mock_api_response("25.10.1")):
-            with patch("sys.argv", ["check_nextflow_version.py", "--config", str(config)]):
-                with pytest.raises(ValueError, match="Version mismatch: 25.10.0 != 25.10.1"):
+        with patch(
+            "urllib.request.urlopen", return_value=self._mock_api_response("25.10.1")
+        ):
+            with patch(
+                "sys.argv", ["check_nextflow_version.py", "--config", str(config)]
+            ):
+                with pytest.raises(
+                    ValueError, match="Version mismatch: 25.10.0 != 25.10.1"
+                ):
                     main()
 
     def test_invalid_config(self, tmp_path: Path) -> None:
@@ -208,13 +249,26 @@ class TestMain:
         "pinned_version,should_match,expected_error",
         [
             ("25.10.2", True, None),  # Pinned matches next available
-            ("25.10.0", False, "Version mismatch: 25.10.0 != 25.10.2"),  # Pinned doesn't match
-        ]
+            (
+                "25.10.0",
+                False,
+                "Version mismatch: 25.10.0 != 25.10.2",
+            ),  # Pinned doesn't match
+        ],
     )
-    def test_excluded_latest_version(self, tmp_path: Path, capsys: pytest.CaptureFixture[str], pinned_version: str, should_match: bool, expected_error: str | None) -> None:
+    def test_excluded_latest_version(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        pinned_version: str,
+        should_match: bool,
+        expected_error: str | None,
+    ) -> None:
         """Test when latest version is excluded and script finds next available version."""
         config = tmp_path / "profiles.config"
-        config.write_text(f"manifest {{\n    nextflowVersion = '!>={pinned_version}'\n}}")
+        config.write_text(
+            f"manifest {{\n    nextflowVersion = '!>={pinned_version}'\n}}"
+        )
 
         mock_latest = self._mock_api_response("25.10.3")
 
@@ -233,16 +287,25 @@ class TestMain:
             return mock_releases
 
         with patch("urllib.request.urlopen", side_effect=mock_urlopen):
-            with patch("sys.argv", ["check_nextflow_version.py", "--config", str(config)]):
+            with patch(
+                "sys.argv", ["check_nextflow_version.py", "--config", str(config)]
+            ):
                 with patch("check_nextflow_version.EXCLUDED_VERSIONS", {"25.10.3"}):
                     if should_match:
                         main()
                         captured = capsys.readouterr()
-                        assert f"Pinned Nextflow version: {pinned_version}" in captured.out
+                        assert (
+                            f"Pinned Nextflow version: {pinned_version}" in captured.out
+                        )
                         assert "Latest Nextflow version: 25.10.3" in captured.out
-                        assert "Latest version 25.10.3 is excluded (known issues)" in captured.out
+                        assert (
+                            "Latest version 25.10.3 is excluded (known issues)"
+                            in captured.out
+                        )
                         assert "Latest non-excluded version: 25.10.2" in captured.out
-                        assert "OK: Pinned version matches target release" in captured.out
+                        assert (
+                            "OK: Pinned version matches target release" in captured.out
+                        )
                     else:
                         with pytest.raises(ValueError, match=expected_error):
                             main()

--- a/bin/test_check_version.py
+++ b/bin/test_check_version.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
 """Unit tests for check_version.py"""
 
-import pytest
+import sys
 from pathlib import Path
 
-import sys
+import pytest
 
 sys.path.insert(0, str(Path(__file__).parent))
 from check_version import (
-    validate_version,
-    get_pyproject_version,
     get_changelog_version,
+    get_pyproject_version,
+    validate_version,
 )
 
 

--- a/bin/test_check_version.py
+++ b/bin/test_check_version.py
@@ -5,6 +5,7 @@ import pytest
 from pathlib import Path
 
 import sys
+
 sys.path.insert(0, str(Path(__file__).parent))
 from check_version import (
     validate_version,
@@ -14,23 +15,29 @@ from check_version import (
 
 
 class TestValidateVersion:
-    @pytest.mark.parametrize("version", [
-        "1.2.3.4",
-        "0.0.0.0",
-        "10.20.30.40",
-        "1.2.3.4-dev",
-    ])
+    @pytest.mark.parametrize(
+        "version",
+        [
+            "1.2.3.4",
+            "0.0.0.0",
+            "10.20.30.40",
+            "1.2.3.4-dev",
+        ],
+    )
     def test_valid(self, version: str) -> None:
         assert validate_version(version, "test") == version
 
-    @pytest.mark.parametrize("version", [
-        "",
-        "1.2.3",
-        "1.2.3.4.5",
-        "v1.2.3.4",
-        "1.2.3.4-beta",
-        "a.b.c.d",
-    ])
+    @pytest.mark.parametrize(
+        "version",
+        [
+            "",
+            "1.2.3",
+            "1.2.3.4.5",
+            "v1.2.3.4",
+            "1.2.3.4-beta",
+            "a.b.c.d",
+        ],
+    )
     def test_invalid(self, version: str) -> None:
         with pytest.raises(ValueError, match="Invalid version format"):
             validate_version(version, "test")
@@ -47,12 +54,17 @@ class TestGetPyprojectVersion:
         pyproject.write_text(f'[project]\nversion = "{version}"\n')
         assert get_pyproject_version(str(pyproject)) == version
 
-    @pytest.mark.parametrize("content,error", [
-        ('[project]\nname = "test"\n', KeyError),
-        ('[tool]\nname = "test"\n', KeyError),
-        ('[project]\nversion = "1.2.3"\n', ValueError),
-    ])
-    def test_invalid(self, tmp_path: Path, content: str, error: type[Exception]) -> None:
+    @pytest.mark.parametrize(
+        "content,error",
+        [
+            ('[project]\nname = "test"\n', KeyError),
+            ('[tool]\nname = "test"\n', KeyError),
+            ('[project]\nversion = "1.2.3"\n', ValueError),
+        ],
+    )
+    def test_invalid(
+        self, tmp_path: Path, content: str, error: type[Exception]
+    ) -> None:
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text(content)
         with pytest.raises(error):
@@ -66,12 +78,15 @@ class TestGetChangelogVersion:
         changelog.write_text(f"# v{version}\n\n## Changes\n")
         assert get_changelog_version(str(changelog)) == version
 
-    @pytest.mark.parametrize("content,match", [
-        ("# 1.2.3.4\n", "must start with '# v'"),
-        ("v1.2.3.4\n", "must start with '# v'"),
-        ("", "must start with '# v'"),
-        ("# v1.2.3\n", "Invalid version format"),
-    ])
+    @pytest.mark.parametrize(
+        "content,match",
+        [
+            ("# 1.2.3.4\n", "must start with '# v'"),
+            ("v1.2.3.4\n", "must start with '# v'"),
+            ("", "must start with '# v'"),
+            ("# v1.2.3\n", "Invalid version format"),
+        ],
+    )
     def test_invalid(self, tmp_path: Path, content: str, match: str) -> None:
         changelog = tmp_path / "CHANGELOG.md"
         changelog.write_text(content)

--- a/bin/test_component_dependencies.py
+++ b/bin/test_component_dependencies.py
@@ -5,6 +5,7 @@ import os
 import re
 import sys
 
+
 def find_dependency(directory: str, component: str) -> set[str]:
 
     directory = directory.rstrip("/")
@@ -27,13 +28,14 @@ def find_dependency(directory: str, component: str) -> set[str]:
     file_paths = set()
     for line in grep_results.stdout.splitlines():
         if any(trigger in line for trigger in relevant_triggers):
-                file = line.split(":", 1)[0]
-                if "nf-test" in file:
-                    continue
-                else:
-                    file_paths.add(file)
+            file = line.split(":", 1)[0]
+            if "nf-test" in file:
+                continue
+            else:
+                file_paths.add(file)
 
     return file_paths
+
 
 def identify_component_file(component: str) -> str | None:
     # Search in subworkflows and workflow directories
@@ -52,6 +54,7 @@ def identify_component_file(component: str) -> str | None:
                 return path
     return None
 
+
 def get_subcomponents(component_path: str) -> tuple[set[str], set[str]]:
     with open(component_path, "r") as f:
         component_content = f.read()
@@ -60,7 +63,7 @@ def get_subcomponents(component_path: str) -> tuple[set[str], set[str]]:
     for line in component_content.splitlines():
         if "include" in line:
             # Extract the first all caps variable in the include line
-            match = re.search(r'include\s*{\s*([A-Z][A-Z0-9_]*)', line)
+            match = re.search(r"include\s*{\s*([A-Z][A-Z0-9_]*)", line)
             if match:
                 if "subworkflows" in line:
                     workflows.add(match.group(1))
@@ -69,7 +72,10 @@ def get_subcomponents(component_path: str) -> tuple[set[str], set[str]]:
                 continue
     return modules, workflows
 
-def collect_component_dependencies(component: str) -> tuple[set[str] | None, set[str] | None]:
+
+def collect_component_dependencies(
+    component: str,
+) -> tuple[set[str] | None, set[str] | None]:
     file_path = identify_component_file(component)
     if file_path is None:
         return None, None
@@ -84,6 +90,7 @@ def collect_component_dependencies(component: str) -> tuple[set[str] | None, set
 
     return modules, workflows
 
+
 def workflow_uses_subworkflow(workflow: str, subworkflow_path: str) -> bool:
     workflow_path = f"workflows/{workflow}"
     subworkflow_dir = subworkflow_path.replace("/main.nf", "")
@@ -92,7 +99,7 @@ def workflow_uses_subworkflow(workflow: str, subworkflow_path: str) -> bool:
         workflow_content = f.read()
 
     # Use word boundaries to preempt substring matches
-    if re.search(r'\b' + re.escape(subworkflow_dir) + r'\b', workflow_content):
+    if re.search(r"\b" + re.escape(subworkflow_dir) + r"\b", workflow_content):
         return True
     else:
         return False
@@ -106,7 +113,9 @@ def subworkflow_uses_subworkflow(subworkflow: str, dependent_subworkflow: str) -
         subworkflow_content = f.read()
 
     # Use word boundaries to preempt substring matches
-    if re.search(r'\b' + re.escape(dependent_subworkflow_dir) + r'\b', subworkflow_content):
+    if re.search(
+        r"\b" + re.escape(dependent_subworkflow_dir) + r"\b", subworkflow_content
+    ):
         return True
     else:
         return False
@@ -114,7 +123,7 @@ def subworkflow_uses_subworkflow(subworkflow: str, dependent_subworkflow: str) -
 
 def get_workflow_test(workflow: str) -> str:
     workflow_path = f"workflows/{workflow}"
-    if re.search(r'\b' + re.escape("run_dev_se") + r'\b', workflow_path):
+    if re.search(r"\b" + re.escape("run_dev_se") + r"\b", workflow_path):
         return "tests/workflows/run_dev.nf.test"
     else:
         base_name = os.path.basename(workflow_path).split(".")[0]
@@ -160,15 +169,16 @@ def main() -> None:
     component, verbose, skip_subcomponents = parse_args()
 
     # Validate component name - only allow alphanumerics and underscores
-    if not re.match(r'^[a-zA-Z0-9_]+$', component):
-        raise ValueError(f"Error: Invalid component name '{component}'. Component names must contain only alphanumeric characters and underscores.")
+    if not re.match(r"^[a-zA-Z0-9_]+$", component):
+        raise ValueError(
+            f"Error: Invalid component name '{component}'. Component names must contain only alphanumeric characters and underscores."
+        )
 
     tests_to_execute = set()
 
-
-    #-----------------------------------------------------------------#
+    # -----------------------------------------------------------------#
     # Identifying tests that directly use the component
-    #-----------------------------------------------------------------#
+    # -----------------------------------------------------------------#
 
     direct_tests = find_dependency("tests/", component)
     tests_to_execute.update(direct_tests)
@@ -185,9 +195,9 @@ def main() -> None:
         print(f"   • {test}")
     print()
 
-    #-----------------------------------------------------------------#
+    # -----------------------------------------------------------------#
     # Identifying dependents
-    #-----------------------------------------------------------------#
+    # -----------------------------------------------------------------#
 
     # Find dependent subworkflows
     dependent_subworkflows = set(find_dependency("subworkflows/", component))
@@ -230,7 +240,6 @@ def main() -> None:
     for workflow in dependent_workflows:
         workflow_tests.add(get_workflow_test(workflow))
 
-
     print("=" * 72)
     print(f"Found {len(workflow_tests)} tests for affected workflows:")
     print("=" * 72)
@@ -238,9 +247,9 @@ def main() -> None:
         print(f"   • {test}")
     print()
 
-    #-----------------------------------------------------------------#
+    # -----------------------------------------------------------------#
     # Identifying dependencies
-    #-----------------------------------------------------------------#
+    # -----------------------------------------------------------------#
 
     # Identifying module and subworkflow dependencies and their tests
     if not skip_subcomponents:
@@ -253,11 +262,14 @@ def main() -> None:
         else:
             if modules is not None:
                 for module in modules:
-                    subcomp_tests.update(find_dependency("tests/modules/local/", module))
+                    subcomp_tests.update(
+                        find_dependency("tests/modules/local/", module)
+                    )
             if workflows is not None:
                 for workflow in workflows:
-                    subcomp_tests.update(find_dependency("tests/subworkflows/local/", workflow))
-
+                    subcomp_tests.update(
+                        find_dependency("tests/subworkflows/local/", workflow)
+                    )
 
             print("=" * 72)
             print(f"Found {len(subcomp_tests)} tests for subcomponents of {component}:")
@@ -268,13 +280,12 @@ def main() -> None:
             print()
             tests_to_execute.update(subcomp_tests)
 
-
     tests_to_execute.update(subworkflow_tests)
     tests_to_execute.update(workflow_tests)
 
-    #-----------------------------------------------------------------#
+    # -----------------------------------------------------------------#
     # Running tests
-    #-----------------------------------------------------------------#
+    # -----------------------------------------------------------------#
 
     print("=" * 72)
     print(f"Identified {len(tests_to_execute)} test files to execute. Running...")

--- a/bin/test_component_dependencies.py
+++ b/bin/test_component_dependencies.py
@@ -97,9 +97,7 @@ def workflow_uses_subworkflow(workflow: str, subworkflow_path: str) -> bool:
         workflow_content = f.read()
 
     # Use word boundaries to preempt substring matches
-    if re.search(r"\b" + re.escape(subworkflow_dir) + r"\b", workflow_content):
-        return True
-    return False
+    return bool(re.search(r"\b" + re.escape(subworkflow_dir) + r"\b", workflow_content))
 
 
 def subworkflow_uses_subworkflow(subworkflow: str, dependent_subworkflow: str) -> bool:
@@ -110,11 +108,11 @@ def subworkflow_uses_subworkflow(subworkflow: str, dependent_subworkflow: str) -
         subworkflow_content = f.read()
 
     # Use word boundaries to preempt substring matches
-    if re.search(
-        r"\b" + re.escape(dependent_subworkflow_dir) + r"\b", subworkflow_content
-    ):
-        return True
-    return False
+    return bool(
+        re.search(
+            r"\b" + re.escape(dependent_subworkflow_dir) + r"\b", subworkflow_content
+        )
+    )
 
 
 def get_workflow_test(workflow: str) -> str:
@@ -297,7 +295,7 @@ def main() -> None:
         print(f"   • {test}")
     print("-" * 72)
 
-    result = subprocess.run(cmd)
+    subprocess.run(cmd)
 
 
 if __name__ == "__main__":

--- a/bin/test_component_dependencies.py
+++ b/bin/test_component_dependencies.py
@@ -1,9 +1,8 @@
 #! /usr/bin/env python3
 import argparse
-import subprocess
 import os
 import re
-import sys
+import subprocess
 
 
 def find_dependency(directory: str, component: str) -> set[str]:
@@ -31,8 +30,7 @@ def find_dependency(directory: str, component: str) -> set[str]:
             file = line.split(":", 1)[0]
             if "nf-test" in file:
                 continue
-            else:
-                file_paths.add(file)
+            file_paths.add(file)
 
     return file_paths
 
@@ -56,7 +54,7 @@ def identify_component_file(component: str) -> str | None:
 
 
 def get_subcomponents(component_path: str) -> tuple[set[str], set[str]]:
-    with open(component_path, "r") as f:
+    with open(component_path) as f:
         component_content = f.read()
 
     modules, workflows = set(), set()
@@ -95,21 +93,20 @@ def workflow_uses_subworkflow(workflow: str, subworkflow_path: str) -> bool:
     workflow_path = f"workflows/{workflow}"
     subworkflow_dir = subworkflow_path.replace("/main.nf", "")
 
-    with open(workflow_path, "r") as f:
+    with open(workflow_path) as f:
         workflow_content = f.read()
 
     # Use word boundaries to preempt substring matches
     if re.search(r"\b" + re.escape(subworkflow_dir) + r"\b", workflow_content):
         return True
-    else:
-        return False
+    return False
 
 
 def subworkflow_uses_subworkflow(subworkflow: str, dependent_subworkflow: str) -> bool:
     subworkflow_path = f"subworkflows/local/{subworkflow}/main.nf"
     dependent_subworkflow_dir = dependent_subworkflow.replace("/main.nf", "")
 
-    with open(subworkflow_path, "r") as f:
+    with open(subworkflow_path) as f:
         subworkflow_content = f.read()
 
     # Use word boundaries to preempt substring matches
@@ -117,17 +114,15 @@ def subworkflow_uses_subworkflow(subworkflow: str, dependent_subworkflow: str) -
         r"\b" + re.escape(dependent_subworkflow_dir) + r"\b", subworkflow_content
     ):
         return True
-    else:
-        return False
+    return False
 
 
 def get_workflow_test(workflow: str) -> str:
     workflow_path = f"workflows/{workflow}"
     if re.search(r"\b" + re.escape("run_dev_se") + r"\b", workflow_path):
         return "tests/workflows/run_dev.nf.test"
-    else:
-        base_name = os.path.basename(workflow_path).split(".")[0]
-        return f"tests/workflows/{base_name}.nf.test"
+    base_name = os.path.basename(workflow_path).split(".")[0]
+    return f"tests/workflows/{base_name}.nf.test"
 
 
 def parse_args() -> tuple[str, bool, bool]:
@@ -294,9 +289,9 @@ def main() -> None:
     cmd = ["nf-test", "test"] + sorted(tests_to_execute)
     if verbose:
         cmd.append("--verbose")
-        print(f"\nRunning test files with verbose output:")
+        print("\nRunning test files with verbose output:")
     else:
-        print(f"\nRunning test files:")
+        print("\nRunning test files:")
 
     for test in sorted(tests_to_execute):
         print(f"   • {test}")

--- a/bin/test_download_db.py
+++ b/bin/test_download_db.py
@@ -24,44 +24,57 @@ from download_db import (
     main,
 )
 
+
 class TestParseSourcePath:
     """Test source path parsing and normalization."""
 
-    @pytest.mark.parametrize("input_path,expected_path,expected_is_s3", [
-        # S3 paths - various malformed inputs
-        ("s3://bucket/path/db", "s3://bucket/path/db", True),
-        ("s3:///bucket/path/db", "s3://bucket/path/db", True),
-        ("s3:/bucket/path/db", "s3://bucket/path/db", True),
-        ("s3:bucket/path/db", "s3://bucket/path/db", True),
-        ("s3://bucket//path///db", "s3://bucket/path/db", True),
-        # Local paths
-        ("/path/to/db", "/path/to/db", False),
-        ("/path//to///db", "/path/to/db", False),
-        ("relative/path/db", "relative/path/db", False),
-    ])
-    def test_parse_source_path(self, input_path: str, expected_path: str, expected_is_s3: bool) -> None:
+    @pytest.mark.parametrize(
+        "input_path,expected_path,expected_is_s3",
+        [
+            # S3 paths - various malformed inputs
+            ("s3://bucket/path/db", "s3://bucket/path/db", True),
+            ("s3:///bucket/path/db", "s3://bucket/path/db", True),
+            ("s3:/bucket/path/db", "s3://bucket/path/db", True),
+            ("s3:bucket/path/db", "s3://bucket/path/db", True),
+            ("s3://bucket//path///db", "s3://bucket/path/db", True),
+            # Local paths
+            ("/path/to/db", "/path/to/db", False),
+            ("/path//to///db", "/path/to/db", False),
+            ("relative/path/db", "relative/path/db", False),
+        ],
+    )
+    def test_parse_source_path(
+        self, input_path: str, expected_path: str, expected_is_s3: bool
+    ) -> None:
         """Test path normalization with various inputs."""
         normalized, is_s3 = parse_source_path(input_path)
         assert normalized == expected_path
         assert is_s3 == expected_is_s3
 
+
 class TestGetCacheName:
     """Test cache name generation."""
 
-    @pytest.mark.parametrize("source_path,expected_name", [
-        ("s3://bucket/path/kraken_db", "kraken_db_35f571f1"),
-        ("s3://bucket/path/db", "db_56898535"),
-        ("/local/path/bowtie2_idx", "bowtie2_idx_46a0d77f"),
-    ])
+    @pytest.mark.parametrize(
+        "source_path,expected_name",
+        [
+            ("s3://bucket/path/kraken_db", "kraken_db_35f571f1"),
+            ("s3://bucket/path/db", "db_56898535"),
+            ("/local/path/bowtie2_idx", "bowtie2_idx_46a0d77f"),
+        ],
+    )
     def test_cache_name(self, source_path: str, expected_name: str) -> None:
         """Test that cache name is basename + first 8 chars of sha256 hash."""
         assert get_cache_name(source_path) == expected_name
+
 
 class TestFileLock:
     """Test file locking context manager."""
 
     @pytest.mark.parametrize("lock_path", ["test.lock", "subdir/nested/test.lock"])
-    def test_lock_creates_file_and_parents(self, tmp_path: Path, lock_path: str) -> None:
+    def test_lock_creates_file_and_parents(
+        self, tmp_path: Path, lock_path: str
+    ) -> None:
         """Test that lock creates the lock file and any parent directories."""
         lock_file = tmp_path / lock_path
         with file_lock(lock_file):
@@ -77,33 +90,55 @@ class TestFileLock:
                     pass
             # Lock is released when file is closed
 
+
 class TestConfigureAwsS3Transfer:
     """Test AWS S3 transfer configuration."""
 
-    @patch('download_db.subprocess.run')
+    @patch("download_db.subprocess.run")
     def test_configure_aws_s3_transfer(self, mock_run: MagicMock) -> None:
         """Test that AWS CLI settings are configured correctly."""
         mock_run.return_value = MagicMock(returncode=0)
         configure_aws_s3_transfer()
         assert mock_run.call_count == 3
         calls = [call[0][0] for call in mock_run.call_args_list]
-        assert ["aws", "configure", "set", "default.s3.max_concurrent_requests", "20"] in calls
-        assert ["aws", "configure", "set", "default.s3.multipart_threshold", "64MB"] in calls
-        assert ["aws", "configure", "set", "default.s3.multipart_chunksize", "16MB"] in calls
+        assert [
+            "aws",
+            "configure",
+            "set",
+            "default.s3.max_concurrent_requests",
+            "20",
+        ] in calls
+        assert [
+            "aws",
+            "configure",
+            "set",
+            "default.s3.multipart_threshold",
+            "64MB",
+        ] in calls
+        assert [
+            "aws",
+            "configure",
+            "set",
+            "default.s3.multipart_chunksize",
+            "16MB",
+        ] in calls
 
-    @patch('download_db.subprocess.run')
+    @patch("download_db.subprocess.run")
     def test_configure_aws_s3_transfer_failure(self, mock_run: MagicMock) -> None:
         """Test that configuration failure raises exception."""
         mock_run.side_effect = subprocess.CalledProcessError(1, "aws")
         with pytest.raises(subprocess.CalledProcessError):
             configure_aws_s3_transfer()
 
+
 class TestSyncFromS3:
     """Test S3 sync function."""
 
-    @patch('download_db.configure_aws_s3_transfer')
-    @patch('download_db.subprocess.run')
-    def test_sync_from_s3_success(self, mock_run: MagicMock, mock_configure: MagicMock) -> None:
+    @patch("download_db.configure_aws_s3_transfer")
+    @patch("download_db.subprocess.run")
+    def test_sync_from_s3_success(
+        self, mock_run: MagicMock, mock_configure: MagicMock
+    ) -> None:
         """Test successful S3 sync."""
         sync_from_s3("s3://bucket/db", Path("/scratch/db"))
         mock_configure.assert_called_once()
@@ -114,18 +149,21 @@ class TestSyncFromS3:
             text=True,
         )
 
-    @patch('download_db.configure_aws_s3_transfer')
-    @patch('download_db.subprocess.run')
-    def test_sync_from_s3_failure(self, mock_run: MagicMock, mock_configure: MagicMock) -> None:
+    @patch("download_db.configure_aws_s3_transfer")
+    @patch("download_db.subprocess.run")
+    def test_sync_from_s3_failure(
+        self, mock_run: MagicMock, mock_configure: MagicMock
+    ) -> None:
         """Test S3 sync failure raises CalledProcessError."""
         mock_run.side_effect = subprocess.CalledProcessError(1, "aws s3 sync")
         with pytest.raises(subprocess.CalledProcessError):
             sync_from_s3("s3://bucket/db", Path("/scratch/db"))
 
+
 class TestSyncFromLocal:
     """Test local rsync function."""
 
-    @patch('download_db.subprocess.run')
+    @patch("download_db.subprocess.run")
     def test_sync_from_local_success(self, mock_run: MagicMock) -> None:
         """Test successful local sync."""
         sync_from_local("/source/db", Path("/scratch/db"))
@@ -136,29 +174,44 @@ class TestSyncFromLocal:
             text=True,
         )
 
-    @patch('download_db.subprocess.run')
+    @patch("download_db.subprocess.run")
     def test_sync_from_local_failure(self, mock_run: MagicMock) -> None:
         """Test local sync failure raises CalledProcessError."""
         mock_run.side_effect = subprocess.CalledProcessError(1, "rsync")
         with pytest.raises(subprocess.CalledProcessError):
             sync_from_local("/source/db", Path("/scratch/db"))
 
+
 class TestDownloadDatabase:
     """Test main download_database function."""
 
     @pytest.fixture
     def mock_file_lock(self) -> Generator[MagicMock, None, None]:
-        with patch('download_db.file_lock') as mock:
+        with patch("download_db.file_lock") as mock:
             mock.return_value.__enter__ = MagicMock()
             mock.return_value.__exit__ = MagicMock(return_value=False)
             yield mock
 
-    @pytest.mark.parametrize("source_path,expected_basename,sync_func", [
-        ("s3://bucket/kraken_db", "kraken_db_", "download_db.sync_from_s3"),
-        ("/source/bowtie2_db", "bowtie2_db_", "download_db.sync_from_local"),
-        ("s3:///bucket//path///db", "db_", "download_db.sync_from_s3"),  # tests normalization
-    ])
-    def test_download_database(self, mock_file_lock: MagicMock, tmp_path: Path, source_path: str, expected_basename: str, sync_func: str) -> None:
+    @pytest.mark.parametrize(
+        "source_path,expected_basename,sync_func",
+        [
+            ("s3://bucket/kraken_db", "kraken_db_", "download_db.sync_from_s3"),
+            ("/source/bowtie2_db", "bowtie2_db_", "download_db.sync_from_local"),
+            (
+                "s3:///bucket//path///db",
+                "db_",
+                "download_db.sync_from_s3",
+            ),  # tests normalization
+        ],
+    )
+    def test_download_database(
+        self,
+        mock_file_lock: MagicMock,
+        tmp_path: Path,
+        source_path: str,
+        expected_basename: str,
+        sync_func: str,
+    ) -> None:
         """Test downloading from S3 and local paths."""
         with patch(sync_func) as mock_sync:
             result = download_database(source_path, scratch_dir=tmp_path)
@@ -166,10 +219,12 @@ class TestDownloadDatabase:
             assert result.name.startswith(expected_basename)
             mock_sync.assert_called_once()
 
-    def test_download_database_creates_scratch_dir(self, mock_file_lock: MagicMock, tmp_path: Path) -> None:
+    def test_download_database_creates_scratch_dir(
+        self, mock_file_lock: MagicMock, tmp_path: Path
+    ) -> None:
         """Test that scratch directory is created if it doesn't exist."""
         _ = mock_file_lock  # fixture needed for side effect
-        with patch('download_db.sync_from_s3'):
+        with patch("download_db.sync_from_s3"):
             scratch = tmp_path / "new_scratch"
             assert not scratch.exists()
             download_database("s3://bucket/db", scratch_dir=scratch)
@@ -177,32 +232,48 @@ class TestDownloadDatabase:
 
     def test_download_database_passes_timeout(self, tmp_path: Path) -> None:
         """Test that timeout is passed to file_lock."""
-        with patch('download_db.file_lock') as mock_lock, patch('download_db.sync_from_s3'):
+        with (
+            patch("download_db.file_lock") as mock_lock,
+            patch("download_db.sync_from_s3"),
+        ):
             mock_lock.return_value.__enter__ = MagicMock()
             mock_lock.return_value.__exit__ = MagicMock(return_value=False)
-            download_database("s3://bucket/db", timeout_seconds=600, scratch_dir=tmp_path)
+            download_database(
+                "s3://bucket/db", timeout_seconds=600, scratch_dir=tmp_path
+            )
             assert mock_lock.call_args[0][1] == 600
+
 
 class TestMain:
     """Test main entry point."""
 
-    @pytest.mark.parametrize("argv,expected_args", [
-        (['download_db.py', 's3://bucket/db', '300'], ('s3://bucket/db', 300)),
-        (['download_db.py', '/local/path/db'], ('/local/path/db', None)),
-    ])
-    @patch('download_db.download_database')
-    def test_main(self, mock_download: MagicMock, argv: list[str], expected_args: tuple[str, int | None]) -> None:
+    @pytest.mark.parametrize(
+        "argv,expected_args",
+        [
+            (["download_db.py", "s3://bucket/db", "300"], ("s3://bucket/db", 300)),
+            (["download_db.py", "/local/path/db"], ("/local/path/db", None)),
+        ],
+    )
+    @patch("download_db.download_database")
+    def test_main(
+        self,
+        mock_download: MagicMock,
+        argv: list[str],
+        expected_args: tuple[str, int | None],
+    ) -> None:
         """Test that main parses args and calls download_database."""
         mock_download.return_value = Path("/scratch/db_abc123")
-        with patch('sys.argv', argv):
+        with patch("sys.argv", argv):
             main()
             mock_download.assert_called_once_with(*expected_args)
 
-    @patch('download_db.download_database')
-    def test_main_prints_path(self, mock_download: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+    @patch("download_db.download_database")
+    def test_main_prints_path(
+        self, mock_download: MagicMock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         """Test that main prints the local path to stdout."""
         mock_download.return_value = Path("/scratch/kraken_db_abc12345")
-        with patch('sys.argv', ['download_db.py', 's3://bucket/db']):
+        with patch("sys.argv", ["download_db.py", "s3://bucket/db"]):
             main()
         captured = capsys.readouterr()
         assert captured.out.strip() == "/scratch/kraken_db_abc12345"

--- a/bin/test_download_db.py
+++ b/bin/test_download_db.py
@@ -84,9 +84,11 @@ class TestFileLock:
         lock_file = tmp_path / "test.lock"
         with open(lock_file, "w") as f:
             fcntl.flock(f, fcntl.LOCK_EX)
-            with pytest.raises(TimeoutError, match="Timed out waiting for lock"):
-                with file_lock(lock_file, timeout_seconds=0.2):
-                    pass
+            with (
+                pytest.raises(TimeoutError, match="Timed out waiting for lock"),
+                file_lock(lock_file, timeout_seconds=0.2),
+            ):
+                pass
             # Lock is released when file is closed
 
 

--- a/bin/test_download_db.py
+++ b/bin/test_download_db.py
@@ -8,20 +8,19 @@ Run with: pytest bin/test_download_db.py
 import fcntl
 import subprocess
 from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
-from pathlib import Path
-from unittest.mock import patch, MagicMock
-
 from download_db import (
-    parse_source_path,
-    get_cache_name,
-    file_lock,
     configure_aws_s3_transfer,
-    sync_from_s3,
-    sync_from_local,
     download_database,
+    file_lock,
+    get_cache_name,
     main,
+    parse_source_path,
+    sync_from_local,
+    sync_from_s3,
 )
 
 

--- a/bin/test_extract_changelog.py
+++ b/bin/test_extract_changelog.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 """Unit tests for extract_changelog.py"""
 
-import pytest
+import sys
 from pathlib import Path
 
-import sys
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from extract_changelog import (
-    parse_version_header,
     extract_changelog,
+    parse_version_header,
 )
 
 

--- a/bin/test_extract_changelog.py
+++ b/bin/test_extract_changelog.py
@@ -5,6 +5,7 @@ import pytest
 from pathlib import Path
 
 import sys
+
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from extract_changelog import (
     parse_version_header,
@@ -13,143 +14,164 @@ from extract_changelog import (
 
 
 class TestParseVersionHeader:
-    @pytest.mark.parametrize("line,expected", [
-        ("# v1.2.3.4", "1.2.3.4"),
-        ("# 1.2.3.4", "1.2.3.4"),
-        ("# v1.2.3.4-dev", "1.2.3.4-dev"),
-        ("# 1.2.3.4-dev", "1.2.3.4-dev"),
-        ("# v0.0.0.0", "0.0.0.0"),
-        ("# v10.20.30.40", "10.20.30.40"),
-        ("#v1.2.3.4", "1.2.3.4"),  # No space after #
-        ("#  v1.2.3.4", "1.2.3.4"),  # Multiple spaces
-    ])
+    @pytest.mark.parametrize(
+        "line,expected",
+        [
+            ("# v1.2.3.4", "1.2.3.4"),
+            ("# 1.2.3.4", "1.2.3.4"),
+            ("# v1.2.3.4-dev", "1.2.3.4-dev"),
+            ("# 1.2.3.4-dev", "1.2.3.4-dev"),
+            ("# v0.0.0.0", "0.0.0.0"),
+            ("# v10.20.30.40", "10.20.30.40"),
+            ("#v1.2.3.4", "1.2.3.4"),  # No space after #
+            ("#  v1.2.3.4", "1.2.3.4"),  # Multiple spaces
+        ],
+    )
     def test_valid_headers(self, line: str, expected: str) -> None:
         """Test parsing of valid version headers."""
         assert parse_version_header(line) == expected
 
-    @pytest.mark.parametrize("line", [
-        "# v1.2.3",  # Wrong format (X.Y.Z instead of X.Y.Z.W)
-        "# v1.2.3.4.5",  # Too many components
-        "# 1.2.3",  # Wrong format without v prefix
-        "## v1.2.3.4",  # Wrong markdown level
-        "v1.2.3.4",  # No #
-        "# Version 1.2.3.4",  # Wrong prefix
-        "# v1.2.3.4-beta",  # Wrong suffix (not -dev)
-        "# va.b.c.d",  # Non-numeric
-        "",  # Empty
-        "   ",  # Whitespace only
-        "# Some other header",  # Not a version
-    ])
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "# v1.2.3",  # Wrong format (X.Y.Z instead of X.Y.Z.W)
+            "# v1.2.3.4.5",  # Too many components
+            "# 1.2.3",  # Wrong format without v prefix
+            "## v1.2.3.4",  # Wrong markdown level
+            "v1.2.3.4",  # No #
+            "# Version 1.2.3.4",  # Wrong prefix
+            "# v1.2.3.4-beta",  # Wrong suffix (not -dev)
+            "# va.b.c.d",  # Non-numeric
+            "",  # Empty
+            "   ",  # Whitespace only
+            "# Some other header",  # Not a version
+        ],
+    )
     def test_invalid_headers(self, line: str) -> None:
         """Test that invalid headers return None."""
         assert parse_version_header(line) is None
 
 
 class TestExtractChangelog:
-    @pytest.mark.parametrize("content,version,expected", [
-        # Basic extraction
-        (
-            "# v1.0.0.0\n- First feature\n- Second feature\n\n# v0.9.0.0\n- Old feature\n",
-            "1.0.0.0",
-            "- First feature\n- Second feature\n",
-        ),
-        # Without v prefix
-        (
-            "# 1.0.0.0\n- Feature\n\n# 0.9.0.0\n- Old\n",
-            "1.0.0.0",
-            "- Feature\n",
-        ),
-        # Dev version
-        (
-            "# v1.0.0.1-dev\n- Dev feature\n- Another dev feature\n\n# v1.0.0.0\n- Released\n",
-            "1.0.0.1-dev",
-            "- Dev feature\n- Another dev feature\n",
-        ),
-        # First version in changelog
-        (
-            "# v2.0.0.0\n- Latest feature\n\n# v1.0.0.0\n- Old feature\n",
-            "2.0.0.0",
-            "- Latest feature\n",
-        ),
-        # Last version in changelog (no next header)
-        (
-            "# v2.0.0.0\n- New\n\n# v1.0.0.0\n- Old feature\n- Another old feature\n",
-            "1.0.0.0",
-            "- Old feature\n- Another old feature\n",
-        ),
-        # Middle version
-        (
-            "# v3.0.0.0\n- Newest\n\n# v2.0.0.0\n- Middle feature\n- Another middle\n\n# v1.0.0.0\n- Oldest\n",
-            "2.0.0.0",
-            "- Middle feature\n- Another middle\n",
-        ),
-        # Various version number formats
-        (
-            "# v10.20.30.40\n- Feature\n\n# v0.0.0.0\n- Old\n",
-            "10.20.30.40",
-            "- Feature\n",
-        ),
-        (
-            "# v0.0.0.0\n- Feature\n\n# v1.0.0.0\n- Newer\n",
-            "0.0.0.0",
-            "- Feature\n",
-        ),
-    ])
-    def test_extraction_scenarios(self, tmp_path: Path, content: str, version: str, expected: str) -> None:
+    @pytest.mark.parametrize(
+        "content,version,expected",
+        [
+            # Basic extraction
+            (
+                "# v1.0.0.0\n- First feature\n- Second feature\n\n# v0.9.0.0\n- Old feature\n",
+                "1.0.0.0",
+                "- First feature\n- Second feature\n",
+            ),
+            # Without v prefix
+            (
+                "# 1.0.0.0\n- Feature\n\n# 0.9.0.0\n- Old\n",
+                "1.0.0.0",
+                "- Feature\n",
+            ),
+            # Dev version
+            (
+                "# v1.0.0.1-dev\n- Dev feature\n- Another dev feature\n\n# v1.0.0.0\n- Released\n",
+                "1.0.0.1-dev",
+                "- Dev feature\n- Another dev feature\n",
+            ),
+            # First version in changelog
+            (
+                "# v2.0.0.0\n- Latest feature\n\n# v1.0.0.0\n- Old feature\n",
+                "2.0.0.0",
+                "- Latest feature\n",
+            ),
+            # Last version in changelog (no next header)
+            (
+                "# v2.0.0.0\n- New\n\n# v1.0.0.0\n- Old feature\n- Another old feature\n",
+                "1.0.0.0",
+                "- Old feature\n- Another old feature\n",
+            ),
+            # Middle version
+            (
+                "# v3.0.0.0\n- Newest\n\n# v2.0.0.0\n- Middle feature\n- Another middle\n\n# v1.0.0.0\n- Oldest\n",
+                "2.0.0.0",
+                "- Middle feature\n- Another middle\n",
+            ),
+            # Various version number formats
+            (
+                "# v10.20.30.40\n- Feature\n\n# v0.0.0.0\n- Old\n",
+                "10.20.30.40",
+                "- Feature\n",
+            ),
+            (
+                "# v0.0.0.0\n- Feature\n\n# v1.0.0.0\n- Newer\n",
+                "0.0.0.0",
+                "- Feature\n",
+            ),
+        ],
+    )
+    def test_extraction_scenarios(
+        self, tmp_path: Path, content: str, version: str, expected: str
+    ) -> None:
         """Test various extraction scenarios."""
         changelog = tmp_path / "CHANGELOG.md"
         changelog.write_text(content)
         result = extract_changelog(version, changelog)
         assert result == expected
 
-    @pytest.mark.parametrize("content,version,expected", [
-        # Empty lines filtered out
-        (
-            "# v1.0.0.0\n\n- Feature one\n\n\n- Feature two\n    - Sub-feature\n\n# v0.9.0.0\n- Old\n",
-            "1.0.0.0",
-            "- Feature one\n- Feature two\n    - Sub-feature\n",
-        ),
-        # Indentation preserved
-        (
-            "# v1.0.0.0\n- Top level\n    - Indented\n        - More indented\n- Another top level\n\n# v0.9.0.0\n- Old\n",
-            "1.0.0.0",
-            "- Top level\n    - Indented\n        - More indented\n- Another top level\n",
-        ),
-        # Multiline entries
-        (
-            "# v1.0.0.0\n- Feature with\n  continuation line\n- Another feature\n\n# v0.9.0.0\n- Old\n",
-            "1.0.0.0",
-            "- Feature with\n  continuation line\n- Another feature\n",
-        ),
-        # Subsections
-        (
-            "# v3.0.0.0\n## Breaking Changes\n- Breaking feature\n## Bug Fixes\n- Fixed bug\n\n# v2.0.0.0\n- Old\n",
-            "3.0.0.0",
-            "## Breaking Changes\n- Breaking feature\n## Bug Fixes\n- Fixed bug\n",
-        ),
-    ])
-    def test_formatting_preservation(self, tmp_path: Path, content: str, version: str, expected: str) -> None:
+    @pytest.mark.parametrize(
+        "content,version,expected",
+        [
+            # Empty lines filtered out
+            (
+                "# v1.0.0.0\n\n- Feature one\n\n\n- Feature two\n    - Sub-feature\n\n# v0.9.0.0\n- Old\n",
+                "1.0.0.0",
+                "- Feature one\n- Feature two\n    - Sub-feature\n",
+            ),
+            # Indentation preserved
+            (
+                "# v1.0.0.0\n- Top level\n    - Indented\n        - More indented\n- Another top level\n\n# v0.9.0.0\n- Old\n",
+                "1.0.0.0",
+                "- Top level\n    - Indented\n        - More indented\n- Another top level\n",
+            ),
+            # Multiline entries
+            (
+                "# v1.0.0.0\n- Feature with\n  continuation line\n- Another feature\n\n# v0.9.0.0\n- Old\n",
+                "1.0.0.0",
+                "- Feature with\n  continuation line\n- Another feature\n",
+            ),
+            # Subsections
+            (
+                "# v3.0.0.0\n## Breaking Changes\n- Breaking feature\n## Bug Fixes\n- Fixed bug\n\n# v2.0.0.0\n- Old\n",
+                "3.0.0.0",
+                "## Breaking Changes\n- Breaking feature\n## Bug Fixes\n- Fixed bug\n",
+            ),
+        ],
+    )
+    def test_formatting_preservation(
+        self, tmp_path: Path, content: str, version: str, expected: str
+    ) -> None:
         """Test that formatting is preserved correctly."""
         changelog = tmp_path / "CHANGELOG.md"
         changelog.write_text(content)
         result = extract_changelog(version, changelog)
         assert result == expected
 
-    @pytest.mark.parametrize("content,version,match", [
-        # Version not found
-        (
-            "# v1.0.0.0\n- Feature\n\n# v0.9.0.0\n- Old\n",
-            "2.0.0.0",
-            "Version 2.0.0.0 not found",
-        ),
-        # Version found but no content
-        (
-            "# v1.0.0.0\n\n# v0.9.0.0\n- Old\n",
-            "1.0.0.0",
-            "Version 1.0.0.0 found in CHANGELOG.md but contains no content",
-        ),
-    ])
-    def test_errors(self, tmp_path: Path, content: str, version: str, match: str) -> None:
+    @pytest.mark.parametrize(
+        "content,version,match",
+        [
+            # Version not found
+            (
+                "# v1.0.0.0\n- Feature\n\n# v0.9.0.0\n- Old\n",
+                "2.0.0.0",
+                "Version 2.0.0.0 not found",
+            ),
+            # Version found but no content
+            (
+                "# v1.0.0.0\n\n# v0.9.0.0\n- Old\n",
+                "1.0.0.0",
+                "Version 1.0.0.0 found in CHANGELOG.md but contains no content",
+            ),
+        ],
+    )
+    def test_errors(
+        self, tmp_path: Path, content: str, version: str, match: str
+    ) -> None:
         """Test error conditions."""
         changelog = tmp_path / "CHANGELOG.md"
         changelog.write_text(content)

--- a/bin/test_prepare_tiny_test_data.py
+++ b/bin/test_prepare_tiny_test_data.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Unit tests for prepare_tiny_test_data.py"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+from prepare_tiny_test_data import parse_s3_uri
+
+
+class TestParseS3Uri:
+    @pytest.mark.parametrize(
+        ("uri", "default_key", "expected_bucket", "expected_key"),
+        [
+            # Standard cases
+            ("s3://bucket/key", "default.txt", "bucket", "key"),
+            ("s3://bucket/path/to/key", "default.txt", "bucket", "path/to/key"),
+            # No key in URI: use default
+            ("s3://bucket", "default.txt", "bucket", "default.txt"),
+            ("s3://bucket/", "default.txt", "bucket", "default.txt"),
+            # Trailing slash on key stripped
+            ("s3://bucket/key/", "default.txt", "bucket", "key"),
+            # Regression for B005: lstrip("s3://") would treat "s3://" as a
+            # character set and consume any leading combination of {s,3,:,/}.
+            # removeprefix("s3://") must strip the literal scheme exactly once.
+            ("s3://sssbucket/key", "default.txt", "sssbucket", "key"),
+            ("s3://3bucket/key", "default.txt", "3bucket", "key"),
+        ],
+    )
+    def test_valid(
+        self, uri: str, default_key: str, expected_bucket: str, expected_key: str
+    ) -> None:
+        bucket, key = parse_s3_uri(uri, default_key)
+        assert bucket == expected_bucket
+        assert key == expected_key
+
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            "",
+            "bucket/key",
+            "http://bucket/key",
+            "S3://bucket/key",  # uppercase scheme rejected (case-sensitive)
+            "s3:/bucket/key",  # missing second slash
+        ],
+    )
+    def test_invalid(self, uri: str) -> None:
+        with pytest.raises(ValueError, match="Invalid S3 URI"):
+            parse_s3_uri(uri, "default.txt")

--- a/bin/test_run_nf_test_parallel.py
+++ b/bin/test_run_nf_test_parallel.py
@@ -12,6 +12,7 @@ import subprocess
 
 # Import functions from the script
 import sys
+
 sys.path.insert(0, str(Path(__file__).parent))
 from run_nf_test_parallel import (
     find_test_files,
@@ -25,12 +26,13 @@ from run_nf_test_parallel import (
     write_test_log,
 )
 
+
 class TestStripAnsiCodes:
     """Test ANSI escape code removal."""
 
     def test_strip_complex_codes(self) -> None:
         """Test removal of complex ANSI sequences."""
-        text = "\x1B[1;32;40mBold green on black\x1B[0m"
+        text = "\x1b[1;32;40mBold green on black\x1b[0m"
         assert strip_ansi_codes(text) == "Bold green on black"
 
     def test_no_ansi_codes(self) -> None:
@@ -40,8 +42,9 @@ class TestStripAnsiCodes:
 
     def test_multiple_codes(self) -> None:
         """Test text with multiple ANSI codes."""
-        text = "\x1B[31mRed\x1B[0m and \x1B[32mGreen\x1B[0m"
+        text = "\x1b[31mRed\x1b[0m and \x1b[32mGreen\x1b[0m"
         assert strip_ansi_codes(text) == "Red and Green"
+
 
 class TestFindTestFiles:
     """Test finding *.nf.test files."""
@@ -61,7 +64,7 @@ class TestFindTestFiles:
         (tmp_path / "other.txt").touch()
         result = find_test_files([str(tmp_path)])
         assert len(result) == 2
-        assert all(f.name.endswith('.nf.test') for f in result)
+        assert all(f.name.endswith(".nf.test") for f in result)
 
     def test_find_files_recursively(self, tmp_path: Path) -> None:
         """Test recursive search in nested directories."""
@@ -98,15 +101,30 @@ class TestFindTestFiles:
         names = [f.name for f in result]
         assert names == sorted(names)
 
+
 class TestDivideTestFiles:
     """Test dividing test files among workers."""
 
-    @pytest.mark.parametrize("n_files,n_workers", [
-        (6, 3), (9, 3), (4, 2), (8, 4),  # Even distribution
-        (5, 3), (7, 3), (10, 4), (11, 5),  # Uneven distribution
-        (2, 5), (1, 3), (3, 10),  # More workers than files
-        (0, 3), (5, 1), (1, 1), (100, 7),  # Edge cases
-    ])
+    @pytest.mark.parametrize(
+        "n_files,n_workers",
+        [
+            (6, 3),
+            (9, 3),
+            (4, 2),
+            (8, 4),  # Even distribution
+            (5, 3),
+            (7, 3),
+            (10, 4),
+            (11, 5),  # Uneven distribution
+            (2, 5),
+            (1, 3),
+            (3, 10),  # More workers than files
+            (0, 3),
+            (5, 1),
+            (1, 1),
+            (100, 7),  # Edge cases
+        ],
+    )
     def test_divide_distribution(self, n_files: int, n_workers: int) -> None:
         """Test file distribution with various combinations."""
         files = [Path(f"test{i}.nf.test") for i in range(n_files)]
@@ -122,10 +140,11 @@ class TestDivideTestFiles:
         assert len(all_assigned_files) == n_files
         assert set(all_assigned_files) == set(files)
 
+
 class TestExecuteSubprocess:
     """Test subprocess execution wrapper."""
 
-    @patch('run_nf_test_parallel.subprocess.run')
+    @patch("run_nf_test_parallel.subprocess.run")
     def test_execute_subprocess(self, mock_run: MagicMock) -> None:
         """Test that execute_subprocess correctly wraps subprocess.run."""
         mock_result = MagicMock()
@@ -137,7 +156,10 @@ class TestExecuteSubprocess:
         assert exit_code == mock_result.returncode
         assert stdout == mock_result.stdout
         assert stderr == mock_result.stderr
-        mock_run.assert_called_once_with(["test", "command"], capture_output=True, text=True)
+        mock_run.assert_called_once_with(
+            ["test", "command"], capture_output=True, text=True
+        )
+
 
 class TestRunNfTestWorker:
     """Test nf-test worker function."""
@@ -145,11 +167,7 @@ class TestRunNfTestWorker:
     def test_worker_with_no_files(self) -> None:
         """Test worker with no assigned test files."""
         worker_id, exit_code, stdout, stderr, cmd_str = run_nf_test_worker(
-            worker_id=1,
-            test_files=[],
-            total_workers=3,
-            debug=False,
-            ci=False
+            worker_id=1, test_files=[], total_workers=3, debug=False, ci=False
         )
         assert worker_id == 1
         assert exit_code == 0
@@ -157,72 +175,99 @@ class TestRunNfTestWorker:
         assert stderr == ""
         assert cmd_str == ""
 
-    @pytest.mark.parametrize("test_files,expected_exit,mock_stdout,mock_stderr", [
-        ([Path("test1.nf.test")], 0, "Test passed\n", ""),
-        ([Path("test1.nf.test"), Path("test2.nf.test"), Path("test3.nf.test")], 0, "All tests passed\n", ""),
-        ([Path("failing_test.nf.test")], 1, "FAILED (1.0s)\n", "Error message"),
-    ])
-    @patch('run_nf_test_parallel.execute_subprocess')
-    def test_worker_with_files(self, mock_execute: MagicMock, test_files: list[Path], expected_exit: int, mock_stdout: str, mock_stderr: str) -> None:
+    @pytest.mark.parametrize(
+        "test_files,expected_exit,mock_stdout,mock_stderr",
+        [
+            ([Path("test1.nf.test")], 0, "Test passed\n", ""),
+            (
+                [Path("test1.nf.test"), Path("test2.nf.test"), Path("test3.nf.test")],
+                0,
+                "All tests passed\n",
+                "",
+            ),
+            ([Path("failing_test.nf.test")], 1, "FAILED (1.0s)\n", "Error message"),
+        ],
+    )
+    @patch("run_nf_test_parallel.execute_subprocess")
+    def test_worker_with_files(
+        self,
+        mock_execute: MagicMock,
+        test_files: list[Path],
+        expected_exit: int,
+        mock_stdout: str,
+        mock_stderr: str,
+    ) -> None:
         """Test worker with various file configurations and outcomes."""
         mock_execute.return_value = (expected_exit, mock_stdout, mock_stderr)
         worker_id, exit_code, stdout, stderr, cmd_str = run_nf_test_worker(
-            worker_id=1,
-            test_files=test_files,
-            total_workers=2,
-            debug=False,
-            ci=False
+            worker_id=1, test_files=test_files, total_workers=2, debug=False, ci=False
         )
         assert worker_id == 1
         assert exit_code == expected_exit
         assert stdout == mock_stdout
         assert stderr == mock_stderr
-        exp_call_args = ["nf-test", "test"] + [str(test_file) for test_file in test_files]
+        exp_call_args = ["nf-test", "test"] + [
+            str(test_file) for test_file in test_files
+        ]
         assert cmd_str == " ".join(exp_call_args)
         mock_execute.assert_called_once()
         assert mock_execute.call_args[0][0] == exp_call_args
 
-    @pytest.mark.parametrize("debug,ci,expected_flags", [
-        (True, False, ["--debug", "--verbose"]),
-        (False, True, ["--ci"]),
-        (True, True, ["--debug", "--verbose", "--ci"]),
-    ])
-    @patch('run_nf_test_parallel.execute_subprocess')
-    def test_worker_with_flags(self, mock_execute: MagicMock, debug: bool, ci: bool, expected_flags: list[str]) -> None:
+    @pytest.mark.parametrize(
+        "debug,ci,expected_flags",
+        [
+            (True, False, ["--debug", "--verbose"]),
+            (False, True, ["--ci"]),
+            (True, True, ["--debug", "--verbose", "--ci"]),
+        ],
+    )
+    @patch("run_nf_test_parallel.execute_subprocess")
+    def test_worker_with_flags(
+        self, mock_execute: MagicMock, debug: bool, ci: bool, expected_flags: list[str]
+    ) -> None:
         """Test worker with debug and CI mode flags."""
         mock_execute.return_value = (0, "test1", "test2")
         test_files = [Path("test1.nf.test"), Path("test2.nf.test")]
         worker_id, exit_code, stdout, stderr, cmd_str = run_nf_test_worker(
-            worker_id=1,
-            test_files=test_files,
-            total_workers=2,
-            debug=debug,
-            ci=ci
+            worker_id=1, test_files=test_files, total_workers=2, debug=debug, ci=ci
         )
         assert worker_id == 1
         assert exit_code == 0
         assert stdout == "test1"
         assert stderr == "test2"
-        exp_call_args = ["nf-test", "test"] + expected_flags + [str(test_file) for test_file in test_files]
+        exp_call_args = (
+            ["nf-test", "test"]
+            + expected_flags
+            + [str(test_file) for test_file in test_files]
+        )
         assert cmd_str == " ".join(exp_call_args)
         mock_execute.assert_called_once()
         assert mock_execute.call_args[0][0] == exp_call_args
+
 
 class TestExtractFailuresFromOutput:
     """Test extracting FAILED test names from output."""
 
     def test_extract_failures(self) -> None:
         """Test extracting failures from output."""
-        lines = ["Test 1", "FAILED (1.0s)", "Test 2", "PASSED (0.5s)", "Test 3", "FAILED (2.0s)"]
+        lines = [
+            "Test 1",
+            "FAILED (1.0s)",
+            "Test 2",
+            "PASSED (0.5s)",
+            "Test 3",
+            "FAILED (2.0s)",
+        ]
         input = "\n".join(lines)
         exp_result = [line for line in lines if "FAILED" in line]
         result = extract_failures_from_output(input)
         assert result == exp_result
 
+
 class TestUpdatePlugins:
     """Test nf-test plugin update function."""
 
-    @patch('run_nf_test_parallel.subprocess.run')
+    @patch("run_nf_test_parallel.subprocess.run")
     def test_update_plugins_success(self, mock_run: MagicMock) -> None:
         """Test successful plugin update."""
         mock_result = MagicMock()
@@ -231,13 +276,10 @@ class TestUpdatePlugins:
         mock_run.return_value = mock_result
         update_plugins()
         mock_run.assert_called_once_with(
-            ["nf-test", "update-plugins"],
-            capture_output=True,
-            text=True,
-            timeout=120
+            ["nf-test", "update-plugins"], capture_output=True, text=True, timeout=120
         )
 
-    @patch('run_nf_test_parallel.subprocess.run')
+    @patch("run_nf_test_parallel.subprocess.run")
     def test_update_plugins_failure(self, mock_run: MagicMock) -> None:
         """Test plugin update with non-zero exit code."""
         mock_result = MagicMock()
@@ -247,35 +289,54 @@ class TestUpdatePlugins:
         with pytest.raises(RuntimeError, match="Failed to update plugins"):
             update_plugins()
 
-    @patch('run_nf_test_parallel.subprocess.run')
+    @patch("run_nf_test_parallel.subprocess.run")
     def test_update_plugins_timeout(self, mock_run: MagicMock) -> None:
         """Test plugin update timeout."""
         mock_run.side_effect = subprocess.TimeoutExpired(cmd="nf-test", timeout=120)
-        with pytest.raises(RuntimeError, match="Plugin update timed out after 120 seconds"):
+        with pytest.raises(
+            RuntimeError, match="Plugin update timed out after 120 seconds"
+        ):
             update_plugins()
+
 
 class TestRunParallelTests:
     """Test parallel test execution orchestration."""
 
-    @patch('run_nf_test_parallel.write_test_log')
-    @patch('run_nf_test_parallel.multiprocessing.Pool')
-    @patch('run_nf_test_parallel.divide_test_files')
-    @patch('run_nf_test_parallel.update_plugins')
-    @patch('run_nf_test_parallel.find_test_files')
-    def test_run_parallel_tests_no_files(self, mock_find: MagicMock, mock_update: MagicMock, mock_divide: MagicMock, mock_pool: MagicMock, mock_write: MagicMock) -> None:
+    @patch("run_nf_test_parallel.write_test_log")
+    @patch("run_nf_test_parallel.multiprocessing.Pool")
+    @patch("run_nf_test_parallel.divide_test_files")
+    @patch("run_nf_test_parallel.update_plugins")
+    @patch("run_nf_test_parallel.find_test_files")
+    def test_run_parallel_tests_no_files(
+        self,
+        mock_find: MagicMock,
+        mock_update: MagicMock,
+        mock_divide: MagicMock,
+        mock_pool: MagicMock,
+        mock_write: MagicMock,
+    ) -> None:
         """Test when no test files are found."""
         mock_find.return_value = []
         with pytest.raises(RuntimeError, match="No test files found"):
-            run_parallel_tests(2, ["tests"], Path("test-logs.txt"), debug=False, ci=False)
+            run_parallel_tests(
+                2, ["tests"], Path("test-logs.txt"), debug=False, ci=False
+            )
         mock_find.assert_called_once_with(["tests"])
         mock_update.assert_not_called()
 
-    @patch('run_nf_test_parallel.write_test_log')
-    @patch('run_nf_test_parallel.multiprocessing.Pool')
-    @patch('run_nf_test_parallel.divide_test_files')
-    @patch('run_nf_test_parallel.update_plugins')
-    @patch('run_nf_test_parallel.find_test_files')
-    def test_run_parallel_tests_success(self, mock_find: MagicMock, mock_update: MagicMock, mock_divide: MagicMock, mock_pool: MagicMock, mock_write: MagicMock) -> None:
+    @patch("run_nf_test_parallel.write_test_log")
+    @patch("run_nf_test_parallel.multiprocessing.Pool")
+    @patch("run_nf_test_parallel.divide_test_files")
+    @patch("run_nf_test_parallel.update_plugins")
+    @patch("run_nf_test_parallel.find_test_files")
+    def test_run_parallel_tests_success(
+        self,
+        mock_find: MagicMock,
+        mock_update: MagicMock,
+        mock_divide: MagicMock,
+        mock_pool: MagicMock,
+        mock_write: MagicMock,
+    ) -> None:
         """Test successful parallel execution."""
         test_files = [Path("test1.nf.test"), Path("test2.nf.test")]
         mock_find.return_value = test_files
@@ -286,19 +347,28 @@ class TestRunParallelTests:
             (1, 0, "stdout1", "stderr1", "cmd1"),
             (2, 0, "stdout2", "stderr2", "cmd2"),
         ]
-        exit_code = run_parallel_tests(2, ["tests"], Path("test-logs.txt"), debug=False, ci=False)
+        exit_code = run_parallel_tests(
+            2, ["tests"], Path("test-logs.txt"), debug=False, ci=False
+        )
         assert exit_code == 0
         mock_find.assert_called_once_with(["tests"])
         mock_update.assert_called_once()
         mock_divide.assert_called_once_with(test_files, 2)
         mock_write.assert_called_once()
 
-    @patch('run_nf_test_parallel.write_test_log')
-    @patch('run_nf_test_parallel.multiprocessing.Pool')
-    @patch('run_nf_test_parallel.divide_test_files')
-    @patch('run_nf_test_parallel.update_plugins')
-    @patch('run_nf_test_parallel.find_test_files')
-    def test_run_parallel_tests_with_failures(self, mock_find: MagicMock, mock_update: MagicMock, mock_divide: MagicMock, mock_pool: MagicMock, mock_write: MagicMock) -> None:
+    @patch("run_nf_test_parallel.write_test_log")
+    @patch("run_nf_test_parallel.multiprocessing.Pool")
+    @patch("run_nf_test_parallel.divide_test_files")
+    @patch("run_nf_test_parallel.update_plugins")
+    @patch("run_nf_test_parallel.find_test_files")
+    def test_run_parallel_tests_with_failures(
+        self,
+        mock_find: MagicMock,
+        mock_update: MagicMock,
+        mock_divide: MagicMock,
+        mock_pool: MagicMock,
+        mock_write: MagicMock,
+    ) -> None:
         """Test parallel execution with some worker failures."""
         test_files = [Path("test1.nf.test"), Path("test2.nf.test")]
         mock_find.return_value = test_files
@@ -309,16 +379,25 @@ class TestRunParallelTests:
             (1, 0, "stdout1", "stderr1", "cmd1"),
             (2, 1, "stdout2", "stderr2", "cmd2"),
         ]
-        exit_code = run_parallel_tests(2, ["tests"], Path("test-logs.txt"), debug=False, ci=False)
+        exit_code = run_parallel_tests(
+            2, ["tests"], Path("test-logs.txt"), debug=False, ci=False
+        )
         assert exit_code == 1
         mock_write.assert_called_once()
 
-    @patch('run_nf_test_parallel.write_test_log')
-    @patch('run_nf_test_parallel.multiprocessing.Pool')
-    @patch('run_nf_test_parallel.divide_test_files')
-    @patch('run_nf_test_parallel.update_plugins')
-    @patch('run_nf_test_parallel.find_test_files')
-    def test_run_parallel_tests_adjusts_workers(self, mock_find: MagicMock, mock_update: MagicMock, mock_divide: MagicMock, mock_pool: MagicMock, mock_write: MagicMock) -> None:
+    @patch("run_nf_test_parallel.write_test_log")
+    @patch("run_nf_test_parallel.multiprocessing.Pool")
+    @patch("run_nf_test_parallel.divide_test_files")
+    @patch("run_nf_test_parallel.update_plugins")
+    @patch("run_nf_test_parallel.find_test_files")
+    def test_run_parallel_tests_adjusts_workers(
+        self,
+        mock_find: MagicMock,
+        mock_update: MagicMock,
+        mock_divide: MagicMock,
+        mock_pool: MagicMock,
+        mock_write: MagicMock,
+    ) -> None:
         """Test that number of workers is reduced when it exceeds number of test files."""
         test_files = [Path("test1.nf.test"), Path("test2.nf.test")]
         mock_find.return_value = test_files
@@ -329,16 +408,25 @@ class TestRunParallelTests:
             (1, 0, "stdout1", "stderr1", "cmd1"),
             (2, 0, "stdout2", "stderr2", "cmd2"),
         ]
-        exit_code = run_parallel_tests(5, ["tests"], Path("test-logs.txt"), debug=False, ci=False)
+        exit_code = run_parallel_tests(
+            5, ["tests"], Path("test-logs.txt"), debug=False, ci=False
+        )
         assert exit_code == 0
         mock_divide.assert_called_once_with(test_files, 2)
 
-    @patch('run_nf_test_parallel.write_test_log')
-    @patch('run_nf_test_parallel.multiprocessing.Pool')
-    @patch('run_nf_test_parallel.divide_test_files')
-    @patch('run_nf_test_parallel.update_plugins')
-    @patch('run_nf_test_parallel.find_test_files')
-    def test_run_parallel_tests_passes_ci_flag(self, mock_find: MagicMock, mock_update: MagicMock, mock_divide: MagicMock, mock_pool: MagicMock, mock_write: MagicMock) -> None:
+    @patch("run_nf_test_parallel.write_test_log")
+    @patch("run_nf_test_parallel.multiprocessing.Pool")
+    @patch("run_nf_test_parallel.divide_test_files")
+    @patch("run_nf_test_parallel.update_plugins")
+    @patch("run_nf_test_parallel.find_test_files")
+    def test_run_parallel_tests_passes_ci_flag(
+        self,
+        mock_find: MagicMock,
+        mock_update: MagicMock,
+        mock_divide: MagicMock,
+        mock_pool: MagicMock,
+        mock_write: MagicMock,
+    ) -> None:
         """Test that CI flag is passed through to workers."""
         test_files = [Path("test1.nf.test"), Path("test2.nf.test")]
         mock_find.return_value = test_files
@@ -349,7 +437,9 @@ class TestRunParallelTests:
             (1, 0, "stdout1", "stderr1", "cmd1"),
             (2, 0, "stdout2", "stderr2", "cmd2"),
         ]
-        exit_code = run_parallel_tests(2, ["tests"], Path("test-logs.txt"), debug=False, ci=True)
+        exit_code = run_parallel_tests(
+            2, ["tests"], Path("test-logs.txt"), debug=False, ci=True
+        )
         assert exit_code == 0
         # Verify starmap was called with worker args that include ci=True
         starmap_call_args = mock_pool_instance.starmap.call_args[0]

--- a/bin/test_run_nf_test_parallel.py
+++ b/bin/test_run_nf_test_parallel.py
@@ -5,25 +5,25 @@ Unit tests for run-nf-test-parallel.py
 Run with: pytest bin/test_run-nf-test-parallel.py
 """
 
-import pytest
-from pathlib import Path
-from unittest.mock import patch, MagicMock
 import subprocess
 
 # Import functions from the script
 import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).parent))
 from run_nf_test_parallel import (
-    find_test_files,
     divide_test_files,
-    extract_failures_from_output,
-    strip_ansi_codes,
     execute_subprocess,
+    extract_failures_from_output,
+    find_test_files,
     run_nf_test_worker,
-    update_plugins,
     run_parallel_tests,
-    write_test_log,
+    strip_ansi_codes,
+    update_plugins,
 )
 
 

--- a/bin/test_validate_schemas.py
+++ b/bin/test_validate_schemas.py
@@ -239,9 +239,11 @@ class TestReorderedToSchema:
         schema_path = self._make_schema(tmp_path, ["a", "b", "c"], "equal")
         data_file = tmp_path / "test.tsv"
         data_file.write_text("a\tb\ta\n1\t2\t3\n")
-        with pytest.raises(ValueError, match="Duplicate columns"):
-            with reordered_to_schema(data_file, schema_path):
-                pass
+        with (
+            pytest.raises(ValueError, match="Duplicate columns"),
+            reordered_to_schema(data_file, schema_path),
+        ):
+            pass
 
 
 #######################

--- a/bin/test_validate_schemas.py
+++ b/bin/test_validate_schemas.py
@@ -22,6 +22,7 @@ from validate_schemas import (
 # get_output_schema_names  #
 ############################
 
+
 class TestGetOutputSchemaNames:
     def test_extracts_schema_names_from_pyproject(self, tmp_path: Path) -> None:
         pyproject = tmp_path / "pyproject.toml"
@@ -59,9 +60,11 @@ some-other-key = "value"
         result = get_output_schema_names(pyproject)
         assert result == set()
 
+
 #########################
 # find_schema_for_file  #
 #########################
+
 
 class TestFindSchemaForFile:
     def test_returns_path_when_schema_exists(self, tmp_path: Path) -> None:
@@ -102,9 +105,11 @@ class TestFindSchemaForFile:
         result = find_schema_for_file(data_file, schema_dir, known_schema_names)
         assert result == schema_file
 
+
 ####################
 # find_data_files  #
 ####################
+
 
 class TestFindDataFiles:
     def test_finds_files_in_results_dirs(self, tmp_path: Path) -> None:
@@ -132,9 +137,11 @@ class TestFindDataFiles:
         files = find_data_files(tmp_path)
         assert files == []
 
+
 #####################
 # decompressed_path #
 #####################
+
 
 class TestDecompressedPath:
     def test_yields_original_path_for_uncompressed(self, tmp_path: Path) -> None:
@@ -153,9 +160,11 @@ class TestDecompressedPath:
             assert path != data_file
             assert path.read_text() == content
 
+
 ########################
 # reordered_to_schema  #
 ########################
+
 
 class TestReorderedToSchema:
     def _make_schema(
@@ -189,7 +198,11 @@ class TestReorderedToSchema:
         ],
     )
     def test_no_reorder(
-        self, tmp_path: Path, fields: list[str], fields_match: str | None, data: str,
+        self,
+        tmp_path: Path,
+        fields: list[str],
+        fields_match: str | None,
+        data: str,
     ) -> None:
         schema_path = self._make_schema(tmp_path, fields, fields_match)
         data_file = tmp_path / "test.tsv"
@@ -210,7 +223,11 @@ class TestReorderedToSchema:
         ids=["basic", "quote_characters"],
     )
     def test_reorders(
-        self, tmp_path: Path, fields: list[str], data: str, expected: str,
+        self,
+        tmp_path: Path,
+        fields: list[str],
+        data: str,
+        expected: str,
     ) -> None:
         schema_path = self._make_schema(tmp_path, fields, "equal")
         data_file = tmp_path / "test.tsv"
@@ -227,9 +244,11 @@ class TestReorderedToSchema:
             with reordered_to_schema(data_file, schema_path) as path:
                 pass
 
+
 #######################
 # validate_json_file  #
 #######################
+
 
 class TestValidateJsonFile:
     SCHEMA_WITH_REQUIRED = {
@@ -243,13 +262,19 @@ class TestValidateJsonFile:
         "type": "object",
     }
 
-    @pytest.mark.parametrize("schema,data,should_pass", [
-        (SCHEMA_WITH_REQUIRED, {"name": "hello"}, True),
-        (SCHEMA_WITH_REQUIRED, {}, False),
-        (SCHEMA_WITH_REQUIRED, {"name": "hello", "count": "not_an_int"}, False),
-        (PERMISSIVE_SCHEMA, {}, True),
-    ], ids=["valid", "missing_required", "wrong_type", "empty_object_permissive"])
-    def test_validates_json(self, tmp_path: Path, schema: dict, data: dict, should_pass: bool) -> None:
+    @pytest.mark.parametrize(
+        "schema,data,should_pass",
+        [
+            (SCHEMA_WITH_REQUIRED, {"name": "hello"}, True),
+            (SCHEMA_WITH_REQUIRED, {}, False),
+            (SCHEMA_WITH_REQUIRED, {"name": "hello", "count": "not_an_int"}, False),
+            (PERMISSIVE_SCHEMA, {}, True),
+        ],
+        ids=["valid", "missing_required", "wrong_type", "empty_object_permissive"],
+    )
+    def test_validates_json(
+        self, tmp_path: Path, schema: dict, data: dict, should_pass: bool
+    ) -> None:
         data_file = tmp_path / "test.json"
         data_file.write_text(json.dumps(data))
         is_valid, errors = validate_json_file(data_file, schema)
@@ -287,9 +312,11 @@ class TestValidateJsonFile:
         assert len(errors) == 1
         assert "Invalid schema" in errors[0]
 
+
 #################
 # validate_file #
 #################
+
 
 class TestValidateFile:
     @pytest.fixture
@@ -320,14 +347,18 @@ class TestValidateFile:
         assert is_valid
         assert errors == []
 
-    def test_invalid_type_returns_errors(self, tmp_path: Path, simple_schema: Path) -> None:
+    def test_invalid_type_returns_errors(
+        self, tmp_path: Path, simple_schema: Path
+    ) -> None:
         data_file = tmp_path / "test.tsv"
         data_file.write_text("col1\tcol2\nfoo\tnot_an_int\n")
         is_valid, errors = validate_file(data_file, simple_schema)
         assert not is_valid
         assert len(errors) > 0
 
-    def test_empty_data_file_is_valid(self, tmp_path: Path, simple_schema: Path) -> None:
+    def test_empty_data_file_is_valid(
+        self, tmp_path: Path, simple_schema: Path
+    ) -> None:
         """Header-only files should validate successfully."""
         data_file = tmp_path / "test.tsv"
         data_file.write_text("col1\tcol2\n")
@@ -346,19 +377,37 @@ class TestValidateFile:
             ),
             # Pattern constraint - invalid
             (
-                [{"name": "id", "type": "string", "constraints": {"pattern": "^[^/]+(/[^/]+)?$"}}],
+                [
+                    {
+                        "name": "id",
+                        "type": "string",
+                        "constraints": {"pattern": "^[^/]+(/[^/]+)?$"},
+                    }
+                ],
                 "id\nfoo/bar/baz\n",
                 False,
             ),
             # Pattern constraint - valid
             (
-                [{"name": "id", "type": "string", "constraints": {"pattern": "^[^/]+(/[^/]+)?$"}}],
+                [
+                    {
+                        "name": "id",
+                        "type": "string",
+                        "constraints": {"pattern": "^[^/]+(/[^/]+)?$"},
+                    }
+                ],
                 "id\nNC_001234.1\nAB/CD\n",
                 True,
             ),
             # Enum constraint - invalid
             (
-                [{"name": "status", "type": "string", "constraints": {"enum": ["pass", "fail"]}}],
+                [
+                    {
+                        "name": "status",
+                        "type": "string",
+                        "constraints": {"enum": ["pass", "fail"]},
+                    }
+                ],
                 "status\nunknown\n",
                 False,
             ),
@@ -375,7 +424,14 @@ class TestValidateFile:
                 False,
             ),
         ],
-        ids=["required", "pattern_invalid", "pattern_valid", "enum", "minimum", "maximum"],
+        ids=[
+            "required",
+            "pattern_invalid",
+            "pattern_valid",
+            "enum",
+            "minimum",
+            "maximum",
+        ],
     )
     def test_constraint_validation(
         self, tmp_path: Path, schema_fields: list, data: str, should_pass: bool
@@ -429,19 +485,29 @@ class TestValidateFile:
         assert is_valid
         assert errors == []
 
-    def test_multiple_errors_all_reported(self, tmp_path: Path, simple_schema: Path) -> None:
+    def test_multiple_errors_all_reported(
+        self, tmp_path: Path, simple_schema: Path
+    ) -> None:
         """Multiple validation errors should all be reported."""
         data_file = tmp_path / "test.tsv"
-        data_file.write_text("col1\tcol2\nfoo\tnot_int_1\nbar\tnot_int_2\nbaz\tnot_int_3\n")
+        data_file.write_text(
+            "col1\tcol2\nfoo\tnot_int_1\nbar\tnot_int_2\nbaz\tnot_int_3\n"
+        )
         is_valid, errors = validate_file(data_file, simple_schema)
         assert not is_valid
         assert len(errors) >= 3
 
-    @pytest.mark.parametrize("data,should_pass", [
-        ({"name": "hello"}, True),
-        ({}, False),
-    ], ids=["valid_json", "invalid_json"])
-    def test_json_schema_dispatch(self, tmp_path: Path, data: dict, should_pass: bool) -> None:
+    @pytest.mark.parametrize(
+        "data,should_pass",
+        [
+            ({"name": "hello"}, True),
+            ({}, False),
+        ],
+        ids=["valid_json", "invalid_json"],
+    )
+    def test_json_schema_dispatch(
+        self, tmp_path: Path, data: dict, should_pass: bool
+    ) -> None:
         """validate_file dispatches to JSON Schema validation for JSON Schemas."""
         schema = {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -458,9 +524,11 @@ class TestValidateFile:
         if not should_pass:
             assert len(errors) > 0
 
+
 ####################
 # validate_outputs #
 ####################
+
 
 class TestValidateOutputs:
     @pytest.fixture
@@ -506,7 +574,9 @@ expected-outputs-downstream = [
         exit_code = validate_outputs(output_dir, schema_dir, pyproject)
         assert exit_code == 1
 
-    def test_success_when_no_matching_schemas(self, tmp_path: Path, pyproject: Path) -> None:
+    def test_success_when_no_matching_schemas(
+        self, tmp_path: Path, pyproject: Path
+    ) -> None:
         schema_dir = tmp_path / "schemas"
         schema_dir.mkdir()
         output_dir = tmp_path / "output"
@@ -517,14 +587,18 @@ expected-outputs-downstream = [
         exit_code = validate_outputs(output_dir, schema_dir, pyproject)
         assert exit_code == 0
 
-    def test_failure_when_output_dir_missing(self, tmp_path: Path, pyproject: Path) -> None:
+    def test_failure_when_output_dir_missing(
+        self, tmp_path: Path, pyproject: Path
+    ) -> None:
         schema_dir = tmp_path / "schemas"
         schema_dir.mkdir()
         output_dir = tmp_path / "nonexistent"
         exit_code = validate_outputs(output_dir, schema_dir, pyproject)
         assert exit_code == 1
 
-    def test_failure_when_schema_dir_missing(self, tmp_path: Path, pyproject: Path) -> None:
+    def test_failure_when_schema_dir_missing(
+        self, tmp_path: Path, pyproject: Path
+    ) -> None:
         output_dir = tmp_path / "output"
         output_dir.mkdir()
         schema_dir = tmp_path / "nonexistent"
@@ -540,12 +614,31 @@ expected-outputs-downstream = [
         exit_code = validate_outputs(output_dir, schema_dir, pyproject)
         assert exit_code == 1
 
-    @pytest.mark.parametrize("schema,expected_exit", [
-        ({"$schema": "https://json-schema.org/draft/2020-12/schema", "type": "object"}, 0),
-        ({"$schema": "https://json-schema.org/draft/2020-12/schema", "type": "object",
-          "properties": {"name": {"type": "string"}}, "required": ["name"]}, 1),
-    ], ids=["valid_json", "invalid_json"])
-    def test_json_validation(self, tmp_path: Path, schema: dict, expected_exit: int) -> None:
+    @pytest.mark.parametrize(
+        "schema,expected_exit",
+        [
+            (
+                {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "type": "object",
+                },
+                0,
+            ),
+            (
+                {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                    "required": ["name"],
+                },
+                1,
+            ),
+        ],
+        ids=["valid_json", "invalid_json"],
+    )
+    def test_json_validation(
+        self, tmp_path: Path, schema: dict, expected_exit: int
+    ) -> None:
         """JSON files are validated against JSON Schemas."""
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text("""
@@ -570,12 +663,19 @@ expected-outputs-downstream = [
 # TestFastpSchemaIntegration  #
 ###############################
 
+
 class TestFastpSchemaIntegration:
     def test_real_fastp_schema_integration(self) -> None:
         """Integration test: validate real test data against the fastp schema."""
         repo_root = Path(__file__).resolve().parent.parent
         schema_path = repo_root / "schemas" / "fastp.schema.json"
-        data_path = repo_root / "test-data" / "results" / "downstream_output_shortread" / "tt1_fastp.json"
+        data_path = (
+            repo_root
+            / "test-data"
+            / "results"
+            / "downstream_output_shortread"
+            / "tt1_fastp.json"
+        )
         is_valid, errors = validate_file(data_path, schema_path)
         assert is_valid, f"Validation errors: {errors}"
 
@@ -589,11 +689,16 @@ class TestFastpSchemaIntegration:
 
         repo_root = Path(__file__).resolve().parent.parent
         schema_path = repo_root / "schemas" / "fastp.schema.json"
-        fixture_path = repo_root / "test-data" / "downstream" / "empty" / "empty_sample_fastp.json"
+        fixture_path = (
+            repo_root / "test-data" / "downstream" / "empty" / "empty_sample_fastp.json"
+        )
         with open(schema_path) as f:
             full_schema = json.load(f)
         # Extract sample_entry and inject $defs so $ref resolution works
-        sample_entry_schema = {**full_schema["$defs"]["sample_entry"], "$defs": full_schema["$defs"]}
+        sample_entry_schema = {
+            **full_schema["$defs"]["sample_entry"],
+            "$defs": full_schema["$defs"],
+        }
         with open(fixture_path) as f:
             fixture_data = json.load(f)
         # The fixture is a per-sample file; add pipeline-injected fields
@@ -601,5 +706,9 @@ class TestFastpSchemaIntegration:
         fixture_data["group"] = "empty_group"
         validator_cls = validator_for(full_schema)
         validator = validator_cls(sample_entry_schema)
-        errors = sorted(validator.iter_errors(fixture_data), key=lambda e: list(e.absolute_path))
-        assert not errors, f"Fixture fails sample_entry validation: {[e.message for e in errors]}"
+        errors = sorted(
+            validator.iter_errors(fixture_data), key=lambda e: list(e.absolute_path)
+        )
+        assert not errors, (
+            f"Fixture fails sample_entry validation: {[e.message for e in errors]}"
+        )

--- a/bin/test_validate_schemas.py
+++ b/bin/test_validate_schemas.py
@@ -6,7 +6,6 @@ import json
 from pathlib import Path
 
 import pytest
-
 from validate_schemas import (
     decompressed_path,
     find_data_files,

--- a/bin/test_validate_schemas.py
+++ b/bin/test_validate_schemas.py
@@ -240,7 +240,7 @@ class TestReorderedToSchema:
         data_file = tmp_path / "test.tsv"
         data_file.write_text("a\tb\ta\n1\t2\t3\n")
         with pytest.raises(ValueError, match="Duplicate columns"):
-            with reordered_to_schema(data_file, schema_path) as path:
+            with reordered_to_schema(data_file, schema_path):
                 pass
 
 

--- a/bin/test_validate_test_data_sync.py
+++ b/bin/test_validate_test_data_sync.py
@@ -11,6 +11,7 @@ from validate_test_data_sync import (
     validate_snapshot,
 )
 
+
 def make_snapshot(content_map: dict[str, list[str]]) -> dict:
     """Helper to create snapshot structure from {name: [entries]} mapping."""
     return {
@@ -18,9 +19,11 @@ def make_snapshot(content_map: dict[str, list[str]]) -> dict:
         for name, entries in content_map.items()
     }
 
+
 ##################
 # parse_snapshot #
 ##################
+
 
 class TestParseSnapshot:
     @pytest.mark.parametrize(
@@ -44,7 +47,11 @@ class TestParseSnapshot:
             ),
             # Entries without :md5, are ignored
             (
-                ["file1.tsv.gz:md5,abc123", "not_an_md5_entry", "another:entry:without:md5"],
+                [
+                    "file1.tsv.gz:md5,abc123",
+                    "not_an_md5_entry",
+                    "another:entry:without:md5",
+                ],
                 {"file1.tsv": "abc123"},
             ),
             # Empty content
@@ -53,7 +60,10 @@ class TestParseSnapshot:
         ids=["single", "multiple", "extensions", "ignore_non_md5", "empty"],
     )
     def test_parses_content_entries(
-        self, tmp_path: Path, content_entries: list[str], expected_md5_map: dict[str, str]
+        self,
+        tmp_path: Path,
+        content_entries: list[str],
+        expected_md5_map: dict[str, str],
     ) -> None:
         snapshot = make_snapshot({"test_output": content_entries})
         snapshot_path = tmp_path / "test.snap"
@@ -63,10 +73,12 @@ class TestParseSnapshot:
 
     def test_parses_multiple_snapshot_names(self, tmp_path: Path) -> None:
         """Parametrized cases above use a single snapshot name; verify multiple names in one file."""
-        snapshot = make_snapshot({
-            "snapshot_one": ["file1.tsv.gz:md5,aaa111"],
-            "snapshot_two": ["file2.tsv.gz:md5,bbb222"],
-        })
+        snapshot = make_snapshot(
+            {
+                "snapshot_one": ["file1.tsv.gz:md5,aaa111"],
+                "snapshot_two": ["file2.tsv.gz:md5,bbb222"],
+            }
+        )
         snapshot_path = tmp_path / "test.snap"
         snapshot_path.write_text(json.dumps(snapshot))
         result = parse_snapshot(snapshot_path)
@@ -82,9 +94,11 @@ class TestParseSnapshot:
         result = parse_snapshot(snapshot_path)
         assert result == {"test_output": {}}
 
+
 ###############
 # compute_md5 #
 ###############
+
 
 class TestComputeMd5:
     @pytest.mark.parametrize(
@@ -101,6 +115,7 @@ class TestComputeMd5:
         test_file.write_bytes(content)
         expected_md5 = hashlib.md5(content).hexdigest()
         assert compute_md5(test_file) == expected_md5
+
 
 #####################
 # validate_snapshot #

--- a/bin/test_validate_test_data_sync.py
+++ b/bin/test_validate_test_data_sync.py
@@ -4,6 +4,7 @@
 import hashlib
 import json
 from pathlib import Path
+
 import pytest
 from validate_test_data_sync import (
     compute_md5,

--- a/bin/validate_schemas.py
+++ b/bin/validate_schemas.py
@@ -40,6 +40,7 @@ from jsonschema.validators import validator_for
 # LOGGING #
 ###########
 
+
 class UTCFormatter(logging.Formatter):
     """Custom logging formatter that displays timestamps in UTC."""
 
@@ -47,6 +48,7 @@ class UTCFormatter(logging.Formatter):
         """Format log timestamps in UTC timezone."""
         dt = datetime.fromtimestamp(record.created, timezone.utc)
         return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger()
@@ -59,6 +61,7 @@ logger.addHandler(handler)
 ####################
 # HELPER FUNCTIONS #
 ####################
+
 
 def get_output_schema_names(pyproject_path: Path) -> set[str]:
     """
@@ -90,6 +93,7 @@ def get_output_schema_names(pyproject_path: Path) -> set[str]:
             schema_names.add(p.name)
     return schema_names
 
+
 def find_schema_for_file(
     data_file: Path,
     schema_dir: Path,
@@ -118,6 +122,7 @@ def find_schema_for_file(
                 return schema_path
     return None
 
+
 def find_data_files(output_dir: Path) -> list[Path]:
     """
     Find all files in results*/ subdirectories of the output directory.
@@ -131,6 +136,7 @@ def find_data_files(output_dir: Path) -> list[Path]:
         if results_dir.is_dir():
             files.extend(f for f in results_dir.iterdir() if f.is_file())
     return sorted(files)
+
 
 @contextmanager
 def decompressed_path(data_file: Path) -> Generator[Path, None, None]:
@@ -151,6 +157,7 @@ def decompressed_path(data_file: Path) -> Generator[Path, None, None]:
             shutil.copyfileobj(f_in, tmp)
         tmp.flush()
         yield Path(tmp.name)
+
 
 @contextmanager
 def reordered_to_schema(
@@ -176,10 +183,11 @@ def reordered_to_schema(
             data_fields = header_line.split("\t")
             if len(data_fields) != len(set(data_fields)):
                 dupes = [f for f in data_fields if data_fields.count(f) > 1]
-                raise ValueError(f"Duplicate columns in data file: {sorted(set(dupes))}")
-            needs_reorder = (
-                data_fields != schema_fields
-                and set(data_fields) == set(schema_fields)
+                raise ValueError(
+                    f"Duplicate columns in data file: {sorted(set(dupes))}"
+                )
+            needs_reorder = data_fields != schema_fields and set(data_fields) == set(
+                schema_fields
             )
     if not needs_reorder:
         yield data_path
@@ -187,7 +195,10 @@ def reordered_to_schema(
     with tempfile.NamedTemporaryFile(mode="w", suffix=".tsv", delete=True) as tmp:
         with open(data_path) as f:
             reader = csv.DictReader(
-                f, delimiter="\t", quoting=csv.QUOTE_NONE, quotechar=None,
+                f,
+                delimiter="\t",
+                quoting=csv.QUOTE_NONE,
+                quotechar=None,
             )
             tmp.write("\t".join(schema_fields) + "\n")
             for row in reader:
@@ -195,9 +206,11 @@ def reordered_to_schema(
         tmp.flush()
         yield Path(tmp.name)
 
+
 def _is_json_schema(schema: dict) -> bool:
     """Check whether a loaded schema dict is a JSON Schema (vs a table-schema)."""
     return "json-schema.org" in schema.get("$schema", "")
+
 
 def validate_json_file(data_file: Path, schema: dict) -> tuple[bool, list[str]]:
     """
@@ -226,9 +239,14 @@ def validate_json_file(data_file: Path, schema: dict) -> tuple[bool, list[str]]:
         return True, []
     messages = []
     for error in errors:
-        path = ".".join(str(p) for p in error.absolute_path) if error.absolute_path else "(root)"
+        path = (
+            ".".join(str(p) for p in error.absolute_path)
+            if error.absolute_path
+            else "(root)"
+        )
         messages.append(f"[{path}] {error.message}")
     return False, messages
+
 
 def validate_file(data_file: Path, schema_path: Path) -> tuple[bool, list[str]]:
     """
@@ -275,9 +293,11 @@ def validate_file(data_file: Path, schema_path: Path) -> tuple[bool, list[str]]:
                 errors.append(error.message)
     return False, errors
 
+
 ##############
 # MAIN LOGIC #
 ##############
+
 
 def validate_outputs(
     output_dir: Path,
@@ -341,6 +361,7 @@ def validate_outputs(
         logger.error("Some validations failed.")
         return 1
 
+
 def parse_arguments() -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(
@@ -348,24 +369,28 @@ def parse_arguments() -> argparse.Namespace:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
-        "-o", "--output-dir",
+        "-o",
+        "--output-dir",
         type=Path,
         help="Base output directory containing results*/ subdirectories",
         required=True,
     )
     parser.add_argument(
-        "-s", "--schema-dir",
+        "-s",
+        "--schema-dir",
         type=Path,
         default=Path(__file__).resolve().parent.parent / "schemas",
         help="Directory containing schema files (default: <repo>/schemas)",
     )
     parser.add_argument(
-        "-p", "--pyproject",
+        "-p",
+        "--pyproject",
         type=Path,
         default=Path(__file__).resolve().parent.parent / "pyproject.toml",
         help="Path to pyproject.toml for schema name lookup (default: <repo>/pyproject.toml)",
     )
     return parser.parse_args()
+
 
 def main() -> None:
     """Main entry point."""
@@ -377,6 +402,7 @@ def main() -> None:
     end_time = time.time()
     logger.info(f"Total time elapsed: {end_time - start_time:.2f} seconds")
     sys.exit(exit_code)
+
 
 if __name__ == "__main__":
     main()

--- a/bin/validate_schemas.py
+++ b/bin/validate_schemas.py
@@ -29,7 +29,7 @@ import time
 import tomllib
 from collections.abc import Generator
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 from frictionless import Dialect, Resource, formats, system, validate
@@ -46,7 +46,7 @@ class UTCFormatter(logging.Formatter):
 
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
         """Format log timestamps in UTC timezone."""
-        dt = datetime.fromtimestamp(record.created, timezone.utc)
+        dt = datetime.fromtimestamp(record.created, UTC)
         return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
@@ -357,9 +357,8 @@ def validate_outputs(
     if all_passed:
         logger.info("All validations passed.")
         return 0
-    else:
-        logger.error("Some validations failed.")
-        return 1
+    logger.error("Some validations failed.")
+    return 1
 
 
 def parse_arguments() -> argparse.Namespace:

--- a/bin/validate_schemas.py
+++ b/bin/validate_schemas.py
@@ -266,16 +266,18 @@ def validate_file(data_file: Path, schema_path: Path) -> tuple[bool, list[str]]:
         return validate_json_file(data_file, schema)
     # Table-schema path: reordered_to_schema and frictionless expect a file path,
     # so the schema is re-read from disk by those functions (intentional).
-    with decompressed_path(data_file) as uncompressed:
-        with reordered_to_schema(uncompressed, schema_path) as file_to_validate:
-            dialect = Dialect(controls=[formats.CsvControl(delimiter="\t")])
-            resource = Resource(
-                path=str(file_to_validate),
-                schema=str(schema_path),
-                dialect=dialect,
-            )
-            with system.use_context(trusted=True):
-                report = validate(resource)
+    with (
+        decompressed_path(data_file) as uncompressed,
+        reordered_to_schema(uncompressed, schema_path) as file_to_validate,
+    ):
+        dialect = Dialect(controls=[formats.CsvControl(delimiter="\t")])
+        resource = Resource(
+            path=str(file_to_validate),
+            schema=str(schema_path),
+            dialect=dialect,
+        )
+        with system.use_context(trusted=True):
+            report = validate(resource)
     if report.valid:
         return True, []
     errors = []

--- a/bin/validate_test_data_sync.py
+++ b/bin/validate_test_data_sync.py
@@ -22,12 +22,15 @@ import time
 # LOGGING #
 ###########
 
+
 class UTCFormatter(logging.Formatter):
     """Custom logging formatter that displays timestamps in UTC."""
+
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
         """Format log timestamps in UTC timezone."""
         dt = datetime.fromtimestamp(record.created, timezone.utc)
         return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger()
@@ -40,6 +43,7 @@ logger.addHandler(handler)
 ####################
 # HELPER FUNCTIONS #
 ####################
+
 
 def parse_snapshot(snapshot_path: Path) -> dict[str, dict[str, str]]:
     """
@@ -67,6 +71,7 @@ def parse_snapshot(snapshot_path: Path) -> dict[str, dict[str, str]]:
         results[snapshot_name] = md5_map
     return results
 
+
 def compute_md5(file_path: Path) -> str:
     """
     Compute MD5 hash of a file.
@@ -80,6 +85,7 @@ def compute_md5(file_path: Path) -> str:
         for chunk in iter(lambda: f.read(8192), b""):
             md5_hash.update(chunk)
     return md5_hash.hexdigest()
+
 
 def validate_snapshot(
     snapshot_path: Path,
@@ -110,12 +116,15 @@ def validate_snapshot(
             else:
                 actual_md5 = compute_md5(file_path)
                 if actual_md5 != expected_md5:
-                    errors.append(f"MD5 mismatch for {file_path}: {actual_md5} (actual) != {expected_md5} (expected)")
+                    errors.append(
+                        f"MD5 mismatch for {file_path}: {actual_md5} (actual) != {expected_md5} (expected)"
+                    )
         if errors:
             logger.error(f"Errors found for {snapshot_name}:")
             for error in errors:
                 logger.error(f"  {error}")
             raise ValueError(f"Errors found for {snapshot_name}")
+
 
 def parse_arguments() -> argparse.Namespace:
     """
@@ -141,9 +150,11 @@ def parse_arguments() -> argparse.Namespace:
     )
     return parser.parse_args()
 
+
 #################
 # MAIN FUNCTION #
 #################
+
 
 def main() -> None:
     """Main entry point for the script."""
@@ -155,6 +166,7 @@ def main() -> None:
     validate_snapshot(args.snapshot, args.results_dir)
     end_time = time.time()
     logger.info(f"Script completed successfully in {end_time - start_time} seconds.")
+
 
 if __name__ == "__main__":
     main()

--- a/bin/validate_test_data_sync.py
+++ b/bin/validate_test_data_sync.py
@@ -14,9 +14,9 @@ import argparse
 import hashlib
 import json
 import logging
-from datetime import datetime, timezone
-from pathlib import Path
 import time
+from datetime import UTC, datetime
+from pathlib import Path
 
 ###########
 # LOGGING #
@@ -28,7 +28,7 @@ class UTCFormatter(logging.Formatter):
 
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
         """Format log timestamps in UTC timezone."""
-        dt = datetime.fromtimestamp(record.created, timezone.utc)
+        dt = datetime.fromtimestamp(record.created, UTC)
         return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
@@ -54,7 +54,7 @@ def parse_snapshot(snapshot_path: Path) -> dict[str, dict[str, str]]:
         dict[str, dict[str, str]]: Dictionary mapping snapshot names to {filename: md5} dictionaries
     """
     results: dict[str, dict[str, str]] = {}
-    with open(snapshot_path, "r") as f:
+    with open(snapshot_path) as f:
         snapshot = json.load(f)
     for snapshot_name, snapshot_data in snapshot.items():
         content = snapshot_data.get("content", [])

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -138,6 +138,7 @@ You can run Python tools directly without installing them first:
 ```bash
 uv run pytest           # Run tests
 uv run ruff check .     # Lint code
+uv run ruff format .    # Auto-format code
 uv run mypy .           # Type checking
 ```
 
@@ -145,8 +146,9 @@ Alternatively, you can sync the environment once and then use the tools directly
 ```bash
 uv sync                 # Install all dependencies from pyproject.toml
 source .venv/bin/activate
-pytest                  
+pytest
 ruff check .
+ruff format .
 mypy .
 ```
 

--- a/modules/local/addConditionalTsvColumn/resources/usr/bin/add_conditional_tsv_column.py
+++ b/modules/local/addConditionalTsvColumn/resources/usr/bin/add_conditional_tsv_column.py
@@ -2,11 +2,11 @@
 
 import argparse
 import csv
-import time
 import datetime
 import gzip
-from typing import IO, Iterator, cast
-from collections.abc import Sequence
+import time
+from collections.abc import Iterator, Sequence
+from typing import IO, cast
 
 
 def print_log(message: str) -> None:
@@ -21,8 +21,7 @@ def open_by_suffix(filename: str, mode: str = "r", debug: bool = False) -> IO[st
         print_log(f"\tGZIP mode: {filename.endswith('.gz')}")
     if filename.endswith(".gz"):
         return cast(IO[str], gzip.open(filename, mode + "t", encoding="utf-8"))
-    else:
-        return open(filename, mode, encoding="utf-8")
+    return open(filename, mode, encoding="utf-8")
 
 
 def validate_columns(

--- a/modules/local/addConditionalTsvColumn/resources/usr/bin/add_conditional_tsv_column.py
+++ b/modules/local/addConditionalTsvColumn/resources/usr/bin/add_conditional_tsv_column.py
@@ -8,8 +8,10 @@ import gzip
 from typing import IO, Iterator, cast
 from collections.abc import Sequence
 
+
 def print_log(message: str) -> None:
     print("[", datetime.datetime.now(), "]  ", message, sep="")
+
 
 def open_by_suffix(filename: str, mode: str = "r", debug: bool = False) -> IO[str]:
     """Open file with automatic decompression based on file extension."""
@@ -17,12 +19,15 @@ def open_by_suffix(filename: str, mode: str = "r", debug: bool = False) -> IO[st
         print_log(f"\tOpening file object: {filename}")
         print_log(f"\tOpening mode: {mode}")
         print_log(f"\tGZIP mode: {filename.endswith('.gz')}")
-    if filename.endswith('.gz'):
-        return cast(IO[str], gzip.open(filename, mode + 't', encoding='utf-8'))
+    if filename.endswith(".gz"):
+        return cast(IO[str], gzip.open(filename, mode + "t", encoding="utf-8"))
     else:
-        return open(filename, mode, encoding='utf-8')
+        return open(filename, mode, encoding="utf-8")
 
-def validate_columns(fieldnames: Sequence[str], chk_col: str, if_col: str, else_col: str) -> None:
+
+def validate_columns(
+    fieldnames: Sequence[str], chk_col: str, if_col: str, else_col: str
+) -> None:
     """Validate that all required columns exist in the header."""
     missing_cols = []
     if chk_col not in fieldnames:
@@ -39,18 +44,35 @@ def validate_columns(fieldnames: Sequence[str], chk_col: str, if_col: str, else_
             f" Available columns: {', '.join(fieldnames)}"
         )
 
-def process_rows(reader: csv.DictReader[str], chk_col: str, match_val: str, if_col: str, else_col: str, new_hdr: str) -> Iterator[dict[str, str]]:
+
+def process_rows(
+    reader: csv.DictReader[str],
+    chk_col: str,
+    match_val: str,
+    if_col: str,
+    else_col: str,
+    new_hdr: str,
+) -> Iterator[dict[str, str]]:
     """Generator that processes rows and adds conditional column value."""
     for row in reader:
         # Select value based on condition
         row[new_hdr] = row[if_col] if row[chk_col] == match_val else row[else_col]
         yield row
 
-def add_conditional_column(input_path: str, chk_col: str, match_val: str, if_col: str, else_col: str, new_hdr: str, out_path: str) -> None:
+
+def add_conditional_column(
+    input_path: str,
+    chk_col: str,
+    match_val: str,
+    if_col: str,
+    else_col: str,
+    new_hdr: str,
+    out_path: str,
+) -> None:
     """Add conditional column to TSV file based on check column value."""
     with open_by_suffix(input_path) as inf, open_by_suffix(out_path, "w") as outf:
         # Use DictReader for cleaner column access by name
-        reader = csv.DictReader(inf, delimiter='\t')
+        reader = csv.DictReader(inf, delimiter="\t")
 
         # Handle empty file
         if reader.fieldnames is None:
@@ -67,6 +89,7 @@ def add_conditional_column(input_path: str, chk_col: str, match_val: str, if_col
         for row in process_rows(reader, chk_col, match_val, if_col, else_col, new_hdr):
             outf.write("\t".join(row[col] for col in fieldnames_out) + "\n")
 
+
 def main() -> None:
     # Parse arguments using named parameters
     parser = argparse.ArgumentParser(
@@ -74,10 +97,18 @@ def main() -> None:
     )
     parser.add_argument("--input", required=True, help="Path to input TSV file.")
     parser.add_argument("--chk-col", required=True, help="Name of column to check.")
-    parser.add_argument("--match-val", required=True, help="Value to match in check column.")
-    parser.add_argument("--if-col", required=True, help="Column to use when check matches.")
-    parser.add_argument("--else-col", required=True, help="Column to use when check doesn't match.")
-    parser.add_argument("--new-hdr", required=True, help="Name of the new column to add.")
+    parser.add_argument(
+        "--match-val", required=True, help="Value to match in check column."
+    )
+    parser.add_argument(
+        "--if-col", required=True, help="Column to use when check matches."
+    )
+    parser.add_argument(
+        "--else-col", required=True, help="Column to use when check doesn't match."
+    )
+    parser.add_argument(
+        "--new-hdr", required=True, help="Name of the new column to add."
+    )
     parser.add_argument("--output", required=True, help="Path to output TSV.")
     args = parser.parse_args()
 
@@ -97,8 +128,13 @@ def main() -> None:
     # Run conditional column function
     print_log("Adding conditional column to TSV...")
     add_conditional_column(
-        args.input, args.chk_col, args.match_val,
-        args.if_col, args.else_col, args.new_hdr, args.output
+        args.input,
+        args.chk_col,
+        args.match_val,
+        args.if_col,
+        args.else_col,
+        args.new_hdr,
+        args.output,
     )
     print_log("...done.")
 
@@ -106,6 +142,6 @@ def main() -> None:
     end_time = time.time()
     print_log(f"Total time elapsed: {end_time - start_time:.2f} seconds")
 
+
 if __name__ == "__main__":
     main()
-

--- a/modules/local/addConditionalTsvColumn/resources/usr/bin/test_add_conditional_tsv_column.py
+++ b/modules/local/addConditionalTsvColumn/resources/usr/bin/test_add_conditional_tsv_column.py
@@ -13,7 +13,9 @@ class TestAddConditionalColumn:
     def test_add_conditional_column_basic(self, tsv_factory: Any) -> None:
         """Test adding a conditional column based on check column values."""
         input_content = "x\ty\tz\n0\t100\t200\n1\t300\t400\n0\t500\t600\n"
-        expected_output = "x\ty\tz\tselected\n0\t100\t200\t100\n1\t300\t400\t400\n0\t500\t600\t500\n"
+        expected_output = (
+            "x\ty\tz\tselected\n0\t100\t200\t100\n1\t300\t400\t400\n0\t500\t600\t500\n"
+        )
 
         input_file = tsv_factory.create_plain("input.tsv", input_content)
         output_file = tsv_factory.get_path("output.tsv")
@@ -69,7 +71,7 @@ class TestAddConditionalColumn:
 
         result = tsv_factory.read_plain(output_file)
         assert result == expected_output
-    
+
     @pytest.mark.parametrize(
         ("col_to_make_missing", "missing_col_name"),
         [
@@ -78,10 +80,10 @@ class TestAddConditionalColumn:
             ("else_col", "not_there"),
         ],
     )
-    def test_missing_columns(self, tsv_factory: Any, col_to_make_missing: str, missing_col_name: str) -> None:
-        input_file = tsv_factory.create_plain(
-            "input.tsv", "x\ty\tz\n0\t100\t200\n"
-        )
+    def test_missing_columns(
+        self, tsv_factory: Any, col_to_make_missing: str, missing_col_name: str
+    ) -> None:
+        input_file = tsv_factory.create_plain("input.tsv", "x\ty\tz\n0\t100\t200\n")
         output_file = tsv_factory.get_path("output.tsv")
 
         kwargs = {
@@ -95,21 +97,30 @@ class TestAddConditionalColumn:
         }
         kwargs[col_to_make_missing] = missing_col_name
 
-        with pytest.raises(ValueError, match="could not find all requested columns in header"):
+        with pytest.raises(
+            ValueError, match="could not find all requested columns in header"
+        ):
             add_conditional_tsv_column.add_conditional_column(**kwargs)
 
-    @pytest.mark.parametrize("quote_string", [
-        'AAAA"BBBB',
-        "AAAA'BBBB",
-    ])
-    def test_fields_with_quote_characters_not_escaped(self, tsv_factory: Any, quote_string: str) -> None:
+    @pytest.mark.parametrize(
+        "quote_string",
+        [
+            'AAAA"BBBB',
+            "AAAA'BBBB",
+        ],
+    )
+    def test_fields_with_quote_characters_not_escaped(
+        self, tsv_factory: Any, quote_string: str
+    ) -> None:
         """Test that fields containing quote characters are not CSV-escaped.
 
         This is important for FASTQ quality strings which may contain the '"'
         character (ASCII 34 = Phred quality score 1). CSV escaping would double
         the quotes and wrap the field, corrupting the quality string length.
         """
-        input_content = f"x\ty\tz\n0\t{quote_string}\tother\n1\tno_quotes\t{quote_string}\n"
+        input_content = (
+            f"x\ty\tz\n0\t{quote_string}\tother\n1\tno_quotes\t{quote_string}\n"
+        )
         expected_output = f"x\ty\tz\tselected\n0\t{quote_string}\tother\t{quote_string}\n1\tno_quotes\t{quote_string}\t{quote_string}\n"
         input_file = tsv_factory.create_plain("input.tsv", input_content)
         output_file = tsv_factory.get_path("output.tsv")
@@ -127,4 +138,3 @@ class TestAddConditionalColumn:
         # Explicitly verify no CSV escaping occurred (doubled quotes or wrapping)
         assert '""' not in result, "Quotes should not be doubled (CSV escaping)"
         assert "''" not in result, "Quotes should not be doubled (CSV escaping)"
-

--- a/modules/local/addConditionalTsvColumn/resources/usr/bin/test_add_conditional_tsv_column.py
+++ b/modules/local/addConditionalTsvColumn/resources/usr/bin/test_add_conditional_tsv_column.py
@@ -2,9 +2,8 @@
 
 from typing import Any
 
-import pytest
-
 import add_conditional_tsv_column
+import pytest
 
 
 class TestAddConditionalColumn:

--- a/modules/local/addFixedColumn/resources/usr/bin/add_fixed_column.py
+++ b/modules/local/addFixedColumn/resources/usr/bin/add_fixed_column.py
@@ -2,9 +2,9 @@
 
 # Import modules
 import argparse
-import time
 import datetime
 import gzip
+import time
 from typing import IO, cast
 
 
@@ -19,8 +19,7 @@ def open_by_suffix(filename: str, mode: str = "r", debug: bool = False) -> IO[st
         print_log(f"\tGZIP mode: {filename.endswith('.gz')}")
     if filename.endswith(".gz"):
         return cast(IO[str], gzip.open(filename, mode + "t"))
-    else:
-        return open(filename, mode)
+    return open(filename, mode)
 
 
 def add_column(
@@ -73,10 +72,10 @@ def main() -> None:
     print_log("Starting process.")
     start_time = time.time()
     # Print parameters
-    print_log("Input TSV file: {}".format(input_path))
-    print_log("Column name: {}".format(column_name))
-    print_log("Column value: {}".format(column_value))
-    print_log("Output TSV file: {}".format(out_path))
+    print_log(f"Input TSV file: {input_path}")
+    print_log(f"Column name: {column_name}")
+    print_log(f"Column value: {column_value}")
+    print_log(f"Output TSV file: {out_path}")
     # Run labeling function
     print_log("Adding column to TSV...")
     add_column(input_path, column_name, column_value, out_path)

--- a/modules/local/addFixedColumn/resources/usr/bin/add_fixed_column.py
+++ b/modules/local/addFixedColumn/resources/usr/bin/add_fixed_column.py
@@ -7,20 +7,25 @@ import datetime
 import gzip
 from typing import IO, cast
 
+
 def print_log(message: str) -> None:
     print("[", datetime.datetime.now(), "]  ", message, sep="")
+
 
 def open_by_suffix(filename: str, mode: str = "r", debug: bool = False) -> IO[str]:
     if debug:
         print_log(f"\tOpening file object: {filename}")
         print_log(f"\tOpening mode: {mode}")
         print_log(f"\tGZIP mode: {filename.endswith('.gz')}")
-    if filename.endswith('.gz'):
-        return cast(IO[str], gzip.open(filename, mode + 't'))
+    if filename.endswith(".gz"):
+        return cast(IO[str], gzip.open(filename, mode + "t"))
     else:
         return open(filename, mode)
 
-def add_column(input_path: str, column_name: str, column_value: str, out_path: str) -> None:
+
+def add_column(
+    input_path: str, column_name: str, column_value: str, out_path: str
+) -> None:
     """Add one or more columns to a TSV file with a fixed value.
 
     The column_name argument can be a single name or a comma-separated list
@@ -47,11 +52,16 @@ def add_column(input_path: str, column_name: str, column_value: str, out_path: s
                 continue
             outf.write(line.rstrip("\r\n") + suffix + "\n")
 
+
 def main() -> None:
     # Parse arguments
-    parser = argparse.ArgumentParser(description="Add column to TSV file with specified name and value.")
+    parser = argparse.ArgumentParser(
+        description="Add column to TSV file with specified name and value."
+    )
     parser.add_argument("input_path", help="Path to input TSV file.")
-    parser.add_argument("column_name", help="Name of the column to add (comma-separated for multiple).")
+    parser.add_argument(
+        "column_name", help="Name of the column to add (comma-separated for multiple)."
+    )
     parser.add_argument("column_value", help="Value for the new column.")
     parser.add_argument("output_file", help="Path to output TSV.")
     args = parser.parse_args()
@@ -74,6 +84,7 @@ def main() -> None:
     # Finish time tracking
     end_time = time.time()
     print_log("Total time elapsed: %.2f seconds" % (end_time - start_time))
+
 
 if __name__ == "__main__":
     main()

--- a/modules/local/addFixedColumn/resources/usr/bin/test_add_fixed_column.py
+++ b/modules/local/addFixedColumn/resources/usr/bin/test_add_fixed_column.py
@@ -2,9 +2,8 @@
 
 from typing import Any
 
-import pytest
-
 import add_fixed_column
+import pytest
 
 
 class TestAddColumn:

--- a/modules/local/addFixedColumn/resources/usr/bin/test_add_fixed_column.py
+++ b/modules/local/addFixedColumn/resources/usr/bin/test_add_fixed_column.py
@@ -64,7 +64,11 @@ class TestAddColumn:
                 "col1\tcol2\tnew_a\tnew_b\n",
             ),
         ],
-        ids=["multi_column_basic", "multi_column_empty_file", "multi_column_header_only"],
+        ids=[
+            "multi_column_basic",
+            "multi_column_empty_file",
+            "multi_column_header_only",
+        ],
     )
     def test_add_multiple_columns(
         self, tsv_factory: Any, input_content: str, columns: str, expected_output: str

--- a/modules/local/addSampleColumn/resources/usr/bin/add_sample_column.py
+++ b/modules/local/addSampleColumn/resources/usr/bin/add_sample_column.py
@@ -2,10 +2,9 @@
 
 # Import modules
 import argparse
-import time
 import datetime
 import gzip
-import os
+import time
 from typing import IO, cast
 
 
@@ -20,8 +19,7 @@ def open_by_suffix(filename: str, mode: str = "r", debug: bool = False) -> IO[st
         print_log(f"\tGZIP mode: {filename.endswith('.gz')}")
     if filename.endswith(".gz"):
         return cast(IO[str], gzip.open(filename, mode + "t"))
-    else:
-        return open(filename, mode)
+    return open(filename, mode)
 
 
 def add_sample_column(
@@ -72,10 +70,10 @@ def main() -> None:
     print_log("Starting process.")
     start_time = time.time()
     # Print parameters
-    print_log("Input TSV file: {}".format(input_path))
-    print_log("Sample name: {}".format(sample_name))
-    print_log("Sample name column: {}".format(sample_column))
-    print_log("Output TSV file: {}".format(out_path))
+    print_log(f"Input TSV file: {input_path}")
+    print_log(f"Sample name: {sample_name}")
+    print_log(f"Sample name column: {sample_column}")
+    print_log(f"Output TSV file: {out_path}")
     # Run labeling function
     print_log("Adding sample name column to TSV...")
     add_sample_column(input_path, sample_name, sample_column, out_path)

--- a/modules/local/addSampleColumn/resources/usr/bin/add_sample_column.py
+++ b/modules/local/addSampleColumn/resources/usr/bin/add_sample_column.py
@@ -8,45 +8,53 @@ import gzip
 import os
 from typing import IO, cast
 
+
 def print_log(message: str) -> None:
     print("[", datetime.datetime.now(), "]  ", message, sep="")
+
 
 def open_by_suffix(filename: str, mode: str = "r", debug: bool = False) -> IO[str]:
     if debug:
         print_log(f"\tOpening file object: {filename}")
         print_log(f"\tOpening mode: {mode}")
         print_log(f"\tGZIP mode: {filename.endswith('.gz')}")
-    if filename.endswith('.gz'):
-        return cast(IO[str], gzip.open(filename, mode + 't'))
+    if filename.endswith(".gz"):
+        return cast(IO[str], gzip.open(filename, mode + "t"))
     else:
         return open(filename, mode)
 
-def add_sample_column(input_path: str, sample_name: str, sample_column: str, out_path: str) -> None:
+
+def add_sample_column(
+    input_path: str, sample_name: str, sample_column: str, out_path: str
+) -> None:
     """Add sample name column to TSV file."""
     with open_by_suffix(input_path) as inf, open_by_suffix(out_path, "w") as outf:
         # Read header line
         header_line = inf.readline().strip()
-        
+
         # Check if file is empty
         if not header_line:
-            print_log(f"Warning: Input file {input_path} is empty. Creating empty output file.")
+            print_log(
+                f"Warning: Input file {input_path} is empty. Creating empty output file."
+            )
             outf.write("")  # Write empty string to create the file
             return
-            
+
         # Process header
         headers_in = header_line.split("\t")
         if sample_column in headers_in:
             raise ValueError(f"Sample name column already exists: {sample_column}")
-            
+
         # Add sample column to header
         headers_out = headers_in + [sample_column]
         new_header = "\t".join(headers_out)
         outf.write(new_header + "\n")
-        
+
         # Add sample name to each subsequent line and write to output
         for line in inf:
             if line.strip():  # Skip completely empty lines
                 outf.write(line.strip() + "\t" + sample_name + "\n")
+
 
 def main() -> None:
     # Parse arguments
@@ -75,6 +83,7 @@ def main() -> None:
     # Finish time tracking
     end_time = time.time()
     print_log("Total time elapsed: %.2f seconds" % (end_time - start_time))
+
 
 if __name__ == "__main__":
     main()

--- a/modules/local/addSampleColumn/resources/usr/bin/test_add_sample_column.py
+++ b/modules/local/addSampleColumn/resources/usr/bin/test_add_sample_column.py
@@ -45,7 +45,9 @@ class TestAddSampleColumn:
         ["plain", "gzip"],
         ids=["plain_tsv", "gzipped_tsv"],
     )
-    def test_add_sample_column_file_formats(self, tsv_factory: Any, file_format: str) -> None:
+    def test_add_sample_column_file_formats(
+        self, tsv_factory: Any, file_format: str
+    ) -> None:
         """Test adding sample column with both plain and gzipped files."""
         input_content = "col1\tcol2\nval1\tval2\n"
         expected = "col1\tcol2\tsample\nval1\tval2\tsample_001\n"

--- a/modules/local/addSampleColumn/resources/usr/bin/test_add_sample_column.py
+++ b/modules/local/addSampleColumn/resources/usr/bin/test_add_sample_column.py
@@ -2,9 +2,8 @@
 
 from typing import Any
 
-import pytest
-
 import add_sample_column
+import pytest
 
 
 class TestAddSampleColumn:

--- a/modules/local/annotateVirusInfection/resources/usr/bin/annotate_viral_hosts.py
+++ b/modules/local/annotateVirusInfection/resources/usr/bin/annotate_viral_hosts.py
@@ -5,21 +5,22 @@
 # =======================================================================
 
 # Import libraries
-import pandas as pd
-from pathlib import Path
 import argparse
-from collections import defaultdict
-from typing import cast, override
 import logging
+from collections import defaultdict
+from datetime import UTC, datetime
 from logging import LogRecord
-from datetime import datetime, timezone
+from pathlib import Path
+from typing import cast, override
+
+import pandas as pd
 
 
 # Configure logging
 class UTCFormatter(logging.Formatter):
     @override
     def formatTime(self, record: LogRecord, datefmt: str | None = None) -> str:
-        dt = datetime.fromtimestamp(record.created, timezone.utc)
+        dt = datetime.fromtimestamp(record.created, UTC)
         return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
@@ -106,7 +107,7 @@ def get_host_taxids(hosts: dict[str, str], nodes: pd.DataFrame) -> dict[str, set
     """
     logger.info("Generating host taxid dictionary from input TSV.")
     host_dict_out: dict[str, set[str]] = dict()
-    for k in hosts.keys():
+    for k in hosts:
         host_dict_out[k] = expand_taxid(hosts[k], nodes)
         n_desc = len(host_dict_out[k])
         logger.info(
@@ -164,8 +165,7 @@ def mark_direct_infections(
             # otherwise return 0
             if bool(virus_host_mapping[virus_taxid] & host_taxids):
                 return MATCH
-            else:
-                return INCONSISTENT
+            return INCONSISTENT
         return UNRESOLVED  # Indicates not in mapping; needs special handling downstream
 
     statuses = virus_taxids.apply(check_direct_infection)
@@ -321,21 +321,17 @@ def mark_ancestor_infections_single(
         if (child_statuses == UNRESOLVED).all():
             return set_checked(virus_taxid, virus_df)
         # Otherwise, if all children have the same status, inherit that status
-        elif (child_statuses == child_statuses.iloc[0]).all():
+        if (child_statuses == child_statuses.iloc[0]).all():
             return set_status(virus_taxid, virus_df, child_statuses.iloc[0])
         # If any child is marked UNCLEAR, mark this taxid as UNCLEAR
-        elif child_statuses.isin([UNCLEAR]).any():
-            return set_status(virus_taxid, virus_df, UNCLEAR)
-        # If there are both children marked [INCONSISTENT or MAYBE_INCONSISTENT] and marked [MATCH or CONSISTENT],
-        # mark this taxid as UNCLEAR
-        elif (
+        if child_statuses.isin([UNCLEAR]).any() or (
             child_statuses.isin([INCONSISTENT, MAYBE_INCONSISTENT]).any()
             and child_statuses.isin([MATCH, CONSISTENT]).any()
         ):
             return set_status(virus_taxid, virus_df, UNCLEAR)
         # If any child is marked [INCONSISTENT or MAYBE_INCONSISTENT], retain any existing mark of INCONSISTENT
         # on the parent node, otherwise mark MAYBE_INCONSISTENT
-        elif (child_statuses.isin([INCONSISTENT, MAYBE_INCONSISTENT])).any():
+        if (child_statuses.isin([INCONSISTENT, MAYBE_INCONSISTENT])).any():
             # If parent is marked INCONSISTENT, keep current status
             if virus_df.loc[virus_taxid]["status"] == INCONSISTENT:
                 return set_checked(virus_taxid, virus_df)
@@ -346,8 +342,7 @@ def mark_ancestor_infections_single(
             return set_status(virus_taxid, virus_df, MAYBE_INCONSISTENT)
         # Otherwise, mark as CONSISTENT
         # This covers all mixtures of MATCH, UNRESOLVED and CONSISTENT
-        else:
-            return set_status(virus_taxid, virus_df, CONSISTENT)
+        return set_status(virus_taxid, virus_df, CONSISTENT)
     # Otherwise, run this function for each unchecked child, then repeat
     children_unchecked = children.loc[~children["checked"]]
     for child in children_unchecked.index:
@@ -534,7 +529,7 @@ def annotate_virus_db(
     # Get viral taxonomic tree
     virus_tree = build_virus_tree(virus_db)
     # Add annotations for each host group
-    for k in host_mapping.keys():
+    for k in host_mapping:
         virus_db = annotate_virus_db_single(
             virus_db,
             k,

--- a/modules/local/annotateVirusInfection/resources/usr/bin/annotate_viral_hosts.py
+++ b/modules/local/annotateVirusInfection/resources/usr/bin/annotate_viral_hosts.py
@@ -59,11 +59,10 @@ def get_virus_host_mapping(db_path: str) -> dict[str, set[str]]:
     logger.info("Importing Virus-Host-DB.")
     df = pd.read_csv(db_path, sep="\t", dtype=str)
     logger.info("Generating mapping from Virus-Host-DB.")
-    mapping = cast(
+    return cast(
         dict[str, set[str]],
         df.groupby("virus tax id")["host tax id"].apply(set).to_dict(),
     )
-    return mapping
 
 
 def expand_taxid(taxid: str, nodes: pd.DataFrame) -> set[str]:
@@ -106,7 +105,7 @@ def get_host_taxids(hosts: dict[str, str], nodes: pd.DataFrame) -> dict[str, set
             expand_taxid().
     """
     logger.info("Generating host taxid dictionary from input TSV.")
-    host_dict_out: dict[str, set[str]] = dict()
+    host_dict_out: dict[str, set[str]] = {}
     for k in hosts:
         host_dict_out[k] = expand_taxid(hosts[k], nodes)
         n_desc = len(host_dict_out[k])

--- a/modules/local/annotateVirusInfection/resources/usr/bin/annotate_viral_hosts.py
+++ b/modules/local/annotateVirusInfection/resources/usr/bin/annotate_viral_hosts.py
@@ -58,7 +58,10 @@ def get_virus_host_mapping(db_path: str) -> dict[str, set[str]]:
     logger.info("Importing Virus-Host-DB.")
     df = pd.read_csv(db_path, sep="\t", dtype=str)
     logger.info("Generating mapping from Virus-Host-DB.")
-    mapping = cast(dict[str, set[str]], df.groupby("virus tax id")["host tax id"].apply(set).to_dict())
+    mapping = cast(
+        dict[str, set[str]],
+        df.groupby("virus tax id")["host tax id"].apply(set).to_dict(),
+    )
     return mapping
 
 
@@ -589,7 +592,9 @@ def main() -> None:
     virus_host_mapping = get_virus_host_mapping(args.infection_db)
     hard_exclude_taxids = args.hard_exclude_taxids.split(" ")
     # Prepare dictionary of host taxids
-    host_dict_single = cast(dict[str, str], host_db.set_index("name")["taxid"].to_dict())
+    host_dict_single = cast(
+        dict[str, str], host_db.set_index("name")["taxid"].to_dict()
+    )
     host_dict_full = get_host_taxids(host_dict_single, nodes_db)
     # Add annotations
     logger.info("Initializing infection-state annotation.")

--- a/modules/local/annotateVirusInfection/resources/usr/bin/test_annotate_viral_hosts.py
+++ b/modules/local/annotateVirusInfection/resources/usr/bin/test_annotate_viral_hosts.py
@@ -3,7 +3,7 @@
 Comprehensive test suite for the annotate_viral_hosts module.
 
 This file tests the viral host infection annotation pipeline, which determines
-whether viruses infect specific host taxa based on Virus-Host DB data and 
+whether viruses infect specific host taxa based on Virus-Host DB data and
 taxonomic relationships.
 
 Test Organization:
@@ -149,7 +149,7 @@ def generate_mixed_state_cases(
 
 
 def inconsistent_propagation_logic(_: StateTuple, initial_parent: State) -> State:
-    # We ignore children states because for this test case, all children are 
+    # We ignore children states because for this test case, all children are
     # UNRESOLVED, MAYBE_INCONSISTENT, or INCONSISTENT. In this scenario,
     # only the parent's initial state determines the outcome.
     if initial_parent == INCONSISTENT:
@@ -234,12 +234,12 @@ def dataframe_factory() -> DataFrameFactory:
 @pytest.fixture
 def host_taxonomy_nodes() -> pd.DataFrame:
     """Create a test NCBI nodes DataFrame for host taxonomy.
-    
+
     Structure:
     9606 (human)
     ├── 741158
     └── 63221
-    
+
     7742 (vertebrate)
     ├── 1476529
     ├── 7776
@@ -257,13 +257,15 @@ def host_taxonomy_nodes() -> pd.DataFrame:
     return pd.DataFrame(nodes_data)
 
 
-@pytest.fixture  
+@pytest.fixture
 def sample_virus_db() -> pd.DataFrame:
     """Create a sample virus database for testing."""
-    return pd.DataFrame({
-        "taxid": ["v1", "v2", "v3"],
-        "parent_taxid": ["0", "0", "0"],
-    })
+    return pd.DataFrame(
+        {
+            "taxid": ["v1", "v2", "v3"],
+            "parent_taxid": ["0", "0", "0"],
+        }
+    )
 
 
 @pytest.fixture
@@ -272,7 +274,7 @@ def sample_virus_tree() -> dict[str, set[str]]:
     return {
         "0": {"v1", "v2", "v3"},
         "v1": set(),
-        "v2": set(), 
+        "v2": set(),
         "v3": set(),
     }
 
@@ -284,6 +286,7 @@ def sample_virus_tree() -> dict[str, set[str]]:
 # =======================================================================
 # Tests for mark_ancestor_infections_single
 # =======================================================================
+
 
 class TestUniformChildStates:
     # Untested before: All combinations
@@ -459,6 +462,7 @@ class TestMixedStatePropagation:
 # Tests for mark_direct_infections
 # =======================================================================
 
+
 class TestMarkDirectInfections:
     """Test the mark_direct_infections function."""
 
@@ -472,10 +476,10 @@ class TestMarkDirectInfections:
             "virus2": {"host2", "host3"},  # Has matching hosts (host2, host3)
             "virus3": {"host4", "host5"},  # No matching hosts
         }
-        
+
         # Act
         result = mark_direct_infections(virus_taxids, host_taxids, virus_host_mapping)
-        
+
         # Assert
         assert result["virus1"] == MATCH
         assert result["virus2"] == MATCH
@@ -490,10 +494,10 @@ class TestMarkDirectInfections:
             "virus1": {"host1"},  # Has matching host
         }
         # virus2 and virus3 are not in mapping
-        
+
         # Act
         result = mark_direct_infections(virus_taxids, host_taxids, virus_host_mapping)
-        
+
         # Assert
         assert result["virus1"] == MATCH
         assert result["virus2"] == UNRESOLVED
@@ -505,10 +509,10 @@ class TestMarkDirectInfections:
         virus_taxids = pd.Series([], dtype=str)
         host_taxids = {"host1", "host2"}
         virus_host_mapping = {"virus1": {"host1"}}
-        
+
         # Act
         result = mark_direct_infections(virus_taxids, host_taxids, virus_host_mapping)
-        
+
         # Assert
         assert len(result) == 0
         assert isinstance(result, pd.Series)
@@ -522,10 +526,10 @@ class TestMarkDirectInfections:
             "virus1": {"host1", "host2"},
             "virus2": {"host3"},
         }
-        
+
         # Act
         result = mark_direct_infections(virus_taxids, host_taxids, virus_host_mapping)
-        
+
         # Assert
         # All viruses should be INCONSISTENT since no hosts match empty set
         assert result["virus1"] == INCONSISTENT
@@ -535,6 +539,7 @@ class TestMarkDirectInfections:
 # =======================================================================
 # Tests for expand_taxid
 # =======================================================================
+
 
 class TestExpandTaxid:
     """Test the expand_taxid function."""
@@ -549,10 +554,10 @@ class TestExpandTaxid:
             {"taxid": "4", "parent_taxid": "3"},  # Great-grandchild of 1
         ]
         nodes = pd.DataFrame(nodes_data)
-        
+
         # Act
         result = expand_taxid("1", nodes)
-        
+
         # Assert
         expected = {"1", "2", "3", "4"}
         assert result == expected
@@ -569,10 +574,10 @@ class TestExpandTaxid:
             {"taxid": "6", "parent_taxid": "3"},  # Another grandchild via second child
         ]
         nodes = pd.DataFrame(nodes_data)
-        
+
         # Act
         result = expand_taxid("1", nodes)
-        
+
         # Assert
         expected = {"1", "2", "3", "4", "5", "6"}
         assert result == expected
@@ -587,10 +592,10 @@ class TestExpandTaxid:
             {"taxid": "4", "parent_taxid": "2"},  # Leaf node
         ]
         nodes = pd.DataFrame(nodes_data)
-        
+
         # Act
         result = expand_taxid("4", nodes)  # Query leaf node
-        
+
         # Assert
         assert result == {"4"}
 
@@ -602,10 +607,10 @@ class TestExpandTaxid:
             {"taxid": "2", "parent_taxid": "1"},
         ]
         nodes = pd.DataFrame(nodes_data)
-        
+
         # Act
         result = expand_taxid("999", nodes)  # Non-existent taxid
-        
+
         # Assert
         assert result == {"999"}
 
@@ -627,11 +632,11 @@ class TestExpandTaxid:
             {"taxid": "211", "parent_taxid": "210"},
         ]
         nodes = pd.DataFrame(nodes_data)
-        
+
         # Act - Expand from different starting points
         result_root = expand_taxid("1", nodes)
         result_branch = expand_taxid("20", nodes)
-        
+
         # Assert
         expected_root = {"1", "10", "11", "12", "20", "21", "22", "210", "211"}
         expected_branch = {"20", "21", "22", "210", "211"}
@@ -642,6 +647,7 @@ class TestExpandTaxid:
 # =======================================================================
 # Tests for build_virus_tree
 # =======================================================================
+
 
 class TestBuildVirusTree:
     """Test the build_virus_tree function."""
@@ -657,13 +663,13 @@ class TestBuildVirusTree:
             {"taxid": "5", "parent_taxid": "2"},  # Another child of 2
         ]
         viral_taxa_df = pd.DataFrame(viral_taxa_data)
-        
+
         # Act
         result = build_virus_tree(viral_taxa_df)
-        
+
         # Assert
         expected = {
-            "0": {"1"},        # Parent 0 has child 1
+            "0": {"1"},  # Parent 0 has child 1
             "1": {"2", "3"},  # Parent 1 has children 2 and 3
             "2": {"4", "5"},  # Parent 2 has children 4 and 5
         }
@@ -671,7 +677,7 @@ class TestBuildVirusTree:
         for parent, children in expected.items():
             assert parent in result
             assert result[parent] == children
-        
+
         # Verify that nodes without children return empty sets
         assert result["3"] == set()
         assert result["4"] == set()
@@ -681,10 +687,10 @@ class TestBuildVirusTree:
         """Test that empty DataFrame returns empty defaultdict."""
         # Arrange
         viral_taxa_df = pd.DataFrame(columns=["taxid", "parent_taxid"])
-        
+
         # Act
         result = build_virus_tree(viral_taxa_df)
-        
+
         # Assert
         # Should be an empty defaultdict
         assert len(result) == 0
@@ -710,10 +716,10 @@ class TestBuildVirusTree:
             {"taxid": "213", "parent_taxid": "210"},
         ]
         viral_taxa_df = pd.DataFrame(viral_taxa_data)
-        
+
         # Act
         result = build_virus_tree(viral_taxa_df)
-        
+
         # Assert
         assert result["root"] == {"100", "200"}
         assert result["100"] == {"110", "120"}
@@ -733,56 +739,58 @@ class TestBuildVirusTree:
 # Tests for mark_descendant_infections
 # =======================================================================
 
+
 class TestMarkDescendantInfections:
     """Test mark_descendant_infections function.
-    
+
     This function propagates infection statuses from parent nodes to their descendants.
     The propagation follows a specific priority order:
     1. MATCH propagation (overrides everything)
     2. INCONSISTENT propagation (overrides everything except MATCH)
     3. CONSISTENT propagation (doesn't override MATCH)
     4. UNCLEAR propagation (only affects UNRESOLVED and MAYBE_INCONSISTENT)
-    
+
     After this function runs:
     - No nodes should have UNRESOLVED status
     - No nodes should have MAYBE_INCONSISTENT status
-    
+
     Valid Parent-Child State Combinations
     Based on the logic in the code, these are the valid parent-child combinations that can exist when mark_descendant_infections is called:
-    
+
     Parent: MATCH
     - Children can be: Any state
     - Note: MATCH parents are marked as "checked" early and skip mark_ancestor_infections_single
-    
+
     Parent: INCONSISTENT
     - If all children are INCONSISTENT: Parent inherits INCONSISTENT (uniform rule)
     - Otherwise: Children can be INCONSISTENT, MAYBE_INCONSISTENT, or UNRESOLVED
     - Cannot have: MATCH or CONSISTENT children (would make parent UNCLEAR instead)
-    
+
     Parent: UNCLEAR
     - Must have one of:
       - At least one UNCLEAR child, OR
       - Mix of (INCONSISTENT/MAYBE_INCONSISTENT) and (MATCH/CONSISTENT) children
     - Cannot have: All children with same state (would trigger uniform rule)
-    
+
     Parent: CONSISTENT
     - Children must be some mix of: MATCH, CONSISTENT, and/or UNRESOLVED only
     - Cannot have: INCONSISTENT, MAYBE_INCONSISTENT, or UNCLEAR children
     - Cannot have: All children with same state (would trigger uniform rule)
-    
+
     Parent: UNRESOLVED
     - If parent is UNRESOLVED after mark_ancestor_infections, children must all be UNRESOLVED
     - This follows from the logic: parent only stays UNRESOLVED if all children are UNRESOLVED
-    
+
     Parent: MAYBE_INCONSISTENT
     - Must have: At least one INCONSISTENT or MAYBE_INCONSISTENT child
     - Parent's original state was UNRESOLVED (before mark_ancestor_infections_single)
     - Cannot have: Only MATCH/CONSISTENT children (would make parent CONSISTENT)
     """
+
     @pytest.fixture
     def simple_tree(self) -> dict[str, set[str]]:
         """Create a simple tree structure for testing.
-        
+
         Structure:
         root
         ├── v1
@@ -799,11 +807,11 @@ class TestMarkDescendantInfections:
             "v12": set(),
             "v21": set(),
         }
-    
+
     @pytest.fixture
     def comprehensive_propagation_tree(self) -> dict[str, set[str]]:
         """Create a comprehensive tree for testing all propagation scenarios.
-        
+
         Structure:
         root (UNCLEAR)
         ├── child1 (MATCH)              # Tests MATCH propagation
@@ -819,7 +827,7 @@ class TestMarkDescendantInfections:
         │   └── child16 (MAYBE_INCONSISTENT) # Has children to test override
         │       ├── child161 (UNRESOLVED)
         │       └── child162 (INCONSISTENT)
-        ├── child2 (CONSISTENT)         # Tests CONSISTENT propagation  
+        ├── child2 (CONSISTENT)         # Tests CONSISTENT propagation
         │   ├── child21 (MATCH)
         │   └── child22 (UNRESOLVED)
         ├── child3 (MAYBE_INCONSISTENT) # Tests UNCLEAR propagation
@@ -834,7 +842,14 @@ class TestMarkDescendantInfections:
         """
         return {
             "root": {"child1", "child2", "child3", "child4"},
-            "child1": {"child11", "child12", "child13", "child14", "child15", "child16"},
+            "child1": {
+                "child11",
+                "child12",
+                "child13",
+                "child14",
+                "child15",
+                "child16",
+            },
             "child2": {"child21", "child22"},
             "child3": {"child31", "child32"},
             "child4": {"child41", "child42", "child43"},
@@ -860,11 +875,12 @@ class TestMarkDescendantInfections:
             "child431": set(),
             "child432": set(),
         }
-    
 
-    def test_all_propagation_scenarios(self, comprehensive_propagation_tree: dict[str, set[str]]) -> None:
+    def test_all_propagation_scenarios(
+        self, comprehensive_propagation_tree: dict[str, set[str]]
+    ) -> None:
         """Test all propagation scenarios in a single comprehensive test.
-        
+
         Initial state setup per the example:
         root (UNCLEAR/2)
         ├── child1 (MATCH/1)
@@ -892,7 +908,7 @@ class TestMarkDescendantInfections:
             └── child43 (MAYBE_INCONSISTENT/-2)
                 ├── child431 (INCONSISTENT/0)
                 └── child432 (UNRESOLVED/-1)
-        
+
         Expected after propagation:
         - All descendants of child1 become MATCH (MATCH overrides all)
         - Descendants of child2: child21 stays MATCH, child22 becomes CONSISTENT
@@ -900,42 +916,46 @@ class TestMarkDescendantInfections:
         - Descendants of child4 become INCONSISTENT
         """
         # Arrange
-        statuses = pd.Series({
-            "root": UNCLEAR,
-            "child1": MATCH,
-            "child11": UNRESOLVED,
-            "child12": INCONSISTENT,
-            "child13": MATCH,
-            "child14": CONSISTENT,
-            "child141": MATCH,
-            "child142": UNRESOLVED,
-            "child15": UNCLEAR,
-            "child151": MATCH,
-            "child152": INCONSISTENT,
-            "child16": MAYBE_INCONSISTENT,
-            "child161": UNRESOLVED,
-            "child162": INCONSISTENT,
-            "child2": CONSISTENT,
-            "child21": MATCH,
-            "child22": UNRESOLVED,
-            "child3": MAYBE_INCONSISTENT,
-            "child31": UNRESOLVED,
-            "child32": INCONSISTENT,
-            "child4": INCONSISTENT,
-            "child41": UNRESOLVED,
-            "child42": INCONSISTENT,
-            "child43": MAYBE_INCONSISTENT,
-            "child431": INCONSISTENT,
-            "child432": UNRESOLVED,
-        })
-        
+        statuses = pd.Series(
+            {
+                "root": UNCLEAR,
+                "child1": MATCH,
+                "child11": UNRESOLVED,
+                "child12": INCONSISTENT,
+                "child13": MATCH,
+                "child14": CONSISTENT,
+                "child141": MATCH,
+                "child142": UNRESOLVED,
+                "child15": UNCLEAR,
+                "child151": MATCH,
+                "child152": INCONSISTENT,
+                "child16": MAYBE_INCONSISTENT,
+                "child161": UNRESOLVED,
+                "child162": INCONSISTENT,
+                "child2": CONSISTENT,
+                "child21": MATCH,
+                "child22": UNRESOLVED,
+                "child3": MAYBE_INCONSISTENT,
+                "child31": UNRESOLVED,
+                "child32": INCONSISTENT,
+                "child4": INCONSISTENT,
+                "child41": UNRESOLVED,
+                "child42": INCONSISTENT,
+                "child43": MAYBE_INCONSISTENT,
+                "child431": INCONSISTENT,
+                "child432": UNRESOLVED,
+            }
+        )
+
         # Act
-        result = mark_descendant_infections(comprehensive_propagation_tree, statuses.copy())
-        
+        result = mark_descendant_infections(
+            comprehensive_propagation_tree, statuses.copy()
+        )
+
         # Assert
         # Root remains UNCLEAR
         assert result["root"] == UNCLEAR
-        
+
         # Test MATCH propagation (child1 and descendants)
         assert result["child1"] == MATCH
         assert result["child11"] == MATCH  # MATCH overrides UNRESOLVED
@@ -950,84 +970,104 @@ class TestMarkDescendantInfections:
         assert result["child16"] == MATCH  # MATCH overrides MAYBE_INCONSISTENT
         assert result["child161"] == MATCH  # Inherits MATCH from grandparent
         assert result["child162"] == MATCH  # MATCH overrides INCONSISTENT
-        
+
         # Test CONSISTENT propagation (child2 and descendants)
         assert result["child2"] == CONSISTENT
-        assert result["child21"] == MATCH      # MATCH is preserved (not overridden by CONSISTENT)
+        assert (
+            result["child21"] == MATCH
+        )  # MATCH is preserved (not overridden by CONSISTENT)
         assert result["child22"] == CONSISTENT  # Inherits CONSISTENT from parent
-        
+
         # Test UNCLEAR propagation to MAYBE_INCONSISTENT (child3 and descendants)
-        assert result["child3"] == UNCLEAR  # Changed from MAYBE_INCONSISTENT by UNCLEAR root
+        assert (
+            result["child3"] == UNCLEAR
+        )  # Changed from MAYBE_INCONSISTENT by UNCLEAR root
         assert result["child31"] == UNCLEAR  # Changed from UNRESOLVED by UNCLEAR parent
-        assert result["child32"] == INCONSISTENT  # INCONSISTENT is preserved (not overridden by UNCLEAR)
-        
+        assert (
+            result["child32"] == INCONSISTENT
+        )  # INCONSISTENT is preserved (not overridden by UNCLEAR)
+
         # Test INCONSISTENT propagation (child4 and descendants)
         assert result["child4"] == INCONSISTENT
         assert result["child41"] == INCONSISTENT  # Inherits from INCONSISTENT parent
         assert result["child42"] == INCONSISTENT  # Already INCONSISTENT, preserved
-        assert result["child43"] == INCONSISTENT  # INCONSISTENT overrides MAYBE_INCONSISTENT
+        assert (
+            result["child43"] == INCONSISTENT
+        )  # INCONSISTENT overrides MAYBE_INCONSISTENT
         assert result["child431"] == INCONSISTENT  # Already INCONSISTENT, preserved
         assert result["child432"] == INCONSISTENT  # INCONSISTENT overrides UNRESOLVED
-        
+
         # Verify no UNRESOLVED or MAYBE_INCONSISTENT states remain
         assert UNRESOLVED not in result.values
         assert MAYBE_INCONSISTENT not in result.values
 
-    def test_assertion_unresolved_remaining(self, simple_tree: dict[str, set[str]]) -> None:
+    def test_assertion_unresolved_remaining(
+        self, simple_tree: dict[str, set[str]]
+    ) -> None:
         """Test that assertion fires if UNRESOLVED remains (shouldn't happen in practice)."""
         # Arrange - Create a tree with an isolated UNRESOLVED node
         isolated_tree: dict[str, set[str]] = {"isolated": set()}
         statuses = pd.Series({"isolated": UNRESOLVED})
-        
+
         # Act & Assert
         with pytest.raises(AssertionError, match="Some taxids are still unresolved"):
             mark_descendant_infections(isolated_tree, statuses)
 
-    def test_assertion_maybe_inconsistent_remaining(self, simple_tree: dict[str, set[str]]) -> None:
+    def test_assertion_maybe_inconsistent_remaining(
+        self, simple_tree: dict[str, set[str]]
+    ) -> None:
         """Test that assertion fires if MAYBE_INCONSISTENT remains (shouldn't happen in practice)."""
         # Arrange - Create a tree with an isolated MAYBE_INCONSISTENT node
         isolated_tree: dict[str, set[str]] = {"isolated": set()}
         statuses = pd.Series({"isolated": MAYBE_INCONSISTENT})
-        
+
         # Act & Assert
-        with pytest.raises(AssertionError, match="Some taxids are still maybe inconsistent"):
+        with pytest.raises(
+            AssertionError, match="Some taxids are still maybe inconsistent"
+        ):
             mark_descendant_infections(isolated_tree, statuses)
 
     def test_assertion_consistent_with_inconsistent_descendant(self) -> None:
         """Test that assertion fires if CONSISTENT has INCONSISTENT descendants."""
         # Arrange - This shouldn't happen after mark_ancestor_infections
-        tree = {
-            "root": {"child"},
-            "child": set()
-        }
-        statuses = pd.Series({
-            "root": CONSISTENT,
-            "child": INCONSISTENT  # Invalid: CONSISTENT parent can't have INCONSISTENT child
-        })
-        
+        tree = {"root": {"child"}, "child": set()}
+        statuses = pd.Series(
+            {
+                "root": CONSISTENT,
+                "child": INCONSISTENT,  # Invalid: CONSISTENT parent can't have INCONSISTENT child
+            }
+        )
+
         # Act & Assert
-        with pytest.raises(AssertionError, match="Some taxids marked as CONSISTENT have descendants marked as INCONSISTENT or UNCLEAR"):
+        with pytest.raises(
+            AssertionError,
+            match="Some taxids marked as CONSISTENT have descendants marked as INCONSISTENT or UNCLEAR",
+        ):
             mark_descendant_infections(tree, statuses)
 
     def test_assertion_consistent_with_unclear_descendant(self) -> None:
         """Test that assertion fires if CONSISTENT has UNCLEAR descendants."""
         # Arrange
-        tree = {
-            "root": {"child"},
-            "child": set()
-        }
-        statuses = pd.Series({
-            "root": CONSISTENT,
-            "child": UNCLEAR  # Invalid: CONSISTENT parent can't have UNCLEAR child
-        })
-        
+        tree = {"root": {"child"}, "child": set()}
+        statuses = pd.Series(
+            {
+                "root": CONSISTENT,
+                "child": UNCLEAR,  # Invalid: CONSISTENT parent can't have UNCLEAR child
+            }
+        )
+
         # Act & Assert
-        with pytest.raises(AssertionError, match="Some taxids marked as CONSISTENT have descendants marked as INCONSISTENT or UNCLEAR"):
+        with pytest.raises(
+            AssertionError,
+            match="Some taxids marked as CONSISTENT have descendants marked as INCONSISTENT or UNCLEAR",
+        ):
             mark_descendant_infections(tree, statuses)
+
 
 # =======================================================================
 # Tests for add_descendants
 # =======================================================================
+
 
 class TestAddDescendants:
     """Test the add_descendants helper function."""
@@ -1046,10 +1086,10 @@ class TestAddDescendants:
             "8": set(),
         }
         taxids_start = {"1"}
-        
+
         # Act
         result = add_descendants(virus_tree, taxids_start)
-        
+
         # Assert
         expected = {"1", "2", "3", "4", "5", "6", "7", "8"}
         assert result == expected
@@ -1063,10 +1103,10 @@ class TestAddDescendants:
             "3": set(),
         }
         taxids_start = {"1", "2"}
-        
+
         # Act
         result = add_descendants(virus_tree, taxids_start)
-        
+
         # Assert
         assert result == taxids_start
 
@@ -1079,10 +1119,10 @@ class TestAddDescendants:
             "3": set(),
         }
         taxids_start: set[str] = set()
-        
+
         # Act
         result = add_descendants(virus_tree, taxids_start)
-        
+
         # Assert
         assert result == set()
 
@@ -1100,10 +1140,10 @@ class TestAddDescendants:
             "8": set(),
         }
         taxids_start = {"1", "6"}
-        
+
         # Act
         result = add_descendants(virus_tree, taxids_start)
-        
+
         # Assert
         expected = {"1", "2", "3", "4", "5", "6", "7", "8"}
         assert result == expected
@@ -1112,6 +1152,7 @@ class TestAddDescendants:
 # =======================================================================
 # Tests for exclude_infections
 # =======================================================================
+
 
 class TestExcludeInfections:
     """Test the exclude_infections function."""
@@ -1126,18 +1167,20 @@ class TestExcludeInfections:
             "4": set(),
             "5": set(),
         }
-        statuses = pd.Series({
-            "1": MATCH,
-            "2": MATCH,
-            "3": UNCLEAR,
-            "4": CONSISTENT,
-            "5": UNRESOLVED,
-        })
+        statuses = pd.Series(
+            {
+                "1": MATCH,
+                "2": MATCH,
+                "3": UNCLEAR,
+                "4": CONSISTENT,
+                "5": UNRESOLVED,
+            }
+        )
         exclude_taxids = ["2"]  # Should exclude 2, 4, and 5
-        
+
         # Act
         result = exclude_infections(virus_tree, statuses.copy(), exclude_taxids)
-        
+
         # Assert
         assert result["1"] == MATCH  # Not excluded
         assert result["2"] == INCONSISTENT  # Excluded
@@ -1153,16 +1196,18 @@ class TestExcludeInfections:
             "2": set(),
             "3": set(),
         }
-        statuses = pd.Series({
-            "1": MATCH,
-            "2": CONSISTENT,
-            "3": UNCLEAR,
-        })
+        statuses = pd.Series(
+            {
+                "1": MATCH,
+                "2": CONSISTENT,
+                "3": UNCLEAR,
+            }
+        )
         exclude_taxids: list[str] = []
 
         # Act
         result = exclude_infections(virus_tree, statuses.copy(), exclude_taxids)
-        
+
         # Assert
         pd.testing.assert_series_equal(result, statuses)
 
@@ -1176,18 +1221,20 @@ class TestExcludeInfections:
             "4": {"5"},
             "5": set(),
         }
-        statuses = pd.Series({
-            "1": MATCH,
-            "2": MATCH,
-            "3": MATCH,
-            "4": MATCH,
-            "5": MATCH,
-        })
+        statuses = pd.Series(
+            {
+                "1": MATCH,
+                "2": MATCH,
+                "3": MATCH,
+                "4": MATCH,
+                "5": MATCH,
+            }
+        )
         exclude_taxids = ["2"]
-        
+
         # Act
         result = exclude_infections(virus_tree, statuses.copy(), exclude_taxids)
-        
+
         # Assert
         assert result["1"] == MATCH  # Not excluded
         assert result["2"] == INCONSISTENT  # Excluded
@@ -1199,6 +1246,7 @@ class TestExcludeInfections:
 # =======================================================================
 # Tests for mark_ancestor_infections
 # =======================================================================
+
 
 class TestMarkAncestorInfections:
     """Test the mark_ancestor_infections wrapper function."""
@@ -1213,17 +1261,19 @@ class TestMarkAncestorInfections:
             "4": set(),
             "5": set(),
         }
-        statuses = pd.Series({
-            "1": UNRESOLVED,
-            "2": UNRESOLVED,
-            "3": MATCH,
-            "4": INCONSISTENT,
-            "5": MATCH,
-        })
-        
+        statuses = pd.Series(
+            {
+                "1": UNRESOLVED,
+                "2": UNRESOLVED,
+                "3": MATCH,
+                "4": INCONSISTENT,
+                "5": MATCH,
+            }
+        )
+
         # Act
         result = mark_ancestor_infections(virus_tree, statuses)
-        
+
         # Assert
         # All nodes should have been processed
         # Node 2 should be UNCLEAR (has both MATCH and INCONSISTENT children)
@@ -1243,16 +1293,18 @@ class TestMarkAncestorInfections:
             "3": set(),
             "4": set(),  # Isolated node
         }
-        statuses = pd.Series({
-            "1": MATCH,  # Should be preserved
-            "2": INCONSISTENT, # Childless, should be preserved
-            "3": UNRESOLVED, # Childless, should be preserved
-            "4": UNCLEAR,  # Childless, should be preserved
-        })
-        
+        statuses = pd.Series(
+            {
+                "1": MATCH,  # Should be preserved
+                "2": INCONSISTENT,  # Childless, should be preserved
+                "3": UNRESOLVED,  # Childless, should be preserved
+                "4": UNCLEAR,  # Childless, should be preserved
+            }
+        )
+
         # Act
         result = mark_ancestor_infections(virus_tree, statuses)
-        
+
         # Assert
         assert result["1"] == MATCH  # Preserved
         assert result["2"] == INCONSISTENT  # Preserved (childless)
@@ -1264,6 +1316,7 @@ class TestMarkAncestorInfections:
 # Tests for get_host_taxids
 # =======================================================================
 
+
 class TestGetHostTaxids:
     """Test the get_host_taxids function."""
 
@@ -1274,10 +1327,10 @@ class TestGetHostTaxids:
             "human": "9606",
             "vertebrate": "7742",
         }
-        
+
         # Act
         result = get_host_taxids(hosts, host_taxonomy_nodes)
-        
+
         # Assert
         assert result["human"] == {"9606", "741158", "63221"}
         assert result["vertebrate"] == {"7742", "1476529", "7776", "2662825"}
@@ -1287,10 +1340,10 @@ class TestGetHostTaxids:
         # Arrange
         hosts: dict[str, str] = {}
         nodes = pd.DataFrame()
-        
+
         # Act
         result = get_host_taxids(hosts, nodes)
-        
+
         # Assert
         assert result == {}
 
@@ -1299,25 +1352,20 @@ class TestGetHostTaxids:
 # Tests for get_virus_host_mapping
 # =======================================================================
 
+
 class TestGetVirusHostMapping:
     """Test the get_virus_host_mapping function."""
 
     def test_valid_tsv(self, tmp_path: Path) -> None:
         """Test reading valid TSV returns correct mapping."""
         # Arrange
-        tsv_content = (
-            "virus tax id\thost tax id\n"
-            "1\t100\n"
-            "1\t101\n"
-            "2\t200\n"
-            "3\t300"
-        )
+        tsv_content = "virus tax id\thost tax id\n1\t100\n1\t101\n2\t200\n3\t300"
         tsv_file = tmp_path / "virus_host.tsv"
         tsv_file.write_text(tsv_content)
-        
+
         # Act
         result = get_virus_host_mapping(str(tsv_file))
-        
+
         # Assert
         assert result["1"] == {"100", "101"}
         assert result["2"] == {"200"}
@@ -1326,19 +1374,13 @@ class TestGetVirusHostMapping:
     def test_duplicate_entries(self, tmp_path: Path) -> None:
         """Test that duplicate entries are handled correctly."""
         # Arrange
-        tsv_content = (
-            "virus tax id\thost tax id\n"
-            "1\t100\n"
-            "1\t100\n"
-            "1\t101\n"
-            "2\t200"
-        )
+        tsv_content = "virus tax id\thost tax id\n1\t100\n1\t100\n1\t101\n2\t200"
         tsv_file = tmp_path / "virus_host.tsv"
         tsv_file.write_text(tsv_content)
-        
+
         # Act
         result = get_virus_host_mapping(str(tsv_file))
-        
+
         # Assert
         assert result["1"] == {"100", "101"}  # Duplicates removed
         assert result["2"] == {"200"}
@@ -1349,10 +1391,10 @@ class TestGetVirusHostMapping:
         tsv_content = "virus tax id\thost tax id"  # Header only
         tsv_file = tmp_path / "virus_host.tsv"
         tsv_file.write_text(tsv_content)
-        
+
         # Act
         result = get_virus_host_mapping(str(tsv_file))
-        
+
         # Assert
         assert result == {}
 
@@ -1361,28 +1403,48 @@ class TestGetVirusHostMapping:
 # Tests for annotate_virus_db_single
 # =======================================================================
 
+
 class TestAnnotateVirusDbSingle:
     """Test the annotate_virus_db_single function."""
 
-    def test_column_naming(self, sample_virus_db: pd.DataFrame, sample_virus_tree: dict[str, set[str]], monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_column_naming(
+        self,
+        sample_virus_db: pd.DataFrame,
+        sample_virus_tree: dict[str, set[str]],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         """Test that infection status column is named correctly."""
+
         # Mock check_infection since it's a complex function with many dependencies
-        def mock_check_infection(virus_taxids: pd.Series, host_taxids: set[str], virus_tree: dict[str, set[str]], virus_host_mapping: dict[str, set[str]], hard_exclude: list[str]) -> pd.Series:  # type: ignore[type-arg]
+        def mock_check_infection(
+            virus_taxids: pd.Series,
+            host_taxids: set[str],
+            virus_tree: dict[str, set[str]],
+            virus_host_mapping: dict[str, set[str]],
+            hard_exclude: list[str],
+        ) -> pd.Series:  # type: ignore[type-arg]
             return pd.Series([MATCH, INCONSISTENT, UNCLEAR], index=virus_taxids)
-        
-        monkeypatch.setattr("annotate_viral_hosts.check_infection", mock_check_infection)
-        
+
+        monkeypatch.setattr(
+            "annotate_viral_hosts.check_infection", mock_check_infection
+        )
+
         # Arrange
         host_name = "human"
         host_taxids = {"9606"}
         virus_host_mapping: dict[str, set[str]] = {}
         hard_exclude: list[str] = []
-        
+
         # Act
         result = annotate_virus_db_single(
-            sample_virus_db, host_name, host_taxids, sample_virus_tree, virus_host_mapping, hard_exclude
+            sample_virus_db,
+            host_name,
+            host_taxids,
+            sample_virus_tree,
+            virus_host_mapping,
+            hard_exclude,
         )
-        
+
         # Assert
         assert "infection_status_human" in result.columns
         assert list(result["infection_status_human"]) == [MATCH, INCONSISTENT, UNCLEAR]

--- a/modules/local/annotateVirusInfection/resources/usr/bin/test_annotate_viral_hosts.py
+++ b/modules/local/annotateVirusInfection/resources/usr/bin/test_annotate_viral_hosts.py
@@ -50,7 +50,7 @@ State meanings:
 import itertools
 from collections.abc import Callable
 from pathlib import Path
-from typing import Protocol, TypeAlias
+from typing import Protocol
 
 import pandas as pd
 import pytest
@@ -78,8 +78,8 @@ from annotate_viral_hosts import (
 # Type definitions and constants
 # =======================================================================
 
-State: TypeAlias = int
-StateTuple: TypeAlias = tuple[State, ...]
+type State = int
+type StateTuple = tuple[State, ...]
 
 
 class DataFrameFactory(Protocol):

--- a/modules/local/annotateVirusInfection/resources/usr/bin/test_annotate_viral_hosts.py
+++ b/modules/local/annotateVirusInfection/resources/usr/bin/test_annotate_viral_hosts.py
@@ -47,31 +47,31 @@ State meanings:
 # Preamble
 # =======================================================================
 
-from pathlib import Path
-
-import pytest
-import pandas as pd
 import itertools
-from typing import Callable, TypeAlias, Protocol
+from collections.abc import Callable
+from pathlib import Path
+from typing import Protocol, TypeAlias
 
+import pandas as pd
+import pytest
 from annotate_viral_hosts import (
-    mark_ancestor_infections_single,
-    mark_direct_infections,
-    expand_taxid,
-    build_virus_tree,
-    mark_descendant_infections,
-    add_descendants,
-    exclude_infections,
-    mark_ancestor_infections,
-    get_host_taxids,
-    get_virus_host_mapping,
-    annotate_virus_db_single,
+    CONSISTENT,
     INCONSISTENT,
     MATCH,
-    UNCLEAR,
-    CONSISTENT,
-    UNRESOLVED,
     MAYBE_INCONSISTENT,
+    UNCLEAR,
+    UNRESOLVED,
+    add_descendants,
+    annotate_virus_db_single,
+    build_virus_tree,
+    exclude_infections,
+    expand_taxid,
+    get_host_taxids,
+    get_virus_host_mapping,
+    mark_ancestor_infections,
+    mark_ancestor_infections_single,
+    mark_descendant_infections,
+    mark_direct_infections,
 )
 
 # =======================================================================
@@ -176,8 +176,7 @@ def generate_test_id(params: tuple) -> str:
     if len(params) == 5:
         c1, c2, c3, initial_p, expected_p = params
         return f"children({c1},{c2},{c3})-init({initial_p})-expect({expected_p})"
-    else:
-        return str(params)
+    return str(params)
 
 
 # =======================================================================

--- a/modules/local/checkTsvDuplicates/resources/usr/bin/check_tsv_duplicates.py
+++ b/modules/local/checkTsvDuplicates/resources/usr/bin/check_tsv_duplicates.py
@@ -10,12 +10,11 @@ If so, write the file to the output path. If not, throw an error.
 # Import modules
 # =======================================================================
 
-import logging
-from datetime import datetime, timezone
 import argparse
-import time
 import gzip
-import io
+import logging
+import time
+from datetime import UTC, datetime
 from typing import IO, cast
 
 # =======================================================================
@@ -25,7 +24,7 @@ from typing import IO, cast
 
 class UTCFormatter(logging.Formatter):
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
-        dt = datetime.fromtimestamp(record.created, timezone.utc)
+        dt = datetime.fromtimestamp(record.created, UTC)
         return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
@@ -73,8 +72,7 @@ def open_by_suffix(filename: str, mode: str = "r") -> IO[str]:
     logger.debug(f"\tGZIP mode: {filename.endswith('.gz')}")
     if filename.lower().endswith(".gz"):
         return cast(IO[str], gzip.open(filename, mode + "t"))
-    else:
-        return open(filename, mode)
+    return open(filename, mode)
 
 
 # =======================================================================
@@ -148,7 +146,7 @@ def check_duplicates(input_path: str, output_path: str, field: str) -> None:
                 logger.error(msg)
                 raise ValueError(msg)
             # Check if field is duplicate with previous line
-            elif field_prev is not None and field_curr == field_prev:
+            if field_prev is not None and field_curr == field_prev:
                 msg = f"Duplicate value found in field {field}: {field_curr}"
                 logger.error(msg)
                 raise ValueError(msg)

--- a/modules/local/checkTsvDuplicates/resources/usr/bin/check_tsv_duplicates.py
+++ b/modules/local/checkTsvDuplicates/resources/usr/bin/check_tsv_duplicates.py
@@ -6,9 +6,9 @@ every line in the file has a unique value of the specified column.
 If so, write the file to the output path. If not, throw an error.
 """
 
-#=======================================================================
+# =======================================================================
 # Import modules
-#=======================================================================
+# =======================================================================
 
 import logging
 from datetime import datetime, timezone
@@ -18,32 +18,38 @@ import gzip
 import io
 from typing import IO, cast
 
-#=======================================================================
+# =======================================================================
 # Configure logging
-#=======================================================================
+# =======================================================================
+
 
 class UTCFormatter(logging.Formatter):
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
         dt = datetime.fromtimestamp(record.created, timezone.utc)
-        return dt.strftime('%Y-%m-%d %H:%M:%S UTC')
+        return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger()
 handler = logging.StreamHandler()
-formatter = UTCFormatter('[%(asctime)s] %(message)s')
+formatter = UTCFormatter("[%(asctime)s] %(message)s")
 handler.setFormatter(formatter)
 logger.handlers.clear()
 logger.addHandler(handler)
 
-#=======================================================================
+# =======================================================================
 # I/O functions
-#=======================================================================
+# =======================================================================
+
 
 def parse_args() -> argparse.Namespace:
     """Parse command-line arguments."""
     # Create parser
-    desc = "Given a sorted TSV file with an initial header line, " \
-           "check that every line has a unique value of the specified column. " \
-           "If so, write the file to the output path. If not, throw an error."
+    desc = (
+        "Given a sorted TSV file with an initial header line, "
+        "check that every line has a unique value of the specified column. "
+        "If so, write the file to the output path. If not, throw an error."
+    )
     parser = argparse.ArgumentParser(description=desc)
     # Add arguments
     parser.add_argument("--input", "-i", help="Path to sorted input TSV.")
@@ -51,6 +57,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--field", "-f", help="Field to check for duplicates.")
     # Return parsed arguments
     return parser.parse_args()
+
 
 def open_by_suffix(filename: str, mode: str = "r") -> IO[str]:
     """
@@ -65,13 +72,15 @@ def open_by_suffix(filename: str, mode: str = "r") -> IO[str]:
     logger.debug(f"\tOpening mode: {mode}")
     logger.debug(f"\tGZIP mode: {filename.endswith('.gz')}")
     if filename.lower().endswith(".gz"):
-        return cast(IO[str], gzip.open(filename, mode + 't'))
+        return cast(IO[str], gzip.open(filename, mode + "t"))
     else:
         return open(filename, mode)
 
-#=======================================================================
+
+# =======================================================================
 # TSV processing functions
-#=======================================================================
+# =======================================================================
+
 
 def get_header_index(headers: list[str], field: str) -> int:
     """
@@ -86,6 +95,7 @@ def get_header_index(headers: list[str], field: str) -> int:
         return headers.index(field)
     except ValueError:
         raise ValueError(f"Field not found in header: {field}")
+
 
 def process_header(header_line: str, field: str) -> int:
     """
@@ -107,6 +117,7 @@ def process_header(header_line: str, field: str) -> int:
     index = get_header_index(headers_in, field)
     # Return index
     return index
+
 
 def check_duplicates(input_path: str, output_path: str, field: str) -> None:
     """
@@ -146,9 +157,11 @@ def check_duplicates(input_path: str, output_path: str, field: str) -> None:
             # Update previous field
             field_prev = field_curr
 
-#=======================================================================
+
+# =======================================================================
 # Main function
-#=======================================================================
+# =======================================================================
+
 
 def main() -> None:
     logger.info("Initializing script.")
@@ -169,6 +182,7 @@ def main() -> None:
     logger.info("Script completed successfully.")
     end_time = time.time()
     logger.info(f"Total time elapsed: {end_time - start_time} seconds")
+
 
 if __name__ == "__main__":
     main()

--- a/modules/local/checkTsvDuplicates/resources/usr/bin/check_tsv_duplicates.py
+++ b/modules/local/checkTsvDuplicates/resources/usr/bin/check_tsv_duplicates.py
@@ -112,9 +112,8 @@ def process_header(header_line: str, field: str) -> int:
     # Split header line into list of fields
     headers_in = header_line.split("\t")
     # Get index of selected field
-    index = get_header_index(headers_in, field)
+    return get_header_index(headers_in, field)
     # Return index
-    return index
 
 
 def check_duplicates(input_path: str, output_path: str, field: str) -> None:

--- a/modules/local/checkTsvDuplicates/resources/usr/bin/check_tsv_duplicates.py
+++ b/modules/local/checkTsvDuplicates/resources/usr/bin/check_tsv_duplicates.py
@@ -92,7 +92,7 @@ def get_header_index(headers: list[str], field: str) -> int:
     try:
         return headers.index(field)
     except ValueError:
-        raise ValueError(f"Field not found in header: {field}")
+        raise ValueError(f"Field not found in header: {field}") from None
 
 
 def process_header(header_line: str, field: str) -> int:

--- a/modules/local/checkTsvDuplicates/resources/usr/bin/test_check_tsv_duplicates.py
+++ b/modules/local/checkTsvDuplicates/resources/usr/bin/test_check_tsv_duplicates.py
@@ -2,9 +2,8 @@
 
 from typing import Any
 
-import pytest
-
 import check_tsv_duplicates
+import pytest
 
 
 class TestCheckDuplicates:

--- a/modules/local/combineSampleJsons/resources/usr/bin/combine_sample_jsons.py
+++ b/modules/local/combineSampleJsons/resources/usr/bin/combine_sample_jsons.py
@@ -61,9 +61,7 @@ def extract_sample_name(filepath: Path, suffix: str) -> str:
     filename = filepath.name
     expected_ending = f"_{suffix}"
     if not filename.endswith(expected_ending):
-        raise ValueError(
-            f"Filename '{filename}' does not end with '{expected_ending}'"
-        )
+        raise ValueError(f"Filename '{filename}' does not end with '{expected_ending}'")
     return filename[: -len(expected_ending)]
 
 
@@ -90,9 +88,7 @@ def combine_sample_jsons(
     for filepath in sorted(input_files):
         sample = extract_sample_name(filepath, suffix)
         if sample in combined:
-            raise ValueError(
-                f"Duplicate sample name '{sample}' from {filepath.name}"
-            )
+            raise ValueError(f"Duplicate sample name '{sample}' from {filepath.name}")
         with open(filepath) as f:
             data = json.load(f)
         data["sample"] = sample
@@ -152,8 +148,10 @@ def main() -> None:
     start_time = time.time()
     logger.info("Initializing script.")
     args = parse_arguments()
-    logger.info(f"Arguments: group={args.group}, suffix={args.suffix}, "
-                f"output={args.output}, input_files={len(args.input_files)} file(s)")
+    logger.info(
+        f"Arguments: group={args.group}, suffix={args.suffix}, "
+        f"output={args.output}, input_files={len(args.input_files)} file(s)"
+    )
     combined = combine_sample_jsons(args.input_files, args.group, args.suffix)
     with open(args.output, "w") as f:
         json.dump(combined, f, indent=2)

--- a/modules/local/combineSampleJsons/resources/usr/bin/test_combine_sample_jsons.py
+++ b/modules/local/combineSampleJsons/resources/usr/bin/test_combine_sample_jsons.py
@@ -4,9 +4,8 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
 import combine_sample_jsons
+import pytest
 
 
 class TestExtractSampleName:

--- a/modules/local/combineSampleJsons/resources/usr/bin/test_combine_sample_jsons.py
+++ b/modules/local/combineSampleJsons/resources/usr/bin/test_combine_sample_jsons.py
@@ -16,11 +16,17 @@ class TestExtractSampleName:
         "filename,suffix,expected",
         [
             pytest.param("sample_1_fastp.json", "fastp.json", "sample_1", id="simple"),
-            pytest.param("a_b_c_fastp.json", "fastp.json", "a_b_c", id="underscores_in_name"),
-            pytest.param("s1_metrics.json", "metrics.json", "s1", id="different_suffix"),
+            pytest.param(
+                "a_b_c_fastp.json", "fastp.json", "a_b_c", id="underscores_in_name"
+            ),
+            pytest.param(
+                "s1_metrics.json", "metrics.json", "s1", id="different_suffix"
+            ),
         ],
     )
-    def test_extracts_sample_name(self, filename: str, suffix: str, expected: str) -> None:
+    def test_extracts_sample_name(
+        self, filename: str, suffix: str, expected: str
+    ) -> None:
         result = combine_sample_jsons.extract_sample_name(Path(filename), suffix)
         assert result == expected
 
@@ -41,7 +47,9 @@ class TestCombineSampleJsons:
             pytest.param(["s1", "s2", "s3"], id="multiple_samples"),
         ],
     )
-    def test_combines_samples_with_injected_fields(self, tmp_path: Path, sample_names: list[str]) -> None:
+    def test_combines_samples_with_injected_fields(
+        self, tmp_path: Path, sample_names: list[str]
+    ) -> None:
         input_data = {name: {"reads": name} for name in sample_names}
         for name, data in input_data.items():
             (tmp_path / f"{name}_fastp.json").write_text(json.dumps(data))
@@ -78,13 +86,18 @@ class TestMain:
         input_file.write_text(json.dumps({"total": 42}))
         output_file = tmp_path / "output.json"
 
-        mock_argv.extend([
-            "combine_sample_jsons.py",
-            "--group", "g1",
-            "--suffix", "fastp.json",
-            "--output", str(output_file),
-            str(input_file),
-        ])
+        mock_argv.extend(
+            [
+                "combine_sample_jsons.py",
+                "--group",
+                "g1",
+                "--suffix",
+                "fastp.json",
+                "--output",
+                str(output_file),
+                str(input_file),
+            ]
+        )
         combine_sample_jsons.main()
 
         result = json.loads(output_file.read_text())

--- a/modules/local/computeTaxidDistance/resources/usr/bin/compute_taxid_distance.py
+++ b/modules/local/computeTaxidDistance/resources/usr/bin/compute_taxid_distance.py
@@ -98,7 +98,7 @@ def get_header_index(headers: list[str], field: str) -> int:
     try:
         return headers.index(field)
     except ValueError:
-        raise ValueError(f"Field not found in header: {field}")
+        raise ValueError(f"Field not found in header: {field}") from None
 
 
 def join_line(inputs: list[str]) -> str:

--- a/modules/local/computeTaxidDistance/resources/usr/bin/compute_taxid_distance.py
+++ b/modules/local/computeTaxidDistance/resources/usr/bin/compute_taxid_distance.py
@@ -8,9 +8,9 @@ for which one taxid is an ancestor of the other will be given a distance of 0
 in the corresponding distance column.
 """
 
-#=======================================================================
+# =======================================================================
 # Import libraries
-#=======================================================================
+# =======================================================================
 
 import logging
 import argparse
@@ -21,31 +21,35 @@ from dataclasses import dataclass
 from collections import defaultdict
 from typing import IO, TextIO, cast
 
-#=======================================================================
+# =======================================================================
 # Configure logging
-#=======================================================================
+# =======================================================================
+
 
 class UTCFormatter(logging.Formatter):
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
         dt = datetime.fromtimestamp(record.created, timezone.utc)
-        return dt.strftime('%Y-%m-%d %H:%M:%S UTC')
+        return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger()
 handler = logging.StreamHandler()
-formatter = UTCFormatter('[%(asctime)s] %(message)s')
+formatter = UTCFormatter("[%(asctime)s] %(message)s")
 handler.setFormatter(formatter)
 logger.handlers.clear()
 logger.addHandler(handler)
 
-#=======================================================================
+# =======================================================================
 # Define constants
-#=======================================================================
+# =======================================================================
 
 TAXID_ROOT = 1
 
-#=======================================================================
+# =======================================================================
 # I/O functions
-#=======================================================================
+# =======================================================================
+
 
 def parse_args() -> argparse.Namespace:
     """Parse command-line arguments."""
@@ -54,25 +58,42 @@ def parse_args() -> argparse.Namespace:
     # Add arguments
     parser.add_argument("--input", "-i", help="Path to input TSV.")
     parser.add_argument("--output", "-o", help="Path to output TSV.")
-    parser.add_argument("--taxid-field-1", "-t1", help="Column header for first input taxid field.")
-    parser.add_argument("--taxid-field-2", "-t2", help="Column header for second input taxid field.")
-    parser.add_argument("--distance-field-1", "-d1", help="Column header for first output distance field.")
-    parser.add_argument("--distance-field-2", "-d2", help="Column header for second output distance field.")
-    parser.add_argument("--nodes-db", "-n", help="Path to taxonomy nodes DB (raw NCBI nodes.dmp file).")
+    parser.add_argument(
+        "--taxid-field-1", "-t1", help="Column header for first input taxid field."
+    )
+    parser.add_argument(
+        "--taxid-field-2", "-t2", help="Column header for second input taxid field."
+    )
+    parser.add_argument(
+        "--distance-field-1",
+        "-d1",
+        help="Column header for first output distance field.",
+    )
+    parser.add_argument(
+        "--distance-field-2",
+        "-d2",
+        help="Column header for second output distance field.",
+    )
+    parser.add_argument(
+        "--nodes-db", "-n", help="Path to taxonomy nodes DB (raw NCBI nodes.dmp file)."
+    )
     # Return parsed arguments
     return parser.parse_args()
+
 
 def open_by_suffix(filename: str, mode: str = "r", debug: bool = False) -> IO[str]:
     """Parse the suffix of a filename to determine the right open method
     to use, then open the file. Can handle .gz and uncompressed files."""
-    if filename.endswith('.gz'):
-        return cast(IO[str], gzip.open(filename, mode + 't'))
+    if filename.endswith(".gz"):
+        return cast(IO[str], gzip.open(filename, mode + "t"))
     else:
         return open(filename, mode)
 
-#=======================================================================
+
+# =======================================================================
 # TSV processing functions
-#=======================================================================
+# =======================================================================
+
 
 def get_header_index(headers: list[str], field: str) -> int:
     """Get the index of a field in a header line."""
@@ -80,12 +101,16 @@ def get_header_index(headers: list[str], field: str) -> int:
         return headers.index(field)
     except ValueError:
         raise ValueError(f"Field not found in header: {field}")
-    
+
+
 def join_line(inputs: list[str]) -> str:
     """Join a list of strings with tabs followed by a newline."""
     return "\t".join(inputs) + "\n"
 
-def parse_header(header_line: str, fields: list[str]) -> tuple[list[str], dict[str, int]]:
+
+def parse_header(
+    header_line: str, fields: list[str]
+) -> tuple[list[str], dict[str, int]]:
     """
     Parse a TSV header line into a list of fields, and compute the
     indices of a set of expected fields.
@@ -112,19 +137,21 @@ def parse_header(header_line: str, fields: list[str]) -> tuple[list[str], dict[s
     # Return fields and indices
     return header_fields, indices
 
-#=======================================================================
-# Taxonomy functions
-#=======================================================================
 
-def parse_taxid(taxid_str: str) -> int|None:
+# =======================================================================
+# Taxonomy functions
+# =======================================================================
+
+
+def parse_taxid(taxid_str: str) -> int | None:
     """Parse a taxid string into an integer."""
     try:
         return int(taxid_str)
     except ValueError:
         return None
 
-def parse_nodes_db(path: str
-                      ) -> tuple[dict[int, int], dict[int, set[int]]]:
+
+def parse_nodes_db(path: str) -> tuple[dict[int, int], dict[int, set[int]]]:
     """
     Parse taxonomy DB into two dictionaries: one mapping each taxid
     to its parent taxid, and one mapping each taxid to its children taxids.
@@ -147,18 +174,24 @@ def parse_nodes_db(path: str
             child_to_parent[taxid] = parent_taxid
             parent_to_children[parent_taxid].add(taxid)
     # Check that DB contains root as the topmost taxid
-    assert TAXID_ROOT in child_to_parent and TAXID_ROOT in parent_to_children, \
+    assert TAXID_ROOT in child_to_parent and TAXID_ROOT in parent_to_children, (
         "Taxonomy DB does not contain root."
-    assert child_to_parent[TAXID_ROOT] == TAXID_ROOT, "Root taxid has a parent." # NCBI file has root as a child of itself
-    assert TAXID_ROOT in parent_to_children[TAXID_ROOT], "Root taxid must be its own child."
+    )
+    assert child_to_parent[TAXID_ROOT] == TAXID_ROOT, (
+        "Root taxid has a parent."
+    )  # NCBI file has root as a child of itself
+    assert TAXID_ROOT in parent_to_children[TAXID_ROOT], (
+        "Root taxid must be its own child."
+    )
     # Return dictionaries
     return child_to_parent, parent_to_children
 
+
 def path_to_root(
-        taxid: int,
-        child_to_parent: dict[int, int],
-        path_cache: dict[int, list[int]],
-        ) -> tuple[list[int], dict[int, list[int]]]:
+    taxid: int,
+    child_to_parent: dict[int, int],
+    path_cache: dict[int, list[int]],
+) -> tuple[list[int], dict[int, list[int]]]:
     """
     Find the path from a taxid to the root of the taxonomy tree.
     Args:
@@ -175,7 +208,9 @@ def path_to_root(
     assert isinstance(taxid, int), "Taxid must be an integer."
     # If path is already cached, return it
     if taxid in path_cache:
-        logger.debug(f"Path to root for target taxid {taxid} already cached: {path_cache[taxid]}")
+        logger.debug(
+            f"Path to root for target taxid {taxid} already cached: {path_cache[taxid]}"
+        )
         return path_cache[taxid], path_cache
     # Initialize path
     path: list[int] = [taxid]
@@ -189,12 +224,16 @@ def path_to_root(
             parent = child_to_parent[path[-1]]
             # Should not encounter loops before reaching the root
             if parent == path[-1]:
-                msg = f"Taxid {taxid} has a self-loop in the child_to_parent dictionary."
+                msg = (
+                    f"Taxid {taxid} has a self-loop in the child_to_parent dictionary."
+                )
                 logger.error(msg)
                 raise ValueError(msg)
             # Check if path for parent is already cached
             if parent in path_cache:
-                logger.debug(f"Path to root for ancestor taxid {parent} already cached: {path_cache[parent]}")
+                logger.debug(
+                    f"Path to root for ancestor taxid {parent} already cached: {path_cache[parent]}"
+                )
                 path.extend(path_cache[parent])
             # Otherwise, add parent to path
             else:
@@ -210,10 +249,11 @@ def path_to_root(
     logger.debug(f"Path to root for target taxid {taxid}: {path}")
     return path, path_cache
 
+
 def compute_lca(
-        path_1: list[int],
-        path_2: list[int],
-        ) -> int | None:
+    path_1: list[int],
+    path_2: list[int],
+) -> int | None:
     """
     Given paths to root for two taxids, compute the lowest common ancestor.
     Paths are lists of taxids starting with the target taxid and ending with
@@ -231,12 +271,13 @@ def compute_lca(
     else:
         return None
 
+
 def compute_taxonomic_distance(
-        taxid_1: int | None,
-        taxid_2: int | None,
-        child_to_parent: dict[int, int],
-        path_cache: dict[int, list[int]],
-        ) -> tuple[int|None, int|None, dict[int, list[int]]]:
+    taxid_1: int | None,
+    taxid_2: int | None,
+    child_to_parent: dict[int, int],
+    path_cache: dict[int, list[int]],
+) -> tuple[int | None, int | None, dict[int, list[int]]]:
     """
     Compute the taxonomic distance between two taxids as a pair of integers
     specifying the distance between each taxid and their lowest common ancestor.
@@ -263,27 +304,35 @@ def compute_taxonomic_distance(
     # Compute LCA
     lca = compute_lca(path_1, path_2)
     if lca is None:
-        logger.debug(f"No LCA found for taxids {taxid_1} and {taxid_2}; returning None.")
+        logger.debug(
+            f"No LCA found for taxids {taxid_1} and {taxid_2}; returning None."
+        )
         return None, None, path_cache
     logger.debug(f"LCA of taxids {taxid_1} and {taxid_2}: {lca}")
     # Compute taxonomic distance to LCA
     distance_1 = path_1.index(lca)
-    logger.debug(f"Taxonomic distance between taxid {taxid_1} and LCA {lca}: {distance_1}")
+    logger.debug(
+        f"Taxonomic distance between taxid {taxid_1} and LCA {lca}: {distance_1}"
+    )
     distance_2 = path_2.index(lca)
-    logger.debug(f"Taxonomic distance between taxid {taxid_2} and LCA {lca}: {distance_2}")
+    logger.debug(
+        f"Taxonomic distance between taxid {taxid_2} and LCA {lca}: {distance_2}"
+    )
     # Return distances and path cache
     return distance_1, distance_2, path_cache
 
-#=======================================================================
+
+# =======================================================================
 # Functions for processing input and output
-#=======================================================================
+# =======================================================================
+
 
 def process_input_to_output(
-        input_path: str,
-        output_path: str,
-        field_names: dict[str, str],
-        child_to_parent: dict[int, int],
-        ) -> None:
+    input_path: str,
+    output_path: str,
+    field_names: dict[str, str],
+    child_to_parent: dict[int, int],
+) -> None:
     """
     Iterate linewise over input TSV, computing the taxonomic distance
     between the two taxids for each group of entries and writing the result
@@ -317,7 +366,10 @@ def process_input_to_output(
         indices[field_names["distance_2"]] = len(header_fields) + 1
         logger.info(f"Indices of target fields: {indices}")
         # Write output header
-        header_fields_out = header_fields + [field_names["distance_1"], field_names["distance_2"]]
+        header_fields_out = header_fields + [
+            field_names["distance_1"],
+            field_names["distance_2"],
+        ]
         outf.write(join_line(header_fields_out))
         # Process rest of input file
         path_cache: dict[int, list[int]] = {}
@@ -325,14 +377,15 @@ def process_input_to_output(
         for line in inf:
             # If line is empty, break
             if not line.strip():
-                break 
+                break
             # Parse line into fields and extract taxids (parsing non-integer strings as None)
             fields = line.strip().split("\t")
             taxid_1 = parse_taxid(fields[indices[field_names["taxid_1"]]])
             taxid_2 = parse_taxid(fields[indices[field_names["taxid_2"]]])
             # Compute taxonomic distance
             distance_1, distance_2, path_cache = compute_taxonomic_distance(
-                taxid_1, taxid_2, child_to_parent, path_cache)
+                taxid_1, taxid_2, child_to_parent, path_cache
+            )
             # Write output line
             distance_out_1 = str(distance_1) if distance_1 is not None else "NA"
             distance_out_2 = str(distance_2) if distance_2 is not None else "NA"
@@ -342,9 +395,11 @@ def process_input_to_output(
             n_entries += 1
         logger.info(f"Processed {n_entries} entries.")
 
-#=======================================================================
+
+# =======================================================================
 # Main function
-#=======================================================================
+# =======================================================================
+
 
 def main() -> None:
     logger.info("Initializing script.")
@@ -359,10 +414,12 @@ def main() -> None:
     logger.info(f"Parsed taxonomy information for {len(child_to_parent)} taxids.")
     logger.debug(f"Child-to-parent dictionary: {child_to_parent}")
     # Prepare fields dict
-    fields = {"taxid_1": args.taxid_field_1,
-              "taxid_2": args.taxid_field_2,
-              "distance_1": args.distance_field_1,
-              "distance_2": args.distance_field_2}
+    fields = {
+        "taxid_1": args.taxid_field_1,
+        "taxid_2": args.taxid_field_2,
+        "distance_1": args.distance_field_1,
+        "distance_2": args.distance_field_2,
+    }
     logger.info(f"Fields: {fields}")
     # Parse input TSV and compute taxonomic distances
     logger.info("Parsing input TSV and computing taxonomic distances.")
@@ -371,6 +428,7 @@ def main() -> None:
     logger.info("Script completed successfully.")
     end_time = time.time()
     logger.info(f"Total time elapsed: {end_time - start_time} seconds")
+
 
 if __name__ == "__main__":
     main()

--- a/modules/local/computeTaxidDistance/resources/usr/bin/compute_taxid_distance.py
+++ b/modules/local/computeTaxidDistance/resources/usr/bin/compute_taxid_distance.py
@@ -12,14 +12,13 @@ in the corresponding distance column.
 # Import libraries
 # =======================================================================
 
-import logging
 import argparse
-from datetime import datetime, timezone
-import time
 import gzip
-from dataclasses import dataclass
+import logging
+import time
 from collections import defaultdict
-from typing import IO, TextIO, cast
+from datetime import UTC, datetime
+from typing import IO, cast
 
 # =======================================================================
 # Configure logging
@@ -28,7 +27,7 @@ from typing import IO, TextIO, cast
 
 class UTCFormatter(logging.Formatter):
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
-        dt = datetime.fromtimestamp(record.created, timezone.utc)
+        dt = datetime.fromtimestamp(record.created, UTC)
         return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
@@ -86,8 +85,7 @@ def open_by_suffix(filename: str, mode: str = "r", debug: bool = False) -> IO[st
     to use, then open the file. Can handle .gz and uncompressed files."""
     if filename.endswith(".gz"):
         return cast(IO[str], gzip.open(filename, mode + "t"))
-    else:
-        return open(filename, mode)
+    return open(filename, mode)
 
 
 # =======================================================================

--- a/modules/local/computeTaxidDistance/resources/usr/bin/test_compute_taxid_distance.py
+++ b/modules/local/computeTaxidDistance/resources/usr/bin/test_compute_taxid_distance.py
@@ -5,9 +5,8 @@
 
 from typing import Any
 
-import pytest
-
 import compute_taxid_distance
+import pytest
 
 
 class TestComputeTaxidDistance:

--- a/modules/local/computeTaxidDistance/resources/usr/bin/test_compute_taxid_distance.py
+++ b/modules/local/computeTaxidDistance/resources/usr/bin/test_compute_taxid_distance.py
@@ -39,18 +39,14 @@ class TestComputeTaxidDistance:
     @pytest.fixture
     def truncated_nodes_db(self, tsv_factory: Any) -> str:
         """Create a truncated taxonomy nodes database (missing root)."""
-        content = (
-            "9000\t|\t9999\n"
-            "9001\t|\t9000\n"
-        )
+        content = "9000\t|\t9999\n9001\t|\t9000\n"
         result: str = tsv_factory.create_plain("nodes_truncated.dmp", content)
         return result
 
     def test_missing_taxid_field(self, tsv_factory: Any, test_nodes_db: str) -> None:
         """Test that missing taxid field raises ValueError."""
         input_file = tsv_factory.create_plain(
-            "input.tsv",
-            "x\ty\tz\n0\t1\t2\n3\t4\t5\n"
+            "input.tsv", "x\ty\tz\n0\t1\t2\n3\t4\t5\n"
         )
         output_file = tsv_factory.get_path("output.tsv")
 
@@ -58,75 +54,72 @@ class TestComputeTaxidDistance:
             "taxid_1": "x",
             "taxid_2": "a",  # Field 'a' doesn't exist
             "distance_1": "distance_1",
-            "distance_2": "distance_2"
+            "distance_2": "distance_2",
         }
 
         child_to_parent, _ = compute_taxid_distance.parse_nodes_db(test_nodes_db)
 
         with pytest.raises(ValueError, match="Field not found in header: a"):
             compute_taxid_distance.process_input_to_output(
-                input_file,
-                output_file,
-                field_names,
-                child_to_parent
+                input_file, output_file, field_names, child_to_parent
             )
 
-    def test_distance_field_1_already_exists(self, tsv_factory: Any, test_nodes_db: str) -> None:
+    def test_distance_field_1_already_exists(
+        self, tsv_factory: Any, test_nodes_db: str
+    ) -> None:
         """Test that existing distance field 1 raises ValueError."""
-        input_file = tsv_factory.create_plain(
-            "input.tsv",
-            "x\ty\tz\tw\n0\t1\t2\t3\n"
-        )
+        input_file = tsv_factory.create_plain("input.tsv", "x\ty\tz\tw\n0\t1\t2\t3\n")
         output_file = tsv_factory.get_path("output.tsv")
 
         field_names = {
             "taxid_1": "x",
             "taxid_2": "y",
             "distance_1": "z",  # Field 'z' already exists
-            "distance_2": "w"
+            "distance_2": "w",
         }
 
         child_to_parent, _ = compute_taxid_distance.parse_nodes_db(test_nodes_db)
 
-        with pytest.raises(ValueError, match="Distance field already present in input header"):
+        with pytest.raises(
+            ValueError, match="Distance field already present in input header"
+        ):
             compute_taxid_distance.process_input_to_output(
-                input_file,
-                output_file,
-                field_names,
-                child_to_parent
+                input_file, output_file, field_names, child_to_parent
             )
 
-    def test_distance_field_2_already_exists(self, tsv_factory: Any, test_nodes_db: str) -> None:
+    def test_distance_field_2_already_exists(
+        self, tsv_factory: Any, test_nodes_db: str
+    ) -> None:
         """Test that existing distance field 2 raises ValueError."""
-        input_file = tsv_factory.create_plain(
-            "input.tsv",
-            "x\ty\tz\tw\n0\t1\t2\t3\n"
-        )
+        input_file = tsv_factory.create_plain("input.tsv", "x\ty\tz\tw\n0\t1\t2\t3\n")
         output_file = tsv_factory.get_path("output.tsv")
 
         field_names = {
             "taxid_1": "x",
             "taxid_2": "y",
             "distance_1": "w",
-            "distance_2": "z"  # Field 'z' already exists
+            "distance_2": "z",  # Field 'z' already exists
         }
 
         child_to_parent, _ = compute_taxid_distance.parse_nodes_db(test_nodes_db)
 
-        with pytest.raises(ValueError, match="Distance field already present in input header"):
+        with pytest.raises(
+            ValueError, match="Distance field already present in input header"
+        ):
             compute_taxid_distance.process_input_to_output(
-                input_file,
-                output_file,
-                field_names,
-                child_to_parent
+                input_file, output_file, field_names, child_to_parent
             )
 
-    def test_missing_root_in_taxonomy_db(self, tsv_factory: Any, truncated_nodes_db: str) -> None:
+    def test_missing_root_in_taxonomy_db(
+        self, tsv_factory: Any, truncated_nodes_db: str
+    ) -> None:
         """Test that missing root in taxonomy DB raises AssertionError."""
         with pytest.raises(AssertionError, match="Taxonomy DB does not contain root"):
             compute_taxid_distance.parse_nodes_db(truncated_nodes_db)
 
-    def test_empty_input_file_no_header(self, tsv_factory: Any, test_nodes_db: str) -> None:
+    def test_empty_input_file_no_header(
+        self, tsv_factory: Any, test_nodes_db: str
+    ) -> None:
         """Test that empty input file (no header) raises ValueError."""
         input_file = tsv_factory.create_plain("input.tsv", "")
         output_file = tsv_factory.get_path("output.tsv")
@@ -135,41 +128,34 @@ class TestComputeTaxidDistance:
             "taxid_1": "x",
             "taxid_2": "a",
             "distance_1": "distance_1",
-            "distance_2": "distance_2"
+            "distance_2": "distance_2",
         }
 
         child_to_parent, _ = compute_taxid_distance.parse_nodes_db(test_nodes_db)
 
-        with pytest.raises(ValueError, match="Header line is empty: no fields to parse"):
+        with pytest.raises(
+            ValueError, match="Header line is empty: no fields to parse"
+        ):
             compute_taxid_distance.process_input_to_output(
-                input_file,
-                output_file,
-                field_names,
-                child_to_parent
+                input_file, output_file, field_names, child_to_parent
             )
 
     def test_header_only_input(self, tsv_factory: Any, test_nodes_db: str) -> None:
         """Test that input file with header only produces header-only output."""
-        input_file = tsv_factory.create_plain(
-            "input.tsv",
-            "x\ty\n"
-        )
+        input_file = tsv_factory.create_plain("input.tsv", "x\ty\n")
         output_file = tsv_factory.get_path("output.tsv")
 
         field_names = {
             "taxid_1": "x",
             "taxid_2": "y",
             "distance_1": "distance_1",
-            "distance_2": "distance_2"
+            "distance_2": "distance_2",
         }
 
         child_to_parent, _ = compute_taxid_distance.parse_nodes_db(test_nodes_db)
 
         compute_taxid_distance.process_input_to_output(
-            input_file,
-            output_file,
-            field_names,
-            child_to_parent
+            input_file, output_file, field_names, child_to_parent
         )
 
         result = tsv_factory.read_plain(output_file)
@@ -220,16 +206,13 @@ class TestComputeTaxidDistance:
             "taxid_1": "taxid1",
             "taxid_2": "taxid2",
             "distance_1": "distance_1",
-            "distance_2": "distance_2"
+            "distance_2": "distance_2",
         }
 
         child_to_parent, _ = compute_taxid_distance.parse_nodes_db(test_nodes_db)
 
         compute_taxid_distance.process_input_to_output(
-            input_file,
-            output_file,
-            field_names,
-            child_to_parent
+            input_file, output_file, field_names, child_to_parent
         )
 
         result = tsv_factory.read_plain(output_file)

--- a/modules/local/concatenateTsvs/resources/usr/bin/concatenate_tsvs.py
+++ b/modules/local/concatenateTsvs/resources/usr/bin/concatenate_tsvs.py
@@ -2,10 +2,9 @@
 
 # Import modules
 import argparse
-import time
 import datetime
 import gzip
-import os
+import time
 from typing import IO, cast
 
 
@@ -20,8 +19,7 @@ def open_by_suffix(filename: str, mode: str = "r", debug: bool = False) -> IO[st
         print_log(f"\tGZIP mode: {filename.endswith('.gz')}")
     if filename.endswith(".gz"):
         return cast(IO[str], gzip.open(filename, mode + "t"))
-    else:
-        return open(filename, mode)
+    return open(filename, mode)
 
 
 def read_header(infile: IO[str]) -> list[str]:
@@ -48,7 +46,7 @@ def check_headers(header: list[str], reference_header: list[str]) -> bool:
     header_difference = hset ^ rset
     if not header_difference:
         return True
-    msg = f"Headers do not match:"
+    msg = "Headers do not match:"
     if rset - hset:
         msg += f"\n\tMissing fields: {rset - hset}"
     if hset - rset:
@@ -94,7 +92,7 @@ def concatenate_tsvs(input_files: list[str], out_path: str) -> None:
             return
 
         # Parse remaining files (after the first valid file) and write to output
-        print_log(f"\tProcessing other files:")
+        print_log("\tProcessing other files:")
         for input_path in input_files[first_valid_index + 1 :]:
             try:
                 with open_by_suffix(input_path) as inf:
@@ -143,7 +141,7 @@ def main() -> None:
     print_log("Starting process.")
     start_time = time.time()
     # Print parameters
-    print_log("Output TSV file: {}".format(out_path))
+    print_log(f"Output TSV file: {out_path}")
     print_log("Input TSV files:")
     for input_path in input_files:
         print_log(f"\t{input_path}")

--- a/modules/local/concatenateTsvs/resources/usr/bin/concatenate_tsvs.py
+++ b/modules/local/concatenateTsvs/resources/usr/bin/concatenate_tsvs.py
@@ -8,18 +8,21 @@ import gzip
 import os
 from typing import IO, cast
 
+
 def print_log(message: str) -> None:
     print("[", datetime.datetime.now(), "]  ", message, sep="")
+
 
 def open_by_suffix(filename: str, mode: str = "r", debug: bool = False) -> IO[str]:
     if debug:
         print_log(f"\tOpening file object: {filename}")
         print_log(f"\tOpening mode: {mode}")
         print_log(f"\tGZIP mode: {filename.endswith('.gz')}")
-    if filename.endswith('.gz'):
-        return cast(IO[str], gzip.open(filename, mode + 't'))
+    if filename.endswith(".gz"):
+        return cast(IO[str], gzip.open(filename, mode + "t"))
     else:
         return open(filename, mode)
+
 
 def read_header(infile: IO[str]) -> list[str]:
     """Read header from TSV file and return as list.
@@ -30,11 +33,13 @@ def read_header(infile: IO[str]) -> list[str]:
     header = header_line.strip().split("\t")
     return header
 
+
 def map_headers(header: list[str], reference_header: list[str]) -> list[int]:
     """Generate mapping of columns in header to reference header."""
     header_mapping = {col: i for i, col in enumerate(header)}
     reference_mapping = [header_mapping[col] for col in reference_header]
     return reference_mapping
+
 
 def check_headers(header: list[str], reference_header: list[str]) -> bool:
     """Check if fields in two headers match and raise error if not."""
@@ -50,13 +55,14 @@ def check_headers(header: list[str], reference_header: list[str]) -> bool:
         msg += f"\n\tExtra fields: {hset - rset}"
     raise ValueError(msg)
 
+
 def concatenate_tsvs(input_files: list[str], out_path: str) -> None:
     """Concatenate multiple TSV files with matching headers."""
     with open_by_suffix(out_path, "w") as outf:
         # Find the first non-empty file to extract headers
         reference_header = []
         first_valid_index = -1
-        
+
         for idx, input_path in enumerate(input_files):
             try:
                 with open_by_suffix(input_path) as inf:
@@ -65,31 +71,31 @@ def concatenate_tsvs(input_files: list[str], out_path: str) -> None:
                     if not header:
                         print_log(f"Warning: File is empty, skipping: {input_path}")
                         continue
-                    
+
                     reference_header = header
                     first_valid_index = idx
                     print_log(f"\tFound first non-empty file: {input_path}")
-                    
+
                     # Write header to output file
                     outf.write("\t".join(reference_header) + "\n")
-                    
+
                     # Write contents of first valid file to output unchanged
                     for line in inf:
                         outf.write(line)
-                    
+
                     break
             except Exception as e:
                 print_log(f"Error processing file {input_path}: {str(e)}")
                 continue
-        
+
         # If no valid files were found, create an empty output with no header
         if not reference_header:
             print_log("Warning: All input files are empty. Creating empty output file.")
             return
-        
+
         # Parse remaining files (after the first valid file) and write to output
         print_log(f"\tProcessing other files:")
-        for input_path in input_files[first_valid_index + 1:]:
+        for input_path in input_files[first_valid_index + 1 :]:
             try:
                 with open_by_suffix(input_path) as inf:
                     # Extract header information
@@ -97,14 +103,14 @@ def concatenate_tsvs(input_files: list[str], out_path: str) -> None:
                     if not header:
                         print_log(f"Warning: File is empty, skipping: {input_path}")
                         continue
-                    
+
                     # Verify header fields match reference header
                     check_headers(header, reference_header)
-                    
+
                     # Generate mapping of header fields to reference header
                     header_mapping = map_headers(header, reference_header)
                     print_log(f"\t\tProcessing file: {input_path}")
-                    
+
                     # Write contents of file to output with mapped fields
                     for line in inf:
                         fields = line.strip().split("\t")
@@ -114,13 +120,22 @@ def concatenate_tsvs(input_files: list[str], out_path: str) -> None:
                 print_log(f"Error processing file {input_path}: {str(e)}")
                 raise
 
+
 def main() -> None:
     # Parse arguments
-    parser = argparse.ArgumentParser(description="Concatenate multiple TSV files with matching headers.")
-    parser.add_argument("input_files", nargs="+", help="Paths to input TSV files.",
-                        metavar="INPUT", type=str)
-    parser.add_argument("-o", "--output_file", help="Path to output TSV.",
-                        type=str, required=True)
+    parser = argparse.ArgumentParser(
+        description="Concatenate multiple TSV files with matching headers."
+    )
+    parser.add_argument(
+        "input_files",
+        nargs="+",
+        help="Paths to input TSV files.",
+        metavar="INPUT",
+        type=str,
+    )
+    parser.add_argument(
+        "-o", "--output_file", help="Path to output TSV.", type=str, required=True
+    )
     args = parser.parse_args()
     input_files = args.input_files
     out_path = args.output_file
@@ -139,6 +154,7 @@ def main() -> None:
     # Finish time tracking
     end_time = time.time()
     print_log("Total time elapsed: %.2f seconds" % (end_time - start_time))
+
 
 if __name__ == "__main__":
     main()

--- a/modules/local/concatenateTsvs/resources/usr/bin/concatenate_tsvs.py
+++ b/modules/local/concatenateTsvs/resources/usr/bin/concatenate_tsvs.py
@@ -28,15 +28,13 @@ def read_header(infile: IO[str]) -> list[str]:
     header_line = infile.readline()
     if not header_line or not header_line.strip():
         return []
-    header = header_line.strip().split("\t")
-    return header
+    return header_line.strip().split("\t")
 
 
 def map_headers(header: list[str], reference_header: list[str]) -> list[int]:
     """Generate mapping of columns in header to reference header."""
     header_mapping = {col: i for i, col in enumerate(header)}
-    reference_mapping = [header_mapping[col] for col in reference_header]
-    return reference_mapping
+    return [header_mapping[col] for col in reference_header]
 
 
 def check_headers(header: list[str], reference_header: list[str]) -> bool:

--- a/modules/local/concatenateTsvs/resources/usr/bin/test_concatenate_tsvs.py
+++ b/modules/local/concatenateTsvs/resources/usr/bin/test_concatenate_tsvs.py
@@ -2,9 +2,8 @@
 
 from typing import Any
 
-import pytest
-
 import concatenate_tsvs
+import pytest
 
 
 class TestConcatenateTsvs:

--- a/modules/local/conftest.py
+++ b/modules/local/conftest.py
@@ -98,7 +98,9 @@ def temp_file_helper() -> Generator[Any, None, None]:
         def __init__(self) -> None:
             self.temp_dir = tempfile.mkdtemp()
 
-        def create_tsv(self, filename: str, header: list[str], rows: list[list[str]]) -> str:
+        def create_tsv(
+            self, filename: str, header: list[str], rows: list[list[str]]
+        ) -> str:
             """Create a TSV file from header and rows."""
             filepath = os.path.join(self.temp_dir, filename)
             with open(filepath, "w") as f:

--- a/modules/local/conftest.py
+++ b/modules/local/conftest.py
@@ -118,12 +118,12 @@ def temp_file_helper() -> Generator[Any, None, None]:
 
         def read_file(self, filepath: str) -> str:
             """Read content from a file."""
-            with open(filepath, "r") as f:
+            with open(filepath) as f:
                 return f.read()
 
         def read_tsv_lines(self, filepath: str) -> list[str]:
             """Read TSV file and return lines as a list."""
-            with open(filepath, "r") as f:
+            with open(filepath) as f:
                 return [line.strip() for line in f if line.strip()]
 
         def get_path(self, filename: str) -> str:

--- a/modules/local/countReadsPerClade/resources/usr/bin/test_count_reads_per_clade.py
+++ b/modules/local/countReadsPerClade/resources/usr/bin/test_count_reads_per_clade.py
@@ -495,7 +495,9 @@ def test_group_mismatch_error(tsv_factory: Any) -> None:
     reads_file = tsv_factory.create_plain("reads.tsv", reads_content)
 
     # Try to process with wrong group
-    with pytest.raises(AssertionError, match="Expected group 'wrong_group', found 'test'"):
+    with pytest.raises(
+        AssertionError, match="Expected group 'wrong_group', found 'test'"
+    ):
         count_direct_reads_per_taxid(read_tsv(reads_file), "wrong_group")
 
 
@@ -525,7 +527,7 @@ def test_header_only_reads_file(tsv_factory: Any) -> None:
 
     # Read and verify output is header-only
     output_content = tsv_factory.read_gzip(output_file).strip()
-    lines = output_content.split('\n')
+    lines = output_content.split("\n")
 
     # Should have exactly 1 line (header only)
     assert len(lines) == 1

--- a/modules/local/countReadsPerClade/resources/usr/bin/test_count_reads_per_clade.py
+++ b/modules/local/countReadsPerClade/resources/usr/bin/test_count_reads_per_clade.py
@@ -454,7 +454,7 @@ def test_missing_reads_columns(tsv_factory: Any, missing_column: str) -> None:
     # Remove the missing column and its corresponding value
     columns = []
     values = []
-    for col, val in zip(all_columns, test_values):
+    for col, val in zip(all_columns, test_values, strict=False):
         if col != missing_column:
             columns.append(col)
             values.append(val)

--- a/modules/local/countReadsPerClade/resources/usr/bin/test_count_reads_per_clade.py
+++ b/modules/local/countReadsPerClade/resources/usr/bin/test_count_reads_per_clade.py
@@ -454,7 +454,7 @@ def test_missing_reads_columns(tsv_factory: Any, missing_column: str) -> None:
     # Remove the missing column and its corresponding value
     columns = []
     values = []
-    for col, val in zip(all_columns, test_values, strict=False):
+    for col, val in zip(all_columns, test_values, strict=True):
         if col != missing_column:
             columns.append(col)
             values.append(val)

--- a/modules/local/createEmptyGroupOutputs/resources/usr/bin/create_empty_group_outputs.py
+++ b/modules/local/createEmptyGroupOutputs/resources/usr/bin/create_empty_group_outputs.py
@@ -240,7 +240,7 @@ def main() -> None:
     args = parse_args()
     logger.info(f"Arguments: {args}")
     # Parse comma-separated groups
-    groups = set(g.strip() for g in args.missing_groups.split(",") if g.strip())
+    groups = {g.strip() for g in args.missing_groups.split(",") if g.strip()}
     if not groups:
         logger.info("No missing groups provided, nothing to create")
         return

--- a/modules/local/createEmptyGroupOutputs/resources/usr/bin/create_empty_group_outputs.py
+++ b/modules/local/createEmptyGroupOutputs/resources/usr/bin/create_empty_group_outputs.py
@@ -15,12 +15,12 @@ table-schema exists for an output, the file includes a header row.
 import argparse
 import gzip
 import json
-from typing import IO, cast
 import logging
 import time
 import tomllib
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import IO, cast
 
 # =============================================================================
 # Logging
@@ -61,8 +61,7 @@ def open_by_suffix(filename: str | Path, mode: str = "r") -> IO[str]:
     filename_str = str(filename)
     if filename_str.endswith(".gz"):
         return cast(IO[str], gzip.open(filename_str, mode + "t"))
-    else:
-        return open(filename_str, mode)
+    return open(filename_str, mode)
 
 
 # =============================================================================

--- a/modules/local/createEmptyGroupOutputs/resources/usr/bin/create_empty_group_outputs.py
+++ b/modules/local/createEmptyGroupOutputs/resources/usr/bin/create_empty_group_outputs.py
@@ -7,9 +7,9 @@ for each expected per-group output defined in pyproject.toml. When a
 table-schema exists for an output, the file includes a header row.
 """
 
-#=============================================================================
+# =============================================================================
 # Imports
-#=============================================================================
+# =============================================================================
 
 # Standard library imports
 import argparse
@@ -22,9 +22,10 @@ import tomllib
 from datetime import UTC, datetime
 from pathlib import Path
 
-#=============================================================================
+# =============================================================================
 # Logging
-#=============================================================================
+# =============================================================================
+
 
 class UTCFormatter(logging.Formatter):
     """Custom logging formatter that displays timestamps in UTC."""
@@ -34,6 +35,7 @@ class UTCFormatter(logging.Formatter):
         dt = datetime.fromtimestamp(record.created, UTC)
         return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
 
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger()
 handler = logging.StreamHandler()
@@ -42,9 +44,10 @@ handler.setFormatter(formatter)
 logger.handlers.clear()
 logger.addHandler(handler)
 
-#=============================================================================
+# =============================================================================
 # File I/O helpers
-#=============================================================================
+# =============================================================================
+
 
 def open_by_suffix(filename: str | Path, mode: str = "r") -> IO[str]:
     """
@@ -61,9 +64,11 @@ def open_by_suffix(filename: str | Path, mode: str = "r") -> IO[str]:
     else:
         return open(filename_str, mode)
 
-#=============================================================================
+
+# =============================================================================
 # Core functions
-#=============================================================================
+# =============================================================================
+
 
 def get_group_output_patterns(pyproject_path: str, platform: str) -> list[str]:
     """
@@ -76,7 +81,11 @@ def get_group_output_patterns(pyproject_path: str, platform: str) -> list[str]:
     """
     with open(pyproject_path, "rb") as f:
         data = tomllib.load(f)
-    key = "expected-outputs-downstream-ont" if platform == "ont" else "expected-outputs-downstream"
+    key = (
+        "expected-outputs-downstream-ont"
+        if platform == "ont"
+        else "expected-outputs-downstream"
+    )
     outputs: list[str] = data.get("tool", {}).get("mgs-workflow", {}).get(key, [])
     patterns: list[str] = []
     for output in outputs:
@@ -160,7 +169,9 @@ def create_empty_outputs(
     created_files: list[str] = []
     for group in sorted(groups):
         if ".." in group or "/" in group:
-            raise ValueError(f"Invalid group name: '{group}' contains path traversal characters.")
+            raise ValueError(
+                f"Invalid group name: '{group}' contains path traversal characters."
+            )
         for pattern in patterns:
             filename = pattern.replace("{GROUP}", group)
             filepath = output_path / filename
@@ -172,9 +183,11 @@ def create_empty_outputs(
             logger.info(f"Created: {filepath}" + (" (with headers)" if headers else ""))
     return created_files
 
-#=============================================================================
+
+# =============================================================================
 # Argument parsing
-#=============================================================================
+# =============================================================================
+
 
 def parse_args() -> argparse.Namespace:
     """
@@ -215,9 +228,11 @@ def parse_args() -> argparse.Namespace:
     )
     return parser.parse_args()
 
-#=============================================================================
+
+# =============================================================================
 # Main
-#=============================================================================
+# =============================================================================
+
 
 def main() -> None:
     """Main entry point for the script."""
@@ -244,6 +259,7 @@ def main() -> None:
     end_time = time.time()
     logger.info(f"Total time elapsed: {end_time - start_time} seconds")
     logger.info("Script completed successfully.")
+
 
 if __name__ == "__main__":
     main()

--- a/modules/local/createEmptyGroupOutputs/resources/usr/bin/test_create_empty_group_outputs.py
+++ b/modules/local/createEmptyGroupOutputs/resources/usr/bin/test_create_empty_group_outputs.py
@@ -286,7 +286,7 @@ class TestIntegration:
         """Test the complete workflow from comma-separated groups to output files."""
         # Groups as comma-separated string (simulating Nextflow input)
         groups_str = "empty_g1,empty_g2"
-        groups = set(g.strip() for g in groups_str.split(",") if g.strip())
+        groups = {g.strip() for g in groups_str.split(",") if g.strip()}
 
         # Create pyproject.toml
         pyproject_path = tmp_path / "pyproject.toml"

--- a/modules/local/createEmptyGroupOutputs/resources/usr/bin/test_create_empty_group_outputs.py
+++ b/modules/local/createEmptyGroupOutputs/resources/usr/bin/test_create_empty_group_outputs.py
@@ -13,11 +13,14 @@ from create_empty_group_outputs import (
 )
 
 
-#=============================================================================
+# =============================================================================
 # Test helpers
-#=============================================================================
+# =============================================================================
 
-def write_pyproject(path: Path, illumina_outputs: list[str], ont_outputs: list[str]) -> None:
+
+def write_pyproject(
+    path: Path, illumina_outputs: list[str], ont_outputs: list[str]
+) -> None:
     """Write a minimal pyproject.toml with expected outputs."""
     content = "[tool.mgs-workflow]\n"
     content += f"expected-outputs-downstream = {illumina_outputs!r}\n"
@@ -25,9 +28,10 @@ def write_pyproject(path: Path, illumina_outputs: list[str], ont_outputs: list[s
     path.write_text(content)
 
 
-#=============================================================================
+# =============================================================================
 # Tests for open_by_suffix
-#=============================================================================
+# =============================================================================
+
 
 class TestOpenBySuffix:
     """Tests for open_by_suffix function."""
@@ -45,63 +49,83 @@ class TestOpenBySuffix:
             assert f.read() == test_content
 
 
-#=============================================================================
+# =============================================================================
 # Tests for get_group_output_patterns
-#=============================================================================
+# =============================================================================
+
 
 class TestGetGroupOutputPatterns:
     """Tests for get_group_output_patterns function."""
 
-    @pytest.mark.parametrize("platform,illumina,ont,expected", [
-        # Illumina platform extracts illumina patterns
-        (
-            "illumina",
-            ["input/file.csv", "results/{GROUP}_clade.tsv.gz", "results/{GROUP}_dup.tsv.gz"],
-            ["results/{GROUP}_val.tsv.gz"],
-            ["{GROUP}_clade.tsv.gz", "{GROUP}_dup.tsv.gz"],
-        ),
-        # ONT platform extracts ont patterns
-        (
-            "ont",
-            ["results/{GROUP}_clade.tsv.gz"],
-            ["input/file.csv", "results/{GROUP}_val.tsv.gz"],
-            ["{GROUP}_val.tsv.gz"],
-        ),
-        # No {GROUP} patterns returns empty
-        (
-            "illumina",
-            ["input/file.csv", "results/output.tsv"],
-            ["input/file.csv"],
-            [],
-        ),
-    ])
-    def test_extracts_patterns(self, tmp_path: Path, platform: str, illumina: list[str], ont: list[str], expected: list[str]) -> None:
+    @pytest.mark.parametrize(
+        "platform,illumina,ont,expected",
+        [
+            # Illumina platform extracts illumina patterns
+            (
+                "illumina",
+                [
+                    "input/file.csv",
+                    "results/{GROUP}_clade.tsv.gz",
+                    "results/{GROUP}_dup.tsv.gz",
+                ],
+                ["results/{GROUP}_val.tsv.gz"],
+                ["{GROUP}_clade.tsv.gz", "{GROUP}_dup.tsv.gz"],
+            ),
+            # ONT platform extracts ont patterns
+            (
+                "ont",
+                ["results/{GROUP}_clade.tsv.gz"],
+                ["input/file.csv", "results/{GROUP}_val.tsv.gz"],
+                ["{GROUP}_val.tsv.gz"],
+            ),
+            # No {GROUP} patterns returns empty
+            (
+                "illumina",
+                ["input/file.csv", "results/output.tsv"],
+                ["input/file.csv"],
+                [],
+            ),
+        ],
+    )
+    def test_extracts_patterns(
+        self,
+        tmp_path: Path,
+        platform: str,
+        illumina: list[str],
+        ont: list[str],
+        expected: list[str],
+    ) -> None:
         """Test extraction of patterns containing {GROUP}."""
         pyproject_path = tmp_path / "pyproject.toml"
         write_pyproject(pyproject_path, illumina, ont)
         assert get_group_output_patterns(str(pyproject_path), platform) == expected
 
 
-#=============================================================================
+# =============================================================================
 # Tests for get_schema_name_from_pattern
-#=============================================================================
+# =============================================================================
+
 
 class TestGetSchemaNameFromPattern:
     """Tests for get_schema_name_from_pattern function."""
 
-    @pytest.mark.parametrize("pattern,expected", [
-        ("{GROUP}_duplicate_stats.tsv.gz", "duplicate_stats"),
-        ("{GROUP}_clade_counts.tsv.gz", "clade_counts"),
-        ("{GROUP}_validation_hits.tsv.gz", "validation_hits"),
-    ])
+    @pytest.mark.parametrize(
+        "pattern,expected",
+        [
+            ("{GROUP}_duplicate_stats.tsv.gz", "duplicate_stats"),
+            ("{GROUP}_clade_counts.tsv.gz", "clade_counts"),
+            ("{GROUP}_validation_hits.tsv.gz", "validation_hits"),
+        ],
+    )
     def test_extracts_schema_name(self, pattern: str, expected: str) -> None:
         """Test schema name extraction from various patterns."""
         assert get_schema_name_from_pattern(pattern) == expected
 
 
-#=============================================================================
+# =============================================================================
 # Tests for load_schema_headers
-#=============================================================================
+# =============================================================================
+
 
 class TestLoadSchemaHeaders:
     """Tests for load_schema_headers function."""
@@ -132,24 +156,30 @@ class TestLoadSchemaHeaders:
         assert result is None
 
 
-#=============================================================================
+# =============================================================================
 # Tests for create_empty_outputs
-#=============================================================================
+# =============================================================================
+
 
 class TestCreateEmptyOutputs:
     """Tests for create_empty_outputs function."""
 
-    @pytest.mark.parametrize("groups,patterns,expected_count", [
-        # Multiple groups and patterns
-        ({"g1", "g2"}, ["{GROUP}_a.tsv.gz", "{GROUP}_b.tsv.gz"], 4),
-        # Single group, single pattern
-        ({"g1"}, ["{GROUP}_a.tsv.gz"], 1),
-        # Empty groups
-        (set(), ["{GROUP}_a.tsv.gz"], 0),
-        # Empty patterns
-        ({"g1"}, [], 0),
-    ])
-    def test_creates_correct_number_of_files(self, tmp_path: Path, groups: set[str], patterns: list[str], expected_count: int) -> None:
+    @pytest.mark.parametrize(
+        "groups,patterns,expected_count",
+        [
+            # Multiple groups and patterns
+            ({"g1", "g2"}, ["{GROUP}_a.tsv.gz", "{GROUP}_b.tsv.gz"], 4),
+            # Single group, single pattern
+            ({"g1"}, ["{GROUP}_a.tsv.gz"], 1),
+            # Empty groups
+            (set(), ["{GROUP}_a.tsv.gz"], 0),
+            # Empty patterns
+            ({"g1"}, [], 0),
+        ],
+    )
+    def test_creates_correct_number_of_files(
+        self, tmp_path: Path, groups: set[str], patterns: list[str], expected_count: int
+    ) -> None:
         """Test that correct number of files are created."""
         output_dir = tmp_path / "output"
         created = create_empty_outputs(groups, patterns, str(output_dir))
@@ -173,9 +203,10 @@ class TestCreateEmptyOutputs:
         assert output_dir.exists()
 
 
-#=============================================================================
+# =============================================================================
 # Tests for parse_args
-#=============================================================================
+# =============================================================================
+
 
 class TestParseArgs:
     """Tests for parse_args function."""
@@ -203,7 +234,9 @@ class TestParseArgs:
         assert args.missing_groups == ""
 
     @pytest.mark.parametrize("platform", ["illumina", "ont"])
-    def test_parses_platform_option(self, monkeypatch: pytest.MonkeyPatch, platform: str) -> None:
+    def test_parses_platform_option(
+        self, monkeypatch: pytest.MonkeyPatch, platform: str
+    ) -> None:
         """Test parsing of --platform option."""
         monkeypatch.setattr(
             "sys.argv",
@@ -221,7 +254,9 @@ class TestParseArgs:
         args = parse_args()
         assert args.output_dir == "output/"
 
-    def test_parses_pattern_filter_option(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_parses_pattern_filter_option(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test parsing of --pattern-filter option."""
         monkeypatch.setattr(
             "sys.argv",
@@ -231,18 +266,24 @@ class TestParseArgs:
         assert args.pattern_filter == "validation_hits"
 
 
-#=============================================================================
+# =============================================================================
 # Integration tests
-#=============================================================================
+# =============================================================================
+
 
 class TestIntegration:
     """Integration tests for the full workflow."""
 
-    @pytest.mark.parametrize("platform,expected_patterns", [
-        ("illumina", ["{GROUP}_clade.tsv.gz", "{GROUP}_dup.tsv.gz"]),
-        ("ont", ["{GROUP}_val.tsv.gz"]),
-    ])
-    def test_full_workflow(self, tmp_path: Path, platform: str, expected_patterns: list[str]) -> None:
+    @pytest.mark.parametrize(
+        "platform,expected_patterns",
+        [
+            ("illumina", ["{GROUP}_clade.tsv.gz", "{GROUP}_dup.tsv.gz"]),
+            ("ont", ["{GROUP}_val.tsv.gz"]),
+        ],
+    )
+    def test_full_workflow(
+        self, tmp_path: Path, platform: str, expected_patterns: list[str]
+    ) -> None:
         """Test the complete workflow from comma-separated groups to output files."""
         # Groups as comma-separated string (simulating Nextflow input)
         groups_str = "empty_g1,empty_g2"
@@ -252,7 +293,11 @@ class TestIntegration:
         pyproject_path = tmp_path / "pyproject.toml"
         write_pyproject(
             pyproject_path,
-            illumina_outputs=["input/f.csv", "results/{GROUP}_clade.tsv.gz", "results/{GROUP}_dup.tsv.gz"],
+            illumina_outputs=[
+                "input/f.csv",
+                "results/{GROUP}_clade.tsv.gz",
+                "results/{GROUP}_dup.tsv.gz",
+            ],
             ont_outputs=["input/f.csv", "results/{GROUP}_val.tsv.gz"],
         )
 

--- a/modules/local/createEmptyGroupOutputs/resources/usr/bin/test_create_empty_group_outputs.py
+++ b/modules/local/createEmptyGroupOutputs/resources/usr/bin/test_create_empty_group_outputs.py
@@ -4,14 +4,13 @@ from pathlib import Path
 
 import pytest
 from create_empty_group_outputs import (
-    open_by_suffix,
+    create_empty_outputs,
     get_group_output_patterns,
     get_schema_name_from_pattern,
     load_schema_headers,
-    create_empty_outputs,
+    open_by_suffix,
     parse_args,
 )
-
 
 # =============================================================================
 # Test helpers

--- a/modules/local/enumerateChildTaxa/resources/usr/bin/enumerate_child_taxa.py
+++ b/modules/local/enumerateChildTaxa/resources/usr/bin/enumerate_child_taxa.py
@@ -9,9 +9,13 @@ import logging
 import time
 from datetime import UTC, datetime
 
+
 class UTCFormatter(logging.Formatter):
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
-        return datetime.fromtimestamp(record.created, UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
+        return datetime.fromtimestamp(record.created, UTC).strftime(
+            "%Y-%m-%d %H:%M:%S UTC"
+        )
+
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger()
@@ -19,6 +23,7 @@ handler = logging.StreamHandler()
 handler.setFormatter(UTCFormatter("[%(asctime)s] %(message)s"))
 logger.handlers.clear()
 logger.addHandler(handler)
+
 
 def enumerate_children(nodes_path: str, parent_taxid: str) -> list[str]:
     """Find direct child taxids of a given parent in nodes.dmp.
@@ -41,12 +46,16 @@ def enumerate_children(nodes_path: str, parent_taxid: str) -> list[str]:
         children = [parent_taxid]
     return children
 
+
 def parse_arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("nodes_dmp", help="Path to NCBI taxonomy nodes.dmp file.")
     parser.add_argument("parent_taxid", help="Parent taxid to find children for.")
-    parser.add_argument("output", help="Output file path for child taxids (one per line).")
+    parser.add_argument(
+        "output", help="Output file path for child taxids (one per line)."
+    )
     return parser.parse_args()
+
 
 def main() -> None:
     start_time = time.time()
@@ -58,6 +67,7 @@ def main() -> None:
         for taxid in children:
             f.write(taxid + "\n")
     logger.info("Total time elapsed: %.2f seconds", time.time() - start_time)
+
 
 if __name__ == "__main__":
     main()

--- a/modules/local/enumerateChildTaxa/resources/usr/bin/test_enumerate_child_taxa.py
+++ b/modules/local/enumerateChildTaxa/resources/usr/bin/test_enumerate_child_taxa.py
@@ -14,22 +14,35 @@ NODES_DMP_CONTENT = """\
 2847173\t|\t12475\t|\tno rank\t|\t\t|\t0\t|\t1\t|\t11\t|\t1\t|\t0\t|\t1\t|\t0\t|\t0\t|\t\t|
 """
 
+
 @pytest.fixture()
 def nodes_dmp_path(tmp_path: Path) -> Path:
     path = tmp_path / "nodes.dmp"
     path.write_text(NODES_DMP_CONTENT)
     return path
 
+
 class TestEnumerateChildren:
-    @pytest.mark.parametrize(("parent_taxid", "expected"), [
-        ("1", ["10239", "2"]),  # Root: children 2 and 10239 (excl self-ref)
-        ("10239", ["10665", "12475"]),  # Internal node: two children
-        ("12475", ["2847173"]),  # Internal node: one child
-        ("2847173", ["2847173"]),  # Leaf: returns self
-        ("99999", ["99999"]),  # Nonexistent taxid: treated as leaf
-    ], ids=["root", "internal_two_children", "internal_one_child", "leaf", "nonexistent"])
-    def test_enumerate_children(self, nodes_dmp_path: Path, parent_taxid: str,
-                                expected: list[str]) -> None:
+    @pytest.mark.parametrize(
+        ("parent_taxid", "expected"),
+        [
+            ("1", ["10239", "2"]),  # Root: children 2 and 10239 (excl self-ref)
+            ("10239", ["10665", "12475"]),  # Internal node: two children
+            ("12475", ["2847173"]),  # Internal node: one child
+            ("2847173", ["2847173"]),  # Leaf: returns self
+            ("99999", ["99999"]),  # Nonexistent taxid: treated as leaf
+        ],
+        ids=[
+            "root",
+            "internal_two_children",
+            "internal_one_child",
+            "leaf",
+            "nonexistent",
+        ],
+    )
+    def test_enumerate_children(
+        self, nodes_dmp_path: Path, parent_taxid: str, expected: list[str]
+    ) -> None:
         assert sorted(enumerate_children(str(nodes_dmp_path), parent_taxid)) == expected
 
     def test_empty_file(self, tmp_path: Path) -> None:

--- a/modules/local/extractVersions/resources/usr/bin/extract_versions.py
+++ b/modules/local/extractVersions/resources/usr/bin/extract_versions.py
@@ -6,7 +6,7 @@ Extract version information from pyproject.toml files and output as environment 
 
 import argparse
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any
 
 try:
     import tomllib
@@ -19,8 +19,8 @@ class VersionInfo:
     """Version information extracted from a pyproject.toml file."""
 
     version: str
-    min_index_version: Optional[str] = None
-    min_pipeline_version: Optional[str] = None
+    min_index_version: str | None = None
+    min_pipeline_version: str | None = None
 
 
 def parse_args() -> argparse.Namespace:

--- a/modules/local/extractVersions/resources/usr/bin/test_extract_versions.py
+++ b/modules/local/extractVersions/resources/usr/bin/test_extract_versions.py
@@ -30,7 +30,9 @@ class TestGetNestedValue:
             "single_key",
         ],
     )
-    def test_get_nested_value(self, data: dict[str, Any], keys: tuple[str, ...], default: Any, expected: Any) -> None:
+    def test_get_nested_value(
+        self, data: dict[str, Any], keys: tuple[str, ...], default: Any, expected: Any
+    ) -> None:
         """Test retrieving nested values with various inputs."""
         assert get_nested_value(data, *keys, default=default) == expected
 
@@ -84,7 +86,9 @@ class TestExtractVersionInfo:
             "prerelease_tag",
         ],
     )
-    def test_extract_version_info(self, toml_data: dict[str, Any], expected: VersionInfo) -> None:
+    def test_extract_version_info(
+        self, toml_data: dict[str, Any], expected: VersionInfo
+    ) -> None:
         """Test extracting version info from various TOML structures."""
         assert extract_version_info(toml_data) == expected
 
@@ -111,18 +115,33 @@ class TestExtractVersionsIntegration:
             (
                 '[project]\nversion = "2.1.0"\n[tool.mgs-workflow]\npipeline-min-index-version = "1.0.0"',
                 '[project]\nversion = "1.5.0"\n[tool.mgs-workflow]\nindex-min-pipeline-version = "2.0.0"',
-                ["PIPELINE_VERSION=2.1.0", "INDEX_VERSION=1.5.0", "PIPELINE_MIN_INDEX=1.0.0", "INDEX_MIN_PIPELINE=2.0.0"],
+                [
+                    "PIPELINE_VERSION=2.1.0",
+                    "INDEX_VERSION=1.5.0",
+                    "PIPELINE_MIN_INDEX=1.0.0",
+                    "INDEX_MIN_PIPELINE=2.0.0",
+                ],
             ),
             (
                 '[project]\nversion = "1.0.0"',
                 '[project]\nversion = "0.9.0"',
-                ["PIPELINE_VERSION=1.0.0", "INDEX_VERSION=0.9.0", "PIPELINE_MIN_INDEX=", "INDEX_MIN_PIPELINE="],
+                [
+                    "PIPELINE_VERSION=1.0.0",
+                    "INDEX_VERSION=0.9.0",
+                    "PIPELINE_MIN_INDEX=",
+                    "INDEX_MIN_PIPELINE=",
+                ],
             ),
         ],
         ids=["with_optional_fields", "without_optional_fields"],
     )
     def test_extract_versions_output(
-        self, temp_file_helper: Any, capsys: pytest.CaptureFixture[str], pipeline_toml: str, index_toml: str, expected_lines: list[str]
+        self,
+        temp_file_helper: Any,
+        capsys: pytest.CaptureFixture[str],
+        pipeline_toml: str,
+        index_toml: str,
+        expected_lines: list[str],
     ) -> None:
         """Test extracting versions from TOML files."""
         pipeline_file = temp_file_helper.create_file("pipeline.toml", pipeline_toml)

--- a/modules/local/extractVersions/resources/usr/bin/test_extract_versions.py
+++ b/modules/local/extractVersions/resources/usr/bin/test_extract_versions.py
@@ -2,10 +2,9 @@
 
 from typing import Any
 
-import pytest
-
 import extract_versions
-from extract_versions import VersionInfo, get_nested_value, extract_version_info
+import pytest
+from extract_versions import VersionInfo, extract_version_info, get_nested_value
 
 
 class TestGetNestedValue:

--- a/modules/local/extractViralHitsToFastqNoref/resources/usr/bin/extract_viral_hits.py
+++ b/modules/local/extractViralHitsToFastqNoref/resources/usr/bin/extract_viral_hits.py
@@ -7,25 +7,30 @@ import datetime
 import gzip
 from typing import IO, cast
 
+
 def print_log(message: str) -> None:
     print("[", datetime.datetime.now(), "]  ", message, sep="")
+
 
 def open_by_suffix(filename: str, mode: str = "r", debug: bool = False) -> IO[str]:
     if debug:
         print_log(f"\tOpening file object: {filename}")
         print_log(f"\tOpening mode: {mode}")
         print_log(f"\tGZIP mode: {filename.endswith('.gz')}")
-    if filename.endswith('.gz'):
-        return cast(IO[str], gzip.open(filename, mode + 't'))
+    if filename.endswith(".gz"):
+        return cast(IO[str], gzip.open(filename, mode + "t"))
     else:
         return open(filename, mode)
 
-def extract_viral_hit(fields: list[str], indices: dict[str, int], single: bool, drop_unpaired: bool) -> str | None:
+
+def extract_viral_hit(
+    fields: list[str], indices: dict[str, int], single: bool, drop_unpaired: bool
+) -> str | None:
     """Convert a single TSV line to a FASTQ entry, handling missing mates (if not single-end)."""
     # Extract fields
     seq_id = fields[indices["seq_id"]]
     query_seq_fwd = fields[indices["query_seq"]]
-    query_qual_fwd = fields[indices["query_qual"]]        
+    query_qual_fwd = fields[indices["query_qual"]]
     if not single:
         query_seq_rev = fields[indices["query_seq_rev"]]
         query_qual_rev = fields[indices["query_qual_rev"]]
@@ -47,7 +52,7 @@ def extract_viral_hit(fields: list[str], indices: dict[str, int], single: bool, 
     else:
         fastq_entry_rev = f"@{seq_id} 2\n{query_seq_rev}\n+\n{query_qual_rev}\n"
         return fastq_entry_fwd + fastq_entry_rev
-        
+
 
 def extract_viral_hits(input_path: str, out_path: str, drop_unpaired: bool) -> None:
     """Extract viral sequences from TSV file and write to FASTQ file."""
@@ -77,12 +82,23 @@ def extract_viral_hits(input_path: str, out_path: str, drop_unpaired: bool) -> N
             if fastq_entry:
                 outf.write(fastq_entry)
 
+
 def main() -> None:
     # Parse arguments
-    parser = argparse.ArgumentParser(description="Extract viral hits from a TSV to FASTQ file.")
+    parser = argparse.ArgumentParser(
+        description="Extract viral hits from a TSV to FASTQ file."
+    )
     parser.add_argument("--input", "-i", required=True, help="Path to input TSV file.")
-    parser.add_argument("--output", "-o", required=True, help="Path to output FASTQ file.")
-    parser.add_argument("--drop_unpaired", "-d", default=False, action="store_true", help="Drop unpaired reads. (Default: False)")
+    parser.add_argument(
+        "--output", "-o", required=True, help="Path to output FASTQ file."
+    )
+    parser.add_argument(
+        "--drop_unpaired",
+        "-d",
+        default=False,
+        action="store_true",
+        help="Drop unpaired reads. (Default: False)",
+    )
     args = parser.parse_args()
     input_path = args.input
     out_path = args.output
@@ -101,6 +117,7 @@ def main() -> None:
     # Finish time tracking
     end_time = time.time()
     print_log("Total time elapsed: %.2f seconds" % (end_time - start_time))
+
 
 if __name__ == "__main__":
     main()

--- a/modules/local/extractViralHitsToFastqNoref/resources/usr/bin/extract_viral_hits.py
+++ b/modules/local/extractViralHitsToFastqNoref/resources/usr/bin/extract_viral_hits.py
@@ -2,9 +2,9 @@
 
 # Import modules
 import argparse
-import time
 import datetime
 import gzip
+import time
 from typing import IO, cast
 
 
@@ -19,8 +19,7 @@ def open_by_suffix(filename: str, mode: str = "r", debug: bool = False) -> IO[st
         print_log(f"\tGZIP mode: {filename.endswith('.gz')}")
     if filename.endswith(".gz"):
         return cast(IO[str], gzip.open(filename, mode + "t"))
-    else:
-        return open(filename, mode)
+    return open(filename, mode)
 
 
 def extract_viral_hit(
@@ -49,9 +48,8 @@ def extract_viral_hit(
     fastq_entry_fwd = f"@{seq_id} 1\n{query_seq_fwd}\n+\n{query_qual_fwd}\n"
     if single:
         return fastq_entry_fwd
-    else:
-        fastq_entry_rev = f"@{seq_id} 2\n{query_seq_rev}\n+\n{query_qual_rev}\n"
-        return fastq_entry_fwd + fastq_entry_rev
+    fastq_entry_rev = f"@{seq_id} 2\n{query_seq_rev}\n+\n{query_qual_rev}\n"
+    return fastq_entry_fwd + fastq_entry_rev
 
 
 def extract_viral_hits(input_path: str, out_path: str, drop_unpaired: bool) -> None:
@@ -107,9 +105,9 @@ def main() -> None:
     print_log("Starting process.")
     start_time = time.time()
     # Print parameters
-    print_log("Input TSV file: {}".format(input_path))
-    print_log("Output FASTQ file: {}".format(out_path))
-    print_log("Drop unpaired reads: {}".format(drop_unpaired))
+    print_log(f"Input TSV file: {input_path}")
+    print_log(f"Output FASTQ file: {out_path}")
+    print_log(f"Drop unpaired reads: {drop_unpaired}")
     # Run labeling function
     print_log("Extracting viral hits...")
     extract_viral_hits(input_path, out_path, drop_unpaired)

--- a/modules/local/filterBlast/resources/usr/bin/filter_blast.py
+++ b/modules/local/filterBlast/resources/usr/bin/filter_blast.py
@@ -2,10 +2,9 @@
 
 # Import modules
 import argparse
-import time
 import datetime
 import gzip
-import os
+import time
 from typing import IO, cast
 
 
@@ -20,8 +19,7 @@ def open_by_suffix(filename: str, mode: str = "r", debug: bool = False) -> IO[st
         print_log(f"\tGZIP mode: {filename.endswith('.gz')}")
     if filename.endswith(".gz"):
         return cast(IO[str], gzip.open(filename, mode + "t"))
-    else:
-        return open(filename, mode)
+    return open(filename, mode)
 
 
 def write_line(line_list: list[str], output_file: IO[str]) -> None:
@@ -167,12 +165,12 @@ def main() -> None:
     print_log("Starting process.")
     start_time = time.time()
     # Print parameters
-    print_log("Input file: {}".format(input_path))
-    print_log("Output file: {}".format(output_path))
-    print_log("Maximum rank: {}".format(max_rank))
-    print_log("Minimum fraction: {}".format(min_frac))
-    print_log("Query index: {}".format(query_index))
-    print_log("Bitscore index: {}".format(bitscore_index))
+    print_log(f"Input file: {input_path}")
+    print_log(f"Output file: {output_path}")
+    print_log(f"Maximum rank: {max_rank}")
+    print_log(f"Minimum fraction: {min_frac}")
+    print_log(f"Query index: {query_index}")
+    print_log(f"Bitscore index: {bitscore_index}")
     # Run filtering function
     filter_blast(
         input_path, output_path, max_rank, min_frac, query_index, bitscore_index

--- a/modules/local/filterBlast/resources/usr/bin/filter_blast.py
+++ b/modules/local/filterBlast/resources/usr/bin/filter_blast.py
@@ -8,33 +8,64 @@ import gzip
 import os
 from typing import IO, cast
 
+
 def print_log(message: str) -> None:
     print("[", datetime.datetime.now(), "]  ", message, sep="")
+
 
 def open_by_suffix(filename: str, mode: str = "r", debug: bool = False) -> IO[str]:
     if debug:
         print_log(f"\tOpening file object: {filename}")
         print_log(f"\tOpening mode: {mode}")
         print_log(f"\tGZIP mode: {filename.endswith('.gz')}")
-    if filename.endswith('.gz'):
-        return cast(IO[str], gzip.open(filename, mode + 't'))
+    if filename.endswith(".gz"):
+        return cast(IO[str], gzip.open(filename, mode + "t"))
     else:
         return open(filename, mode)
+
 
 def write_line(line_list: list[str], output_file: IO[str]) -> None:
     """Write a line to the output file."""
     output_file.write("\t".join(line_list) + "\n")
 
-def filter_blast(input_path: str, output_path: str, max_rank: int, min_frac: float, query_index: int, bitscore_index: int) -> None:
+
+def filter_blast(
+    input_path: str,
+    output_path: str,
+    max_rank: int,
+    min_frac: float,
+    query_index: int,
+    bitscore_index: int,
+) -> None:
     """Filter BLAST input based on query ID and bitscore."""
     max_field = max(query_index, bitscore_index)
     # Open files
-    with open_by_suffix(input_path, "r") as inf, open_by_suffix(output_path, "w") as outf:
+    with (
+        open_by_suffix(input_path, "r") as inf,
+        open_by_suffix(output_path, "w") as outf,
+    ):
         # Write header line
-        header_fields = ["qseqid", "sseqid", "sgi", "staxid", "qlen", "evalue",
-                         "bitscore", "qcovs", "length", "pident", "mismatch",
-                         "gapopen", "sstrand", "qstart", "qend", "sstart", "send",
-                         "bitscore_rank_dense", "bitscore_fraction"]
+        header_fields = [
+            "qseqid",
+            "sseqid",
+            "sgi",
+            "staxid",
+            "qlen",
+            "evalue",
+            "bitscore",
+            "qcovs",
+            "length",
+            "pident",
+            "mismatch",
+            "gapopen",
+            "sstrand",
+            "qstart",
+            "qend",
+            "sstart",
+            "send",
+            "bitscore_rank_dense",
+            "bitscore_fraction",
+        ]
         write_line(header_fields, outf)
         # Read and process lines
         line = inf.readline()
@@ -83,15 +114,47 @@ def filter_blast(input_path: str, output_path: str, max_rank: int, min_frac: flo
             write_line(out_fields, outf)
             line = inf.readline()
 
+
 def main() -> None:
     # Parse arguments
-    parser = argparse.ArgumentParser(description="Filter sorted BLAST output by query ID (ascending) and bitscore (descending).")
-    parser.add_argument("--input", "-i", type=str, help="Path to input TSV file containing sorted BLAST output.")
+    parser = argparse.ArgumentParser(
+        description="Filter sorted BLAST output by query ID (ascending) and bitscore (descending)."
+    )
+    parser.add_argument(
+        "--input",
+        "-i",
+        type=str,
+        help="Path to input TSV file containing sorted BLAST output.",
+    )
     parser.add_argument("--output", "-o", type=str, help="Path to output TSV file.")
-    parser.add_argument("--max_rank", "-r", type=int, default=1, help="Maximum rank of hits to keep for each query.")
-    parser.add_argument("--min_frac", "-f", type=float, default=0.9, help="Minimum fraction of maximum bitscore to keep for each query.")
-    parser.add_argument("--query_index", "-q", type=int, default=0, help="Index of the query ID column (0-based).")
-    parser.add_argument("--bitscore_index", "-b", type=int, default=6, help="Index of the bitscore column (0-based).")
+    parser.add_argument(
+        "--max_rank",
+        "-r",
+        type=int,
+        default=1,
+        help="Maximum rank of hits to keep for each query.",
+    )
+    parser.add_argument(
+        "--min_frac",
+        "-f",
+        type=float,
+        default=0.9,
+        help="Minimum fraction of maximum bitscore to keep for each query.",
+    )
+    parser.add_argument(
+        "--query_index",
+        "-q",
+        type=int,
+        default=0,
+        help="Index of the query ID column (0-based).",
+    )
+    parser.add_argument(
+        "--bitscore_index",
+        "-b",
+        type=int,
+        default=6,
+        help="Index of the bitscore column (0-based).",
+    )
     args = parser.parse_args()
     # Assign variables
     input_path = args.input
@@ -111,10 +174,13 @@ def main() -> None:
     print_log("Query index: {}".format(query_index))
     print_log("Bitscore index: {}".format(bitscore_index))
     # Run filtering function
-    filter_blast(input_path, output_path, max_rank, min_frac, query_index, bitscore_index)
+    filter_blast(
+        input_path, output_path, max_rank, min_frac, query_index, bitscore_index
+    )
     # Finish time tracking
     end_time = time.time()
     print_log("Total time elapsed: %.2f seconds" % (end_time - start_time))
+
 
 if __name__ == "__main__":
     main()

--- a/modules/local/filterTsvColumnByValue/resources/usr/bin/filter_tsv_column_by_value.py
+++ b/modules/local/filterTsvColumnByValue/resources/usr/bin/filter_tsv_column_by_value.py
@@ -215,7 +215,9 @@ def stream_and_filter_tsv(
     """
     logger.info("Initializing streaming TSV reader and writer")
     reader = csv.reader(input_file, delimiter="\t", quotechar=None)
-    writer = csv.writer(output_file, delimiter="\t", lineterminator="\n", quotechar=None)
+    writer = csv.writer(
+        output_file, delimiter="\t", lineterminator="\n", quotechar=None
+    )
     # Read and validate header
     try:
         header = next(reader)
@@ -242,7 +244,9 @@ def stream_and_filter_tsv(
         try:
             # Validate row
             if len(row) != len(header):
-                raise ValueError(f"Row has {len(row)} columns but header has {len(header)} columns")
+                raise ValueError(
+                    f"Row has {len(row)} columns but header has {len(header)} columns"
+                )
             cell_value = row[column_index]
             converted_cell_value = convert_value(cell_value)
             matches = converted_cell_value == filter_value

--- a/modules/local/filterTsvColumnByValue/resources/usr/bin/filter_tsv_column_by_value.py
+++ b/modules/local/filterTsvColumnByValue/resources/usr/bin/filter_tsv_column_by_value.py
@@ -9,13 +9,13 @@ Treats quote characters as regular characters, not as delimiters.
 # Preamble
 # =======================================================================
 
-import logging
 import argparse
 import csv
-import sys
 import gzip
-from typing import IO, TextIO, Any, Union, cast
-from datetime import datetime, timezone
+import logging
+import sys
+from datetime import UTC, datetime
+from typing import IO, Any, TextIO, cast
 
 
 # Configure logging
@@ -38,7 +38,7 @@ class UTCFormatter(logging.Formatter):
         Returns:
             Formatted timestamp string in UTC
         """
-        dt = datetime.fromtimestamp(record.created, timezone.utc)
+        dt = datetime.fromtimestamp(record.created, UTC)
         return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
@@ -69,8 +69,7 @@ def open_by_suffix(filename: str, mode: str = "r") -> IO[str]:
     """
     if filename.endswith(".gz"):
         return cast(IO[str], gzip.open(filename, mode + "t"))
-    else:
-        return open(filename, mode)
+    return open(filename, mode)
 
 
 def parse_args() -> argparse.Namespace:
@@ -155,7 +154,7 @@ def validate_input_columns(
     return column_index
 
 
-def convert_value(value_str: str) -> Union[str, bool, int, float]:
+def convert_value(value_str: str) -> str | bool | int | float:
     """
     Convert string value to appropriate type (bool, int, float, or str).
 

--- a/modules/local/filterTsvColumnByValue/resources/usr/bin/test_filter_tsv_column_by_value.py
+++ b/modules/local/filterTsvColumnByValue/resources/usr/bin/test_filter_tsv_column_by_value.py
@@ -28,9 +28,8 @@ class TestFilterTsvColumnByValue:
                 "test_column",
                 "test_value",
                 keep_matching=True,
-                logger=logger
+                logger=logger,
             )
-
 
         result = tsv_factory.read_plain(output_file)
         assert result == ""
@@ -45,12 +44,7 @@ class TestFilterTsvColumnByValue:
 
         with open(input_file, "r") as inf, open(output_file, "w") as outf:
             filter_tsv_column_by_value.stream_and_filter_tsv(
-                inf,
-                outf,
-                "x",
-                "test_value",
-                keep_matching=True,
-                logger=logger
+                inf, outf, "x", "test_value", keep_matching=True, logger=logger
             )
 
         result = tsv_factory.read_plain(output_file)
@@ -64,7 +58,9 @@ class TestFilterTsvColumnByValue:
 
         logger = logging.getLogger()
 
-        with pytest.raises(ValueError, match="Column 'nonexistent_column' not found in header"):
+        with pytest.raises(
+            ValueError, match="Column 'nonexistent_column' not found in header"
+        ):
             with open(input_file, "r") as inf, open(output_file, "w") as outf:
                 filter_tsv_column_by_value.stream_and_filter_tsv(
                     inf,
@@ -72,7 +68,7 @@ class TestFilterTsvColumnByValue:
                     "nonexistent_column",
                     "false",
                     keep_matching=True,
-                    logger=logger
+                    logger=logger,
                 )
 
     def test_filter_keep_no_rows(self, tsv_factory: Any) -> None:
@@ -90,7 +86,7 @@ class TestFilterTsvColumnByValue:
                 "x",
                 5,  # No rows have x=5
                 keep_matching=True,
-                logger=logger
+                logger=logger,
             )
 
         result = tsv_factory.read_plain(output_file)
@@ -115,7 +111,7 @@ class TestFilterTsvColumnByValue:
                 "x",
                 6,  # Only one row has x=6
                 keep_matching=True,
-                logger=logger
+                logger=logger,
             )
 
         result = tsv_factory.read_plain(output_file)
@@ -141,7 +137,7 @@ class TestFilterTsvColumnByValue:
                 "x",
                 6,  # Discard the row with x=6
                 keep_matching=False,
-                logger=logger
+                logger=logger,
             )
 
         result = tsv_factory.read_plain(output_file)
@@ -158,7 +154,7 @@ class TestFilterTsvColumnByValue:
         for line in lines[1:]:
             fields = line.split("\t")
             assert int(fields[0]) != 6
-    
+
     def test_filter_lines_with_quotes(self, tsv_factory: Any) -> None:
         """Should correctly handle fields with quotes (regression test)."""
         input_content = 'x\ty\tz\n"0"\t"1"\t"2"\n"0"\t"3"\t"4"\n'
@@ -167,12 +163,7 @@ class TestFilterTsvColumnByValue:
         logger = logging.getLogger()
         with open(input_file, "r") as inf, open(output_file, "w") as outf:
             filter_tsv_column_by_value.stream_and_filter_tsv(
-                inf,
-                outf,
-                "x",
-                '"0"',
-                keep_matching=True,
-                logger=logger
+                inf, outf, "x", '"0"', keep_matching=True, logger=logger
             )
         result = tsv_factory.read_plain(output_file)
         assert result == input_content

--- a/modules/local/filterTsvColumnByValue/resources/usr/bin/test_filter_tsv_column_by_value.py
+++ b/modules/local/filterTsvColumnByValue/resources/usr/bin/test_filter_tsv_column_by_value.py
@@ -2,12 +2,11 @@
 
 # TODO: Add unit tests for individual functions in a future pass
 
+import logging
 from typing import Any
 
-import pytest
-import logging
-
 import filter_tsv_column_by_value
+import pytest
 
 
 class TestFilterTsvColumnByValue:
@@ -21,7 +20,7 @@ class TestFilterTsvColumnByValue:
         # Mock logger
         logger = logging.getLogger()
 
-        with open(input_file, "r") as inf, open(output_file, "w") as outf:
+        with open(input_file) as inf, open(output_file, "w") as outf:
             filter_tsv_column_by_value.stream_and_filter_tsv(
                 inf,
                 outf,
@@ -42,7 +41,7 @@ class TestFilterTsvColumnByValue:
 
         logger = logging.getLogger()
 
-        with open(input_file, "r") as inf, open(output_file, "w") as outf:
+        with open(input_file) as inf, open(output_file, "w") as outf:
             filter_tsv_column_by_value.stream_and_filter_tsv(
                 inf, outf, "x", "test_value", keep_matching=True, logger=logger
             )
@@ -58,18 +57,21 @@ class TestFilterTsvColumnByValue:
 
         logger = logging.getLogger()
 
-        with pytest.raises(
-            ValueError, match="Column 'nonexistent_column' not found in header"
+        with (
+            pytest.raises(
+                ValueError, match="Column 'nonexistent_column' not found in header"
+            ),
+            open(input_file) as inf,
+            open(output_file, "w") as outf,
         ):
-            with open(input_file, "r") as inf, open(output_file, "w") as outf:
-                filter_tsv_column_by_value.stream_and_filter_tsv(
-                    inf,
-                    outf,
-                    "nonexistent_column",
-                    "false",
-                    keep_matching=True,
-                    logger=logger,
-                )
+            filter_tsv_column_by_value.stream_and_filter_tsv(
+                inf,
+                outf,
+                "nonexistent_column",
+                "false",
+                keep_matching=True,
+                logger=logger,
+            )
 
     def test_filter_keep_no_rows(self, tsv_factory: Any) -> None:
         """Test filtering that removes all rows (keep_matching=True, no matching values)."""
@@ -79,7 +81,7 @@ class TestFilterTsvColumnByValue:
 
         logger = logging.getLogger()
 
-        with open(input_file, "r") as inf, open(output_file, "w") as outf:
+        with open(input_file) as inf, open(output_file, "w") as outf:
             filter_tsv_column_by_value.stream_and_filter_tsv(
                 inf,
                 outf,
@@ -104,7 +106,7 @@ class TestFilterTsvColumnByValue:
 
         logger = logging.getLogger()
 
-        with open(input_file, "r") as inf, open(output_file, "w") as outf:
+        with open(input_file) as inf, open(output_file, "w") as outf:
             filter_tsv_column_by_value.stream_and_filter_tsv(
                 inf,
                 outf,
@@ -130,7 +132,7 @@ class TestFilterTsvColumnByValue:
 
         logger = logging.getLogger()
 
-        with open(input_file, "r") as inf, open(output_file, "w") as outf:
+        with open(input_file) as inf, open(output_file, "w") as outf:
             filter_tsv_column_by_value.stream_and_filter_tsv(
                 inf,
                 outf,
@@ -161,7 +163,7 @@ class TestFilterTsvColumnByValue:
         input_file = tsv_factory.create_plain("input.tsv", input_content)
         output_file = tsv_factory.get_path("output.tsv")
         logger = logging.getLogger()
-        with open(input_file, "r") as inf, open(output_file, "w") as outf:
+        with open(input_file) as inf, open(output_file, "w") as outf:
             filter_tsv_column_by_value.stream_and_filter_tsv(
                 inf, outf, "x", '"0"', keep_matching=True, logger=logger
             )

--- a/modules/local/filterViralGenbankMetadata/resources/usr/bin/filter-viral-genbank-metadata.py
+++ b/modules/local/filterViralGenbankMetadata/resources/usr/bin/filter-viral-genbank-metadata.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-#=======================================================================
+# =======================================================================
 # Preamble
-#=======================================================================
+# =======================================================================
 
 # Import libraries
 import pandas as pd
@@ -10,33 +10,49 @@ import argparse
 import logging
 from datetime import datetime, timezone
 
+
 # Configure logging
 class UTCFormatter(logging.Formatter):
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
         dt = datetime.fromtimestamp(record.created, timezone.utc)
-        return dt.strftime('%Y-%m-%d %H:%M:%S UTC')
+        return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger()
 handler = logging.StreamHandler()
-formatter = UTCFormatter('[%(asctime)s] %(message)s')
+formatter = UTCFormatter("[%(asctime)s] %(message)s")
 handler.setFormatter(formatter)
 logger.handlers.clear()
 logger.addHandler(handler)
 
-#=======================================================================
+# =======================================================================
 # Main function
-#=======================================================================
+# =======================================================================
+
 
 def main() -> None:
     logger.info("Initializing script.")
     # Define argument parsing
-    parser = argparse.ArgumentParser(description="Filter a ncbi-genome-download viral metadata TSV by host infection status.")
-    parser.add_argument("meta_db", help="Path to metadata table from ncbi-genome-download.")
-    parser.add_argument("virus_db", help="Path to TSV of virus taxa, annotated with infection status.")
-    parser.add_argument("host_taxa", help="Space-separated list of host taxon names to filter to.")
+    parser = argparse.ArgumentParser(
+        description="Filter a ncbi-genome-download viral metadata TSV by host infection status."
+    )
+    parser.add_argument(
+        "meta_db", help="Path to metadata table from ncbi-genome-download."
+    )
+    parser.add_argument(
+        "virus_db", help="Path to TSV of virus taxa, annotated with infection status."
+    )
+    parser.add_argument(
+        "host_taxa", help="Space-separated list of host taxon names to filter to."
+    )
     parser.add_argument("output_db", help="Output path to filtered metadata TSV.")
-    parser.add_argument("output_accessions", help="Output path to filtered list of genome accessions.")
-    parser.add_argument("output_paths", help="Output path to filtered list of genome filepaths.")
+    parser.add_argument(
+        "output_accessions", help="Output path to filtered list of genome accessions."
+    )
+    parser.add_argument(
+        "output_paths", help="Output path to filtered list of genome filepaths."
+    )
     args = parser.parse_args()
     # Import inputs
     logger.info("Importing input TSVs.")
@@ -50,13 +66,21 @@ def main() -> None:
     virus_taxids = virus_db[screen_status]["taxid"].reset_index(drop=True)
     # Filter metadata DB by screening taxa
     logger.info("Filtering metadata table to those virus taxids.")
-    meta_db_filtered = meta_db.loc[(meta_db["taxid"].isin(virus_taxids)) | (meta_db["species_taxid"].isin(virus_taxids))]
+    meta_db_filtered = meta_db.loc[
+        (meta_db["taxid"].isin(virus_taxids))
+        | (meta_db["species_taxid"].isin(virus_taxids))
+    ]
     # Write output
     logger.info("Writing output.")
     meta_db_filtered.to_csv(args.output_db, sep="\t", index=False)
-    meta_db_filtered["assembly_accession"].to_csv(args.output_accessions, index=False, header=False)
-    meta_db_filtered["local_filename"].to_csv(args.output_paths, index=False, header=False)
+    meta_db_filtered["assembly_accession"].to_csv(
+        args.output_accessions, index=False, header=False
+    )
+    meta_db_filtered["local_filename"].to_csv(
+        args.output_paths, index=False, header=False
+    )
     logger.info("Script complete.")
+
 
 if __name__ == "__main__":
     main()

--- a/modules/local/filterViralGenbankMetadata/resources/usr/bin/filter-viral-genbank-metadata.py
+++ b/modules/local/filterViralGenbankMetadata/resources/usr/bin/filter-viral-genbank-metadata.py
@@ -5,16 +5,17 @@
 # =======================================================================
 
 # Import libraries
-import pandas as pd
 import argparse
 import logging
-from datetime import datetime, timezone
+from datetime import UTC, datetime
+
+import pandas as pd
 
 
 # Configure logging
 class UTCFormatter(logging.Formatter):
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
-        dt = datetime.fromtimestamp(record.created, timezone.utc)
+        dt = datetime.fromtimestamp(record.created, UTC)
         return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
 
 

--- a/modules/local/filterViralSam/resources/usr/bin/filter_viral_sam.py
+++ b/modules/local/filterViralSam/resources/usr/bin/filter_viral_sam.py
@@ -300,7 +300,9 @@ def group_unpaired_alignments(
     for group_id, group_alignments in by_group.items():
         if len(group_alignments) > 1:
             group_alignments.sort(key=lambda a: a.alignment_score or 0, reverse=True)
-            logger.debug(f"Group {group_id}: deduplicated {len(group_alignments)} to 1 alignment")
+            logger.debug(
+                f"Group {group_id}: deduplicated {len(group_alignments)} to 1 alignment"
+            )
         filtered_groups[group_id] = [group_alignments[0]]
     return filtered_groups
 
@@ -334,10 +336,23 @@ def group_other_alignments(
         pos_max = max(alignment.pos, alignment.pnext)
         abs_tlen = abs(alignment.tlen)
         # For paired alignments (CP/DP), both scores must be present
-        assert alignment.alignment_score is not None and alignment.mate_alignment_score is not None, \
+        assert (
+            alignment.alignment_score is not None
+            and alignment.mate_alignment_score is not None
+        ), (
             f"Paired alignment missing scores: AS={alignment.alignment_score}, YS={alignment.mate_alignment_score}"
-        score_key = tuple(sorted((alignment.alignment_score, alignment.mate_alignment_score)))
-        pair_key = (alignment.rname, alignment.rnext, pos_min, pos_max, abs_tlen, score_key)
+        )
+        score_key = tuple(
+            sorted((alignment.alignment_score, alignment.mate_alignment_score))
+        )
+        pair_key = (
+            alignment.rname,
+            alignment.rnext,
+            pos_min,
+            pos_max,
+            abs_tlen,
+            score_key,
+        )
         # If the key hasn't been seen before, then this alignment is put into a new group, and recieves a new group ID
         if pair_key not in pair_key_to_group:
             pair_key_to_group[pair_key] = group_idx
@@ -355,10 +370,13 @@ def group_other_alignments(
         if len(group_alignments) != 2:
             read1 = [a for a in group_alignments if a.flag & 64]
             read2 = [a for a in group_alignments if a.flag & 128]
-            assert len(read1) == len(read2), \
+            assert len(read1) == len(read2), (
                 f"Group {group_id}: unequal read1 ({len(read1)}) and read2 ({len(read2)}) alignments"
+            )
             filtered_groups[group_id] = [read1[0], read2[0]]
-            logger.debug(f"Group {group_id}: selected first read1 and read2 from {len(group_alignments)} alignments")
+            logger.debug(
+                f"Group {group_id}: selected first read1 and read2 from {len(group_alignments)} alignments"
+            )
         else:
             filtered_groups[group_id] = group_alignments
     return filtered_groups
@@ -475,7 +493,7 @@ def add_synthetic_mates_by_groups(
         if not (has_read1 and has_read2):
             for alignment in group_alignments:
                 # Only create synthetic mates for unpaired alignments
-                assert alignment.pair_status == "UP" 
+                assert alignment.pair_status == "UP"
                 if alignment.pair_status == "UP":
                     unmapped_mate = alignment.create_unmapped_mate()
                     group_result.append(unmapped_mate)
@@ -573,7 +591,7 @@ def stream_filtered_fastq(fastq_file: str) -> Iterator[str]:
                 if read_id != previous_read_id:
                     # Check if FASTQ file is sorted before yielding
                     if last_read_id is not None and read_id < last_read_id:
-                        msg = f"FASTQ file not sorted by read ID at {read_id}, after {last_read_id}" 
+                        msg = f"FASTQ file not sorted by read ID at {read_id}, after {last_read_id}"
                         logger.error(msg)
                         raise ValueError(msg)
                     yield read_id

--- a/modules/local/filterViralSam/resources/usr/bin/filter_viral_sam.py
+++ b/modules/local/filterViralSam/resources/usr/bin/filter_viral_sam.py
@@ -11,14 +11,16 @@ add missing mates for unpaired reads.
 # Preamble
 # =======================================================================
 
-import math
-import logging
-import gzip
 import argparse
-from datetime import datetime, timezone
-from dataclasses import dataclass
-from typing import IO, Dict, Optional, Tuple, Iterator, cast
+import gzip
+import logging
+import math
 from collections import defaultdict
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import IO, cast
+
 from Bio import SeqIO
 
 
@@ -42,7 +44,7 @@ class UTCFormatter(logging.Formatter):
         Returns:
             Formatted timestamp string in UTC
         """
-        dt = datetime.fromtimestamp(record.created, timezone.utc)
+        dt = datetime.fromtimestamp(record.created, UTC)
         return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
@@ -100,8 +102,7 @@ def open_by_suffix(filename: str, mode: str = "r") -> IO[str]:
     """
     if filename.endswith(".gz"):
         return cast(IO[str], gzip.open(filename, mode + "t"))
-    else:
-        return open(filename, mode)
+    return open(filename, mode)
 
 
 # =======================================================================
@@ -126,9 +127,9 @@ class SamAlignment:
     tlen: int  # insert size
     seq: str  # sequence
     qual: str  # quality score for sequence
-    pair_status: Optional[str]  # pair status
-    alignment_score: Optional[int]  # alignment score
-    mate_alignment_score: Optional[int]  # alignment score of the mate
+    pair_status: str | None  # pair status
+    alignment_score: int | None  # alignment score
+    mate_alignment_score: int | None  # alignment score of the mate
     normalized_score: float | None  # normalized alignment score
     line: str  # original SAM line
     fields: list[str]
@@ -242,7 +243,7 @@ class SamAlignment:
 
 def group_unpaired_alignments(
     alignments: list[SamAlignment],
-) -> Dict[int, list[SamAlignment]]:
+) -> dict[int, list[SamAlignment]]:
     """
     Group unpaired (UP) alignments by position and mate information.
 
@@ -262,7 +263,7 @@ def group_unpaired_alignments(
     Returns:
         Dict[int, list[SamAlignment]]: Dictionary mapping group IDs to lists of alignments in each group
     """
-    by_group: Dict[int, list[SamAlignment]] = defaultdict(list)
+    by_group: dict[int, list[SamAlignment]] = defaultdict(list)
     pair_key_to_group: dict[tuple, int] = {}
     group_idx = 0
 
@@ -309,7 +310,7 @@ def group_unpaired_alignments(
 
 def group_other_alignments(
     alignments: list[SamAlignment],
-) -> Dict[int, list[SamAlignment]]:
+) -> dict[int, list[SamAlignment]]:
     """
     Group other alignments (CP/DP) by position, reference, and template length.
 
@@ -324,8 +325,8 @@ def group_other_alignments(
     Returns:
         Dict[int, list[SamAlignment]]: Dictionary mapping group IDs to lists of alignments in each group
     """
-    by_group: Dict[int, list[SamAlignment]] = defaultdict(list)
-    pair_key_to_group: Dict[tuple, int] = {}
+    by_group: dict[int, list[SamAlignment]] = defaultdict(list)
+    pair_key_to_group: dict[tuple, int] = {}
     group_idx = 0
 
     for alignment in alignments:
@@ -365,7 +366,7 @@ def group_other_alignments(
     # If there is more than one alignment pair, we select the first forward and reverse alignment pair
     # since there is little value in adding multiple alignment pairs that have the same
     # rname, rnext, pos_min, pos_max, tlen, and alignment_score/mate_alignment_score
-    filtered_groups: Dict[int, list[SamAlignment]] = {}
+    filtered_groups: dict[int, list[SamAlignment]] = {}
     for group_id, group_alignments in by_group.items():
         if len(group_alignments) != 2:
             read1 = [a for a in group_alignments if a.flag & 64]
@@ -384,7 +385,7 @@ def group_other_alignments(
 
 def group_secondary_alignments(
     alignments: list[SamAlignment],
-) -> Dict[int, list[SamAlignment]]:
+) -> dict[int, list[SamAlignment]]:
     """
     Group alignments by mate pairs using specialized functions based on pair status.
 
@@ -410,14 +411,13 @@ def group_secondary_alignments(
     )
     if pair_status == "UP":
         return group_unpaired_alignments(alignments)
-    else:
-        # Handle CP (Concordant Pair) and DP (Discordant Pair) reads
-        return group_other_alignments(alignments)
+    # Handle CP (Concordant Pair) and DP (Discordant Pair) reads
+    return group_other_alignments(alignments)
 
 
 def group_and_apply_score_filter(
     alignments: list[SamAlignment], threshold: float, secondary: bool = False
-) -> Dict[int, list[SamAlignment]]:
+) -> dict[int, list[SamAlignment]]:
     """
     Group alignments separately based on their alignment status (primary or secondary),
     then apply the score threshold to each group, based on the max of the bowtie2 length normalized score
@@ -452,22 +452,20 @@ def group_and_apply_score_filter(
             else:
                 logger.debug("Discarding group %s", group_id)
         return kept_groups
-    else:
-        # By default there is at most 1 primary alignment per read in a read pair
-        # (i.e. there is at most 1 group), so we can put all primary alignments
-        # into a single group, and apply the threshold to the whole group
-        max_score = max(
-            a.normalized_score for a in alignments if a.normalized_score is not None
-        )
-        if max_score >= threshold:
-            return {0: alignments}  # Single group for primary
-        else:
-            return {}
+    # By default there is at most 1 primary alignment per read in a read pair
+    # (i.e. there is at most 1 group), so we can put all primary alignments
+    # into a single group, and apply the threshold to the whole group
+    max_score = max(
+        a.normalized_score for a in alignments if a.normalized_score is not None
+    )
+    if max_score >= threshold:
+        return {0: alignments}  # Single group for primary
+    return {}
 
 
 def add_synthetic_mates_by_groups(
-    groups: Dict[int, list[SamAlignment]],
-) -> Dict[int, list[SamAlignment]]:
+    groups: dict[int, list[SamAlignment]],
+) -> dict[int, list[SamAlignment]]:
     """
     Add synthetic mate reads based on provided alignment groups.
 
@@ -602,7 +600,7 @@ def stream_filtered_fastq(fastq_file: str) -> Iterator[str]:
         raise
 
 
-def stream_sam_by_qname(sam_file: str) -> Iterator[Tuple[str, list[SamAlignment]]]:
+def stream_sam_by_qname(sam_file: str) -> Iterator[tuple[str, list[SamAlignment]]]:
     """
     Stream SAM file and yield groups of alignments by query name (also known as read id).
 

--- a/modules/local/filterViralSam/resources/usr/bin/filter_viral_sam.py
+++ b/modules/local/filterViralSam/resources/usr/bin/filter_viral_sam.py
@@ -232,8 +232,7 @@ class SamAlignment:
         fields[6] = "="  # RNEXT = same chromosome as mate
         fields[7] = self.fields[3]  # PNEXT = mate's position
         mate_line = "\t".join(fields)
-        mate = SamAlignment.from_sam_line(mate_line)
-        return mate
+        return SamAlignment.from_sam_line(mate_line)
 
 
 # =======================================================================
@@ -407,7 +406,7 @@ def group_secondary_alignments(
     # Check that all secondary alignments have the same pair status
     assert all(a.pair_status == pair_status for a in alignments), (
         "All secondary alignments for a single read ID must share the same "
-        f"pair_status. Found: {set(a.pair_status for a in alignments)}"
+        f"pair_status. Found: { {a.pair_status for a in alignments} }"
     )
     if pair_status == "UP":
         return group_unpaired_alignments(alignments)

--- a/modules/local/filterViralSam/resources/usr/bin/test_filter_viral_sam.py
+++ b/modules/local/filterViralSam/resources/usr/bin/test_filter_viral_sam.py
@@ -39,17 +39,18 @@ from filter_viral_sam import filter_viral_sam, SamAlignment
 script_dir = Path(__file__).parent
 sys.path.insert(0, str(script_dir))
 
+
 class TestSamAlignment:
     def test_parse_basic_sam_line(self) -> None:
         line = "read1\t99\tchr1\t100\t60\t50M\t=\t200\t150\tACGTACGT\tIIIIIIII\tAS:i:45\tYT:Z:CP"
         alignment = SamAlignment.from_sam_line(line)
 
-        assert alignment.qname == 'read1'
+        assert alignment.qname == "read1"
         assert alignment.flag == 99
-        assert alignment.rname == 'chr1'
+        assert alignment.rname == "chr1"
         assert alignment.pos == 100
         assert alignment.alignment_score == 45
-        assert alignment.pair_status == 'CP'
+        assert alignment.pair_status == "CP"
 
     def test_parse_missing_tags(self) -> None:
         line = "read1\t99\tchr1\t100\t60\t50M\t=\t200\t150\tACGTACGT\tIIIIIIII"
@@ -62,21 +63,36 @@ class TestSamAlignment:
         line = "read1\t99\tchr1\t100\t60\t50M\t=\t200\t150\tACGTACGT\tIIIIIIII\tAS:i:30\tYT:Z:UP"
         alignment = SamAlignment.from_sam_line(line)
 
-        assert alignment.pair_status == 'UP'
+        assert alignment.pair_status == "UP"
+
 
 class TestCalculateNormalizedScore:
     def test_normal_calculation(self) -> None:
         import math
-        line = "read1\t99\tchr1\t100\t60\t50M\t=\t200\t150\t" + "A" * 100 + "\t" + "I" * 100 + "\tAS:i:50"
+
+        line = (
+            "read1\t99\tchr1\t100\t60\t50M\t=\t200\t150\t"
+            + "A" * 100
+            + "\t"
+            + "I" * 100
+            + "\tAS:i:50"
+        )
         alignment = SamAlignment.from_sam_line(line)
         alignment.calculate_normalized_score()
         expected = 50 / math.log(100)
-        assert alignment.normalized_score is not None, "normalized_score should not be None"
+        assert alignment.normalized_score is not None, (
+            "normalized_score should not be None"
+        )
         assert expected is not None, "expected should not be None"
         assert abs(alignment.normalized_score - expected) < 1e-10
 
     def test_none_score(self) -> None:
-        line = "read1\t99\tchr1\t100\t60\t50M\t=\t200\t150\t" + "A" * 100 + "\t" + "I" * 100
+        line = (
+            "read1\t99\tchr1\t100\t60\t50M\t=\t200\t150\t"
+            + "A" * 100
+            + "\t"
+            + "I" * 100
+        )
         alignment = SamAlignment.from_sam_line(line)
         alignment.calculate_normalized_score()
         assert alignment.normalized_score == 0
@@ -86,6 +102,7 @@ class TestCalculateNormalizedScore:
         alignment = SamAlignment.from_sam_line(line)
         alignment.calculate_normalized_score()
         assert alignment.normalized_score == 0
+
 
 class TestCreateUnmappedMate:
     def test_create_mate_from_read1(self) -> None:
@@ -98,7 +115,7 @@ class TestCreateUnmappedMate:
         assert mate.flag & 128  # read2
         assert not (mate.flag & 64)  # not read1
         assert mate.flag & 4  # unmapped
-        assert mate.cigar == '*'
+        assert mate.cigar == "*"
 
     def test_create_mate_from_read2(self) -> None:
         line = "read1\t147\tchr1\t100\t60\t50M\t=\t200\t150\tACGTACGT\tIIIIIIII\tAS:i:45\tYT:Z:UP"
@@ -111,17 +128,19 @@ class TestCreateUnmappedMate:
         assert not (mate.flag & 128)  # not read2
         assert mate.flag & 4  # unmapped
 
+
 class TestFilterViralSam:
     def setup_method(self) -> None:
         self.temp_dir = tempfile.mkdtemp()
 
     def teardown_method(self) -> None:
         import shutil
+
         shutil.rmtree(self.temp_dir)
 
-    def create_temp_file(self, content: str, suffix: str = '.txt') -> str:
+    def create_temp_file(self, content: str, suffix: str = ".txt") -> str:
         fd, path = tempfile.mkstemp(dir=self.temp_dir, suffix=suffix)
-        with os.fdopen(fd, 'w') as f:
+        with os.fdopen(fd, "w") as f:
             f.write(content)
         return path
 
@@ -149,19 +168,19 @@ TGCATGCATGCATGCA
 +
 IIIIIIIIIIIIIIII"""
 
-        sam_file = self.create_temp_file(sam_content, '.sam')
-        filtered_file = self.create_temp_file(filtered_content, '.fastq')
-        output_file = os.path.join(self.temp_dir, 'output.sam')
+        sam_file = self.create_temp_file(sam_content, ".sam")
+        filtered_file = self.create_temp_file(filtered_content, ".fastq")
+        output_file = os.path.join(self.temp_dir, "output.sam")
 
         filter_viral_sam(sam_file, filtered_file, output_file, 0.1)
 
-        with open(output_file, 'r') as f:
+        with open(output_file, "r") as f:
             output_lines = f.readlines()
 
         # Should have both pairs: filtered_read (kept) and read1 (passed score threshold)
         assert len(output_lines) == 4
-        assert any('filtered_read' in line for line in output_lines)
-        assert any('read1' in line for line in output_lines)
+        assert any("filtered_read" in line for line in output_lines)
+        assert any("read1" in line for line in output_lines)
 
     def test_score_threshold_pair_logic(self) -> None:
 
@@ -188,20 +207,20 @@ TGCATGCATGCATGCA
 +
 IIIIIIIIIIIIIIII"""
 
-        sam_file = self.create_temp_file(sam_content, '.sam')
-        filtered_file = self.create_temp_file(filtered_content, '.fastq')
-        output_file = os.path.join(self.temp_dir, 'output.sam')
+        sam_file = self.create_temp_file(sam_content, ".sam")
+        filtered_file = self.create_temp_file(filtered_content, ".fastq")
+        output_file = os.path.join(self.temp_dir, "output.sam")
 
         # Threshold 10 - read1 pair should pass, read2 pair should fail
         filter_viral_sam(sam_file, filtered_file, output_file, 10.0)
 
-        with open(output_file, 'r') as f:
+        with open(output_file, "r") as f:
             output_lines = f.readlines()
 
         # Should only have read1 pair (2 lines)
         assert len(output_lines) == 2
-        assert all('read1' in line for line in output_lines)
-        assert not any('read2' in line for line in output_lines)
+        assert all("read1" in line for line in output_lines)
+        assert not any("read2" in line for line in output_lines)
 
     def test_single_read_above_threshold(self) -> None:
         # Single read above threshold should be kept
@@ -216,17 +235,17 @@ TGCATGCATGCATGCA
 +
 IIIIIIIIIIIIIIII"""
 
-        sam_file = self.create_temp_file(sam_content, '.sam')
-        filtered_file = self.create_temp_file(filtered_content, '.fastq')
-        output_file = os.path.join(self.temp_dir, 'output.sam')
+        sam_file = self.create_temp_file(sam_content, ".sam")
+        filtered_file = self.create_temp_file(filtered_content, ".fastq")
+        output_file = os.path.join(self.temp_dir, "output.sam")
 
         filter_viral_sam(sam_file, filtered_file, output_file, 10.0)
 
-        with open(output_file, 'r') as f:
+        with open(output_file, "r") as f:
             output_lines = f.readlines()
 
         assert len(output_lines) == 2
-        assert 'read1' in output_lines[0]
+        assert "read1" in output_lines[0]
 
     def test_single_read_below_threshold(self) -> None:
         # Single read below threshold should be filtered out
@@ -241,13 +260,13 @@ TGCATGCATGCATGCA
 +
 IIIIIIIIIIIIIIII"""
 
-        sam_file = self.create_temp_file(sam_content, '.sam')
-        filtered_file = self.create_temp_file(filtered_content, '.fastq')
-        output_file = os.path.join(self.temp_dir, 'output.sam')
+        sam_file = self.create_temp_file(sam_content, ".sam")
+        filtered_file = self.create_temp_file(filtered_content, ".fastq")
+        output_file = os.path.join(self.temp_dir, "output.sam")
 
         filter_viral_sam(sam_file, filtered_file, output_file, 10.0)
 
-        with open(output_file, 'r') as f:
+        with open(output_file, "r") as f:
             output_lines = f.readlines()
 
         assert len(output_lines) == 0
@@ -265,13 +284,13 @@ TGCATGCATGCATGCA
 +
 IIIIIIIIIIIIIIII"""
 
-        sam_file = self.create_temp_file(sam_content, '.sam')
-        filtered_file = self.create_temp_file(filtered_content, '.fastq')
-        output_file = os.path.join(self.temp_dir, 'output.sam')
+        sam_file = self.create_temp_file(sam_content, ".sam")
+        filtered_file = self.create_temp_file(filtered_content, ".fastq")
+        output_file = os.path.join(self.temp_dir, "output.sam")
 
         filter_viral_sam(sam_file, filtered_file, output_file, 1.0)
 
-        with open(output_file, 'r') as f:
+        with open(output_file, "r") as f:
             output_lines = f.readlines()
 
         # Should have 2 lines: original read + created unmapped mate
@@ -280,16 +299,16 @@ IIIIIIIIIIIIIIII"""
         print(output_lines)
 
         # Parse both lines
-        read1_line = [line for line in output_lines if '\t99\t' in line][0]
-        read2_line = [line for line in output_lines if '\t167\t' in line][0]
+        read1_line = [line for line in output_lines if "\t99\t" in line][0]
+        read2_line = [line for line in output_lines if "\t167\t" in line][0]
 
         read1_parsed = SamAlignment.from_sam_line(read1_line.strip())
-        assert not (read1_parsed.flag & 4)            # should be mapped
-        assert read1_parsed.cigar != '*'              # should not be unmapped
+        assert not (read1_parsed.flag & 4)  # should be mapped
+        assert read1_parsed.cigar != "*"  # should not be unmapped
 
         read2_parsed = SamAlignment.from_sam_line(read2_line.strip())
         assert read2_parsed.flag & 4  # unmapped
-        assert read2_parsed.cigar == '*'
+        assert read2_parsed.cigar == "*"
 
     def test_secondary_alignments_with_score_filtering(self) -> None:
         # Secondary alignments (flag >= 256) should be processed separately by reference
@@ -307,32 +326,34 @@ TGCATGCATGCATGCA
 +
 IIIIIIIIIIIIIIII"""
 
-        sam_file = self.create_temp_file(sam_content, '.sam')
-        filtered_file = self.create_temp_file(filtered_content, '.fastq')
-        output_file = os.path.join(self.temp_dir, 'output.sam')
+        sam_file = self.create_temp_file(sam_content, ".sam")
+        filtered_file = self.create_temp_file(filtered_content, ".fastq")
+        output_file = os.path.join(self.temp_dir, "output.sam")
 
         # Threshold that allows primary but not secondary chr2
         filter_viral_sam(sam_file, filtered_file, output_file, 17.0)
 
-        with open(output_file, 'r') as f:
+        with open(output_file, "r") as f:
             output_lines = f.readlines()
 
         # Should only have primary alignments (2 lines)
         assert len(output_lines) == 2
-        primary_flags = [SamAlignment.from_sam_line(line.strip()).flag for line in output_lines]
+        primary_flags = [
+            SamAlignment.from_sam_line(line.strip()).flag for line in output_lines
+        ]
         assert all(flag < 256 for flag in primary_flags)
 
     def test_empty_input(self) -> None:
         sam_content = ""
         filtered_content = ""
 
-        sam_file = self.create_temp_file(sam_content, '.sam')
-        filtered_file = self.create_temp_file(filtered_content, '.fastq')
-        output_file = os.path.join(self.temp_dir, 'output.sam')
+        sam_file = self.create_temp_file(sam_content, ".sam")
+        filtered_file = self.create_temp_file(filtered_content, ".fastq")
+        output_file = os.path.join(self.temp_dir, "output.sam")
 
         filter_viral_sam(sam_file, filtered_file, output_file, 1.0)
 
-        with open(output_file, 'r') as f:
+        with open(output_file, "r") as f:
             output_lines = f.readlines()
 
         assert len(output_lines) == 0
@@ -352,18 +373,18 @@ TGCATGCATGCATGCA
 +
 IIIIIIIIIIIIIIII"""
 
-        sam_file = self.create_temp_file(sam_content, '.sam')
-        filtered_file = self.create_temp_file(filtered_content, '.fastq')
-        output_file = os.path.join(self.temp_dir, 'output.sam')
+        sam_file = self.create_temp_file(sam_content, ".sam")
+        filtered_file = self.create_temp_file(filtered_content, ".fastq")
+        output_file = os.path.join(self.temp_dir, "output.sam")
 
         filter_viral_sam(sam_file, filtered_file, output_file, 1.0)
 
-        with open(output_file, 'r') as f:
+        with open(output_file, "r") as f:
             output_lines = f.readlines()
 
         # Should only have the read line, headers ignored
         assert len(output_lines) == 2
-        assert 'read1' in output_lines[0]
+        assert "read1" in output_lines[0]
         assert all("@" not in line for line in output_lines)
 
     def test_multiple_secondary_alignment_pairs(self) -> None:
@@ -385,9 +406,9 @@ TGCATGCATGCATGCA
 +
 IIIIIIIIIIIIIIII"""
 
-        sam_file = self.create_temp_file(sam_content, '.sam')
-        filtered_file = self.create_temp_file(filtered_content, '.fastq')
-        output_file = os.path.join(self.temp_dir, 'output.sam')
+        sam_file = self.create_temp_file(sam_content, ".sam")
+        filtered_file = self.create_temp_file(filtered_content, ".fastq")
+        output_file = os.path.join(self.temp_dir, "output.sam")
 
         # Threshold 15.0:
         # - Primary (chr1): scores ~18.0 and ~17.3 - both pass
@@ -395,17 +416,19 @@ IIIIIIIIIIIIIIII"""
         # - Secondary chr3: scores ~9.0 and ~7.2 - chr3 pair fails (max < 15)
         filter_viral_sam(sam_file, filtered_file, output_file, 15.0)
 
-        with open(output_file, 'r') as f:
+        with open(output_file, "r") as f:
             output_lines = f.readlines()
 
         # Should have primary pair (2) + chr2 secondary pair (2) = 4 lines
         assert len(output_lines) == 4
 
         # Check that we have the right references
-        references = [SamAlignment.from_sam_line(line.strip()).rname for line in output_lines]
-        assert 'chr1' in references  # Primary
-        assert 'chr2' in references  # Secondary that passed
-        assert 'chr3' not in references  # Secondary that failed
+        references = [
+            SamAlignment.from_sam_line(line.strip()).rname for line in output_lines
+        ]
+        assert "chr1" in references  # Primary
+        assert "chr2" in references  # Secondary that passed
+        assert "chr3" not in references  # Secondary that failed
 
         # Check flag distribution: 2 primary (< 256), 2 secondary (>= 256)
         flags = [SamAlignment.from_sam_line(line.strip()).flag for line in output_lines]
@@ -429,13 +452,13 @@ TGCATGCATGCATGCA
 +
 IIIIIIIIIIIIIIII"""
 
-        sam_file = self.create_temp_file(sam_content, '.sam')
-        filtered_file = self.create_temp_file(filtered_content, '.fastq')
-        output_file = os.path.join(self.temp_dir, 'output.sam')
+        sam_file = self.create_temp_file(sam_content, ".sam")
+        filtered_file = self.create_temp_file(filtered_content, ".fastq")
+        output_file = os.path.join(self.temp_dir, "output.sam")
 
         filter_viral_sam(sam_file, filtered_file, output_file, 10.0)
 
-        with open(output_file, 'r') as f:
+        with open(output_file, "r") as f:
             output_lines = f.readlines()
 
         # Should have primary UP + synthetic mate (2) + secondary UP + synthetic mate (2) = 4 lines
@@ -452,7 +475,7 @@ IIIIIIIIIIIIIIII"""
         assert len(secondary_alignments) == 2  # Secondary UP + synthetic mate
 
         # Check that secondary alignments include both mapped and unmapped
-        secondary_chr2 = [a for a in secondary_alignments if a.rname == 'chr2']
+        secondary_chr2 = [a for a in secondary_alignments if a.rname == "chr2"]
         assert len(secondary_chr2) == 2
 
         # One should be mapped (original UP), one should be unmapped (synthetic mate)
@@ -463,7 +486,7 @@ IIIIIIIIIIIIIIII"""
         assert len(unmapped_secondary) == 1
 
         # The unmapped one should have CIGAR '*'
-        assert unmapped_secondary[0].cigar == '*'
+        assert unmapped_secondary[0].cigar == "*"
 
         # Verify the synthetic mate has the correct flag structure
         # Original UP read was flag 355 (read1), synthetic mate should be read2 + unmapped
@@ -493,13 +516,13 @@ TGCATGCATGCATGCA
 +
 IIIIIIIIIIIIIIII"""
 
-        sam_file = self.create_temp_file(sam_content, '.sam')
-        filtered_file = self.create_temp_file(filtered_content, '.fastq')
-        output_file = os.path.join(self.temp_dir, 'output.sam')
+        sam_file = self.create_temp_file(sam_content, ".sam")
+        filtered_file = self.create_temp_file(filtered_content, ".fastq")
+        output_file = os.path.join(self.temp_dir, "output.sam")
 
         filter_viral_sam(sam_file, filtered_file, output_file, 10.0)
 
-        with open(output_file, 'r') as f:
+        with open(output_file, "r") as f:
             output_lines = f.readlines()
 
         # Should have exactly 2 lines: the 2 original UP reads (no synthetic mates needed)
@@ -513,8 +536,8 @@ IIIIIIIIIIIIIIII"""
 
         # Should have reads mapping to both chr1 and chr2
         references = [a.rname for a in alignments]
-        assert 'chr1' in references
-        assert 'chr2' in references
+        assert "chr1" in references
+        assert "chr2" in references
 
         # Verify flag-based ordering: read1 (flag 99 & 64) should come before read2 (flag 147 & 128)
         assert alignments[0].flag & 64  # First alignment is read1
@@ -524,13 +547,13 @@ IIIIIIIIIIIIIIII"""
 
         # Verify specific flag values and references
         assert alignments[0].flag == 99  # read1 flag
-        assert alignments[0].rname == 'chr1'
+        assert alignments[0].rname == "chr1"
         assert alignments[1].flag == 147  # read2 flag
-        assert alignments[1].rname == 'chr2'
+        assert alignments[1].rname == "chr2"
 
         # Both should be UP reads
-        assert alignments[0].pair_status == 'UP'
-        assert alignments[1].pair_status == 'UP'
+        assert alignments[0].pair_status == "UP"
+        assert alignments[1].pair_status == "UP"
 
     def test_primary_up_reads_different_references_with_secondary(self) -> None:
         # Test similar scenario as above but with a secondary read added
@@ -547,13 +570,13 @@ TGCATGCATGCATGCA
 +
 IIIIIIIIIIIIIIII"""
 
-        sam_file = self.create_temp_file(sam_content, '.sam')
-        filtered_file = self.create_temp_file(filtered_content, '.fastq')
-        output_file = os.path.join(self.temp_dir, 'output.sam')
+        sam_file = self.create_temp_file(sam_content, ".sam")
+        filtered_file = self.create_temp_file(filtered_content, ".fastq")
+        output_file = os.path.join(self.temp_dir, "output.sam")
 
         filter_viral_sam(sam_file, filtered_file, output_file, 10.0)
 
-        with open(output_file, 'r') as f:
+        with open(output_file, "r") as f:
             output_lines = f.readlines()
 
         # Should have 4 lines: 2 primary reads + 1 secondary read + 1 synthetic mate for secondary
@@ -572,12 +595,12 @@ IIIIIIIIIIIIIIII"""
 
         # Primary alignments should map to chr1 and chr3
         primary_refs = [a.rname for a in primary_alignments]
-        assert 'chr1' in primary_refs
-        assert 'chr3' in primary_refs
+        assert "chr1" in primary_refs
+        assert "chr3" in primary_refs
 
         # Secondary alignments should map to chr2
         secondary_refs = [a.rname for a in secondary_alignments]
-        assert all(ref == 'chr2' for ref in secondary_refs)
+        assert all(ref == "chr2" for ref in secondary_refs)
 
         # Check that secondary includes both mapped and unmapped (synthetic mate)
         secondary_mapped = [a for a in secondary_alignments if not (a.flag & 4)]
@@ -587,10 +610,10 @@ IIIIIIIIIIIIIIII"""
         assert len(secondary_unmapped) == 1  # Synthetic mate
 
         # Synthetic mate should have CIGAR '*'
-        assert secondary_unmapped[0].cigar == '*'
+        assert secondary_unmapped[0].cigar == "*"
 
         # All reads should have the same qname
-        assert all(a.qname == 'read1' for a in alignments)
+        assert all(a.qname == "read1" for a in alignments)
 
     def test_unpaired_read_secondary_alignments_same_rname(self) -> None:
         # Test unpaired read with one read mapped, other not mapped, but two secondary alignments with same rname and flag
@@ -608,13 +631,13 @@ TGCATGCATGCATGCA
 +
 IIIIIIIIIIIIIIII"""
 
-        sam_file = self.create_temp_file(sam_content, '.sam')
-        filtered_file = self.create_temp_file(filtered_content, '.fastq')
-        output_file = os.path.join(self.temp_dir, 'output.sam')
+        sam_file = self.create_temp_file(sam_content, ".sam")
+        filtered_file = self.create_temp_file(filtered_content, ".fastq")
+        output_file = os.path.join(self.temp_dir, "output.sam")
 
         filter_viral_sam(sam_file, filtered_file, output_file, 10.0)
 
-        with open(output_file, 'r') as f:
+        with open(output_file, "r") as f:
             output_lines = f.readlines()
 
         # Should have 6 lines: 1 primary + 1 synthetic mate + 2 secondary + 2 synthetic mates for secondary
@@ -637,11 +660,11 @@ IIIIIIIIIIIIIIII"""
 
         assert len(primary_mapped) == 1
         assert len(primary_unmapped) == 1
-        assert primary_mapped[0].rname == 'chr1'
-        assert primary_unmapped[0].cigar == '*'
+        assert primary_mapped[0].rname == "chr1"
+        assert primary_unmapped[0].cigar == "*"
 
         # Secondary alignments: should all map to chr2
-        assert all(a.rname == 'chr2' for a in secondary_alignments)
+        assert all(a.rname == "chr2" for a in secondary_alignments)
 
         # Should have 2 mapped (original reads) and 2 unmapped (synthetic mates)
         secondary_mapped = [a for a in secondary_alignments if not (a.flag & 4)]
@@ -651,20 +674,20 @@ IIIIIIIIIIIIIIII"""
         assert len(secondary_unmapped) == 2  # Two synthetic mates
 
         # Both original secondary reads should be UP reads with flag 355
-        assert all(a.pair_status == 'UP' for a in secondary_mapped)
+        assert all(a.pair_status == "UP" for a in secondary_mapped)
         assert all(a.flag == 355 for a in secondary_mapped)
 
         # Both synthetic mates should have CIGAR '*' and be unmapped
-        assert all(a.cigar == '*' for a in secondary_unmapped)
+        assert all(a.cigar == "*" for a in secondary_unmapped)
 
         # All reads should have the same qname
-        assert all(a.qname == 'read1' for a in alignments)
+        assert all(a.qname == "read1" for a in alignments)
 
     @pytest.mark.parametrize(
         "score1,score2,expected_cigar",
         [
             (100, 100, "1S49M"),  # Same scores: keep first alignment
-            (100, 90, "1S49M"),   # First has higher score: keep first
+            (100, 90, "1S49M"),  # First has higher score: keep first
             (90, 100, "10S40M"),  # Second has higher score: keep second
         ],
     )
@@ -687,9 +710,9 @@ TGCATGCATGCATGCATGCATGCATGCATGCA
 +
 IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII"""
 
-        sam_file = self.create_temp_file(sam_content, '.sam')
-        filtered_file = self.create_temp_file(filtered_content, '.fastq')
-        output_file = os.path.join(self.temp_dir, 'output.sam')
+        sam_file = self.create_temp_file(sam_content, ".sam")
+        filtered_file = self.create_temp_file(filtered_content, ".fastq")
+        output_file = os.path.join(self.temp_dir, "output.sam")
 
         filter_viral_sam(sam_file, filtered_file, output_file, 10.0)
 
@@ -705,7 +728,7 @@ IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII"""
             curr_is_read1 = bool(alignments[i].flag & 64)
             next_is_read1 = bool(alignments[i + 1].flag & 64)
             assert curr_is_read1 != next_is_read1, (
-                f"Consecutive alignments at positions {i} and {i+1} are both "
+                f"Consecutive alignments at positions {i} and {i + 1} are both "
                 f"{'read1' if curr_is_read1 else 'read2'}: "
                 f"flags {alignments[i].flag} and {alignments[i + 1].flag}"
             )
@@ -727,8 +750,12 @@ IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII"""
         # Verify secondary has one read1 and one read2
         secondary_read1 = [a for a in secondary_alignments if a.flag & 64]
         secondary_read2 = [a for a in secondary_alignments if a.flag & 128]
-        assert len(secondary_read1) == 1, f"Expected 1 secondary read1, got {len(secondary_read1)}"
-        assert len(secondary_read2) == 1, f"Expected 1 secondary read2, got {len(secondary_read2)}"
+        assert len(secondary_read1) == 1, (
+            f"Expected 1 secondary read1, got {len(secondary_read1)}"
+        )
+        assert len(secondary_read2) == 1, (
+            f"Expected 1 secondary read2, got {len(secondary_read2)}"
+        )
 
         # Verify the correct alignment was kept based on score
         assert secondary_read1[0].cigar == expected_cigar, (
@@ -745,6 +772,7 @@ class TestGrouping:
 
         # Arrange
         from filter_viral_sam import group_other_alignments
+
         alignments: list[SamAlignment] = []
         # Secondary pair 1: TLEN ±147, AS:45/42
         # Note: forward and reverse reads have different CIGARs
@@ -765,21 +793,28 @@ class TestGrouping:
         assert len(groups) == 3, f"Expected 3 groups, got {len(groups)}"
         # Each group should contain exactly 2 alignments (paired reads)
         for group_id, group_alignments in groups.items():
-            assert len(group_alignments) == 2, f"Group {group_id} should have 2 alignments, got {len(group_alignments)}"
+            assert len(group_alignments) == 2, (
+                f"Group {group_id} should have 2 alignments, got {len(group_alignments)}"
+            )
             # Each group should have one read1 (flag 339) and one read2 (flag 403)
             flags = sorted([a.flag for a in group_alignments])
-            assert flags == [339, 403], f"Group {group_id} should have flags [339, 403], got {flags}"
+            assert flags == [339, 403], (
+                f"Group {group_id} should have flags [339, 403], got {flags}"
+            )
             # Verify that AS and YS scores map correctly between mates
             # The AS score of read1 should equal the YS score of read2, and vice versa
             read1 = [a for a in group_alignments if a.flag == 339][0]
             read2 = [a for a in group_alignments if a.flag == 403][0]
-            assert read1.alignment_score == read2.mate_alignment_score, \
+            assert read1.alignment_score == read2.mate_alignment_score, (
                 f"Group {group_id}: read1 AS ({read1.alignment_score}) != read2 YS ({read2.mate_alignment_score})"
-            assert read2.alignment_score == read1.mate_alignment_score, \
+            )
+            assert read2.alignment_score == read1.mate_alignment_score, (
                 f"Group {group_id}: read2 AS ({read2.alignment_score}) != read1 YS ({read1.mate_alignment_score})"
+            )
             # Each group should have matching abs(TLEN) values
             tlens = [abs(a.tlen) for a in group_alignments]
             assert tlens[0] == tlens[1], f"Group {group_id} abs(TLEN) mismatch: {tlens}"
 
-if __name__ == '__main__':
-    pytest.main([__file__, '-v'])
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/modules/local/filterViralSam/resources/usr/bin/test_filter_viral_sam.py
+++ b/modules/local/filterViralSam/resources/usr/bin/test_filter_viral_sam.py
@@ -27,13 +27,13 @@ SAM alignments based on normalized alignment scores, with special handling for
 paired reads and secondary alignments to different viral references.
 """
 
-import pytest
-import tempfile
 import os
 import sys
+import tempfile
 from pathlib import Path
 
-from filter_viral_sam import filter_viral_sam, SamAlignment
+import pytest
+from filter_viral_sam import SamAlignment, filter_viral_sam
 
 # Add the script directory to path so we can import the module
 script_dir = Path(__file__).parent
@@ -174,7 +174,7 @@ IIIIIIIIIIIIIIII"""
 
         filter_viral_sam(sam_file, filtered_file, output_file, 0.1)
 
-        with open(output_file, "r") as f:
+        with open(output_file) as f:
             output_lines = f.readlines()
 
         # Should have both pairs: filtered_read (kept) and read1 (passed score threshold)
@@ -214,7 +214,7 @@ IIIIIIIIIIIIIIII"""
         # Threshold 10 - read1 pair should pass, read2 pair should fail
         filter_viral_sam(sam_file, filtered_file, output_file, 10.0)
 
-        with open(output_file, "r") as f:
+        with open(output_file) as f:
             output_lines = f.readlines()
 
         # Should only have read1 pair (2 lines)
@@ -241,7 +241,7 @@ IIIIIIIIIIIIIIII"""
 
         filter_viral_sam(sam_file, filtered_file, output_file, 10.0)
 
-        with open(output_file, "r") as f:
+        with open(output_file) as f:
             output_lines = f.readlines()
 
         assert len(output_lines) == 2
@@ -266,7 +266,7 @@ IIIIIIIIIIIIIIII"""
 
         filter_viral_sam(sam_file, filtered_file, output_file, 10.0)
 
-        with open(output_file, "r") as f:
+        with open(output_file) as f:
             output_lines = f.readlines()
 
         assert len(output_lines) == 0
@@ -290,7 +290,7 @@ IIIIIIIIIIIIIIII"""
 
         filter_viral_sam(sam_file, filtered_file, output_file, 1.0)
 
-        with open(output_file, "r") as f:
+        with open(output_file) as f:
             output_lines = f.readlines()
 
         # Should have 2 lines: original read + created unmapped mate
@@ -333,7 +333,7 @@ IIIIIIIIIIIIIIII"""
         # Threshold that allows primary but not secondary chr2
         filter_viral_sam(sam_file, filtered_file, output_file, 17.0)
 
-        with open(output_file, "r") as f:
+        with open(output_file) as f:
             output_lines = f.readlines()
 
         # Should only have primary alignments (2 lines)
@@ -353,7 +353,7 @@ IIIIIIIIIIIIIIII"""
 
         filter_viral_sam(sam_file, filtered_file, output_file, 1.0)
 
-        with open(output_file, "r") as f:
+        with open(output_file) as f:
             output_lines = f.readlines()
 
         assert len(output_lines) == 0
@@ -379,7 +379,7 @@ IIIIIIIIIIIIIIII"""
 
         filter_viral_sam(sam_file, filtered_file, output_file, 1.0)
 
-        with open(output_file, "r") as f:
+        with open(output_file) as f:
             output_lines = f.readlines()
 
         # Should only have the read line, headers ignored
@@ -416,7 +416,7 @@ IIIIIIIIIIIIIIII"""
         # - Secondary chr3: scores ~9.0 and ~7.2 - chr3 pair fails (max < 15)
         filter_viral_sam(sam_file, filtered_file, output_file, 15.0)
 
-        with open(output_file, "r") as f:
+        with open(output_file) as f:
             output_lines = f.readlines()
 
         # Should have primary pair (2) + chr2 secondary pair (2) = 4 lines
@@ -458,7 +458,7 @@ IIIIIIIIIIIIIIII"""
 
         filter_viral_sam(sam_file, filtered_file, output_file, 10.0)
 
-        with open(output_file, "r") as f:
+        with open(output_file) as f:
             output_lines = f.readlines()
 
         # Should have primary UP + synthetic mate (2) + secondary UP + synthetic mate (2) = 4 lines
@@ -522,7 +522,7 @@ IIIIIIIIIIIIIIII"""
 
         filter_viral_sam(sam_file, filtered_file, output_file, 10.0)
 
-        with open(output_file, "r") as f:
+        with open(output_file) as f:
             output_lines = f.readlines()
 
         # Should have exactly 2 lines: the 2 original UP reads (no synthetic mates needed)
@@ -576,7 +576,7 @@ IIIIIIIIIIIIIIII"""
 
         filter_viral_sam(sam_file, filtered_file, output_file, 10.0)
 
-        with open(output_file, "r") as f:
+        with open(output_file) as f:
             output_lines = f.readlines()
 
         # Should have 4 lines: 2 primary reads + 1 secondary read + 1 synthetic mate for secondary
@@ -637,7 +637,7 @@ IIIIIIIIIIIIIIII"""
 
         filter_viral_sam(sam_file, filtered_file, output_file, 10.0)
 
-        with open(output_file, "r") as f:
+        with open(output_file) as f:
             output_lines = f.readlines()
 
         # Should have 6 lines: 1 primary + 1 synthetic mate + 2 secondary + 2 synthetic mates for secondary

--- a/modules/local/getRunOutputSuffixes/resources/usr/bin/test_get_run_output_suffixes.py
+++ b/modules/local/getRunOutputSuffixes/resources/usr/bin/test_get_run_output_suffixes.py
@@ -10,37 +10,37 @@ class TestGetRunOutputSuffixes:
     """Test the get_run_output_suffixes function."""
 
     TOML_WITH_SHORTREAD_EXTRA = (
-        '[tool.mgs-workflow]\n'
-        'expected-outputs-run = [\n'
+        "[tool.mgs-workflow]\n"
+        "expected-outputs-run = [\n"
         '    "results/{SAMPLE}_virus_hits.tsv.gz",\n'
-        ']\n'
-        'expected-outputs-run-shortread-extra = [\n'
+        "]\n"
+        "expected-outputs-run-shortread-extra = [\n"
         '    "results/{SAMPLE}_fastp.json",\n'
-        ']\n'
+        "]\n"
     )
 
     @pytest.mark.parametrize(
         "toml_content,expected",
         [
             pytest.param(
-                '[tool.mgs-workflow]\n'
-                'expected-outputs-run = [\n'
+                "[tool.mgs-workflow]\n"
+                "expected-outputs-run = [\n"
                 '    "results/{SAMPLE}_virus_hits.tsv.gz",\n'
                 '    "results/{SAMPLE}_read_counts.tsv",\n'
                 '    "input/samplesheet.csv",\n'
-                ']\n',
+                "]\n",
                 ["read_counts.tsv", "virus_hits.tsv"],
                 id="extracts_sample_suffixes_and_strips_gz",
             ),
             pytest.param(
-                '[tool.mgs-workflow]\n'
-                'expected-outputs-run = [\n'
+                "[tool.mgs-workflow]\n"
+                "expected-outputs-run = [\n"
                 '    "results/{SAMPLE}_read_counts.tsv",\n'
                 '    "input/samplesheet.csv",\n'
-                ']\n'
-                'expected-outputs-downstream = [\n'
+                "]\n"
+                "expected-outputs-downstream = [\n"
                 '    "results_downstream/{GROUP}_validation_hits.tsv.gz",\n'
-                ']\n',
+                "]\n",
                 ["read_counts.tsv"],
                 id="ignores_group_patterns_and_non_templated",
             ),
@@ -51,7 +51,9 @@ class TestGetRunOutputSuffixes:
             ),
         ],
     )
-    def test_get_run_output_suffixes(self, tmp_path: Path, toml_content: str, expected: list[str]) -> None:
+    def test_get_run_output_suffixes(
+        self, tmp_path: Path, toml_content: str, expected: list[str]
+    ) -> None:
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text(toml_content)
         assert get_run_output_suffixes.get_run_output_suffixes(pyproject) == expected
@@ -71,7 +73,9 @@ class TestGetRunOutputSuffixes:
             ),
         ],
     )
-    def test_platform_filtering(self, tmp_path: Path, platform: str, expected: list[str]) -> None:
+    def test_platform_filtering(
+        self, tmp_path: Path, platform: str, expected: list[str]
+    ) -> None:
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text(self.TOML_WITH_SHORTREAD_EXTRA)
         result = get_run_output_suffixes.get_run_output_suffixes(pyproject, platform)
@@ -90,19 +94,25 @@ class TestGetRunOutputSuffixes:
         for s in result:
             assert not s.endswith(".gz")
 
+
 class TestMain:
     """Test the main() CLI entrypoint."""
 
-    def test_prints_suffixes_to_stdout(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_prints_suffixes_to_stdout(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text(
-            '[tool.mgs-workflow]\n'
-            'expected-outputs-run = [\n'
+            "[tool.mgs-workflow]\n"
+            "expected-outputs-run = [\n"
             '    "results/{SAMPLE}_bracken.tsv.gz",\n'
             '    "results/{SAMPLE}_read_counts.tsv",\n'
-            ']\n'
+            "]\n"
         )
-        with patch("sys.argv", ["get_run_output_suffixes.py", "--platform", "illumina", str(pyproject)]):
+        with patch(
+            "sys.argv",
+            ["get_run_output_suffixes.py", "--platform", "illumina", str(pyproject)],
+        ):
             get_run_output_suffixes.main()
         captured = capsys.readouterr()
         assert captured.out == "bracken.tsv\nread_counts.tsv\n"
@@ -110,7 +120,12 @@ class TestMain:
     def test_exits_on_missing_file(self, tmp_path: Path) -> None:
         with patch(
             "sys.argv",
-            ["get_run_output_suffixes.py", "--platform", "illumina", str(tmp_path / "nonexistent.toml")],
+            [
+                "get_run_output_suffixes.py",
+                "--platform",
+                "illumina",
+                str(tmp_path / "nonexistent.toml"),
+            ],
         ):
             with pytest.raises(SystemExit):
                 get_run_output_suffixes.main()

--- a/modules/local/getRunOutputSuffixes/resources/usr/bin/test_get_run_output_suffixes.py
+++ b/modules/local/getRunOutputSuffixes/resources/usr/bin/test_get_run_output_suffixes.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
-from unittest.mock import patch
-import pytest
-import get_run_output_suffixes
 from pathlib import Path
+from unittest.mock import patch
+
+import get_run_output_suffixes
+import pytest
 
 
 class TestGetRunOutputSuffixes:
@@ -118,14 +119,16 @@ class TestMain:
         assert captured.out == "bracken.tsv\nread_counts.tsv\n"
 
     def test_exits_on_missing_file(self, tmp_path: Path) -> None:
-        with patch(
-            "sys.argv",
-            [
-                "get_run_output_suffixes.py",
-                "--platform",
-                "illumina",
-                str(tmp_path / "nonexistent.toml"),
-            ],
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "get_run_output_suffixes.py",
+                    "--platform",
+                    "illumina",
+                    str(tmp_path / "nonexistent.toml"),
+                ],
+            ),
+            pytest.raises(SystemExit),
         ):
-            with pytest.raises(SystemExit):
-                get_run_output_suffixes.main()
+            get_run_output_suffixes.main()

--- a/modules/local/headTsv/resources/usr/bin/head_tsv.py
+++ b/modules/local/headTsv/resources/usr/bin/head_tsv.py
@@ -8,58 +8,68 @@ import gzip
 import os
 from typing import IO, cast
 
+
 def print_log(message: str) -> None:
     print("[", datetime.datetime.now(), "]  ", message, sep="")
+
 
 def open_by_suffix(filename: str, mode: str = "r", debug: bool = False) -> IO[str]:
     if debug:
         print_log(f"\tOpening file object: {filename}")
         print_log(f"\tOpening mode: {mode}")
         print_log(f"\tGZIP mode: {filename.endswith('.gz')}")
-    if filename.endswith('.gz'):
-        return cast(IO[str], gzip.open(filename, mode + 't'))
+    if filename.endswith(".gz"):
+        return cast(IO[str], gzip.open(filename, mode + "t"))
     else:
         return open(filename, mode)
+
 
 def add_header_line(input_path: str, header_fields: list[str], out_path: str) -> None:
     """Add header line to TSV file."""
     with open_by_suffix(input_path) as inf, open_by_suffix(out_path, "w") as outf:
         # Read first line
         first_line_content = inf.readline().strip()
-        
+
         # Check if file is empty
         if not first_line_content:
-            print_log(f"Warning: Input file {input_path} is empty. Creating output with header only.")
+            print_log(
+                f"Warning: Input file {input_path} is empty. Creating output with header only."
+            )
             # Write header line to output
             header_line = "\t".join(header_fields)
             outf.write(header_line + "\n")
             return
-            
+
         # Parse first line
         first_line = first_line_content.split("\t")
-        
+
         # Check number of fields in input
         if len(first_line) != len(header_fields):
             print_log("Number of header fields: {}".format(len(header_fields)))
             print_log("Number of fields in input file: {}".format(len(first_line)))
-            raise ValueError("Number of header fields does not match number of fields in input file.")
-            
+            raise ValueError(
+                "Number of header fields does not match number of fields in input file."
+            )
+
         # Write header line to output
         header_line = "\t".join(header_fields)
         outf.write(header_line + "\n")
-        
+
         # Write first line of input file to output
         outf.write("\t".join(first_line) + "\n")
-        
+
         # Write entire remainder of input file to output
         for line in inf:
             outf.write(line)
+
 
 def main() -> None:
     # Parse arguments
     parser = argparse.ArgumentParser(description="Add a header line to a TSV file.")
     parser.add_argument("input_path", help="Path to input TSV file.")
-    parser.add_argument("header_fields", help="Comma-separated list of header field names.")
+    parser.add_argument(
+        "header_fields", help="Comma-separated list of header field names."
+    )
     parser.add_argument("output_file", help="Path to output TSV.")
     args = parser.parse_args()
     input_path = args.input_path
@@ -79,6 +89,7 @@ def main() -> None:
     # Finish time tracking
     end_time = time.time()
     print_log("Total time elapsed: %.2f seconds" % (end_time - start_time))
+
 
 if __name__ == "__main__":
     main()

--- a/modules/local/headTsv/resources/usr/bin/head_tsv.py
+++ b/modules/local/headTsv/resources/usr/bin/head_tsv.py
@@ -2,10 +2,9 @@
 
 # Import modules
 import argparse
-import time
 import datetime
 import gzip
-import os
+import time
 from typing import IO, cast
 
 
@@ -20,8 +19,7 @@ def open_by_suffix(filename: str, mode: str = "r", debug: bool = False) -> IO[st
         print_log(f"\tGZIP mode: {filename.endswith('.gz')}")
     if filename.endswith(".gz"):
         return cast(IO[str], gzip.open(filename, mode + "t"))
-    else:
-        return open(filename, mode)
+    return open(filename, mode)
 
 
 def add_header_line(input_path: str, header_fields: list[str], out_path: str) -> None:
@@ -45,8 +43,8 @@ def add_header_line(input_path: str, header_fields: list[str], out_path: str) ->
 
         # Check number of fields in input
         if len(first_line) != len(header_fields):
-            print_log("Number of header fields: {}".format(len(header_fields)))
-            print_log("Number of fields in input file: {}".format(len(first_line)))
+            print_log(f"Number of header fields: {len(header_fields)}")
+            print_log(f"Number of fields in input file: {len(first_line)}")
             raise ValueError(
                 "Number of header fields does not match number of fields in input file."
             )
@@ -79,9 +77,9 @@ def main() -> None:
     print_log("Starting process.")
     start_time = time.time()
     # Print parameters
-    print_log("Input TSV file: {}".format(input_path))
-    print_log("Header fields: {}".format(header_fields))
-    print_log("Output TSV file: {}".format(out_path))
+    print_log(f"Input TSV file: {input_path}")
+    print_log(f"Header fields: {header_fields}")
+    print_log(f"Output TSV file: {out_path}")
     # Run labeling function
     print_log("Adding header line to TSV file...")
     add_header_line(input_path, header_fields, out_path)

--- a/modules/local/headTsv/resources/usr/bin/test_head_tsv.py
+++ b/modules/local/headTsv/resources/usr/bin/test_head_tsv.py
@@ -2,9 +2,8 @@
 
 from typing import Any
 
-import pytest
-
 import head_tsv
+import pytest
 
 
 class TestAddHeaderLine:

--- a/modules/local/headTsv/resources/usr/bin/test_head_tsv.py
+++ b/modules/local/headTsv/resources/usr/bin/test_head_tsv.py
@@ -32,7 +32,11 @@ class TestAddHeaderLine:
         ids=["basic_functionality", "empty_file", "single_column"],
     )
     def test_add_header_success_cases(
-        self, tsv_factory: Any, input_content: str, header_fields: list[str], expected_output: str
+        self,
+        tsv_factory: Any,
+        input_content: str,
+        header_fields: list[str],
+        expected_output: str,
     ) -> None:
         """Test adding headers to various TSV file formats."""
         input_file = tsv_factory.create_plain("input.tsv", input_content)

--- a/modules/local/joinFastq/resources/usr/bin/join_fastq_interleaved.py
+++ b/modules/local/joinFastq/resources/usr/bin/join_fastq_interleaved.py
@@ -50,7 +50,7 @@ def join_paired_reads(
         r0 = SeqIO.parse(inf, "fastq")  # Read FASTQ
         if debug:
             print_log("\tOrganizing read pairs...")
-        r = zip(r0, r0)  # Join FASTQ pairs
+        r = zip(r0, r0, strict=False)  # Join FASTQ pairs
         if debug:
             print_log("\tIterating over read pairs...")
         if debug:

--- a/modules/local/joinFastq/resources/usr/bin/join_fastq_interleaved.py
+++ b/modules/local/joinFastq/resources/usr/bin/join_fastq_interleaved.py
@@ -10,48 +10,65 @@ from Bio import Seq
 import os
 from typing import IO, cast
 
+
 def print_log(message: str) -> None:
     print("[", datetime.datetime.now(), "]  ", message, sep="")
+
 
 def open_by_suffix(filename: str, mode: str = "r", debug: bool = False) -> IO[str]:
     if debug:
         print_log(f"\tOpening file object: {filename}")
         print_log(f"\tOpening mode: {mode}")
         print_log(f"\tGZIP mode: {filename.endswith('.gz')}")
-    if filename.endswith('.gz'):
-        return cast(IO[str], gzip.open(filename, mode + 't'))
+    if filename.endswith(".gz"):
+        return cast(IO[str], gzip.open(filename, mode + "t"))
     else:
         return open(filename, mode)
 
-def join_paired_reads(input_file: str, output_file: str, gap: str = "N", debug: bool = False) -> None:
+
+def join_paired_reads(
+    input_file: str, output_file: str, gap: str = "N", debug: bool = False
+) -> None:
     """Join non-overlapping paired-end reads from an interleaved FASTQ file."""
-    with open_by_suffix(input_file, "r", debug) as inf, open_by_suffix(output_file, "w", debug) as outf:
+    with (
+        open_by_suffix(input_file, "r", debug) as inf,
+        open_by_suffix(output_file, "w", debug) as outf,
+    ):
         # Check if file is empty
         pos = inf.tell()
         first_line = inf.readline()
         if not first_line.strip():
-            print_log(f"Warning: Input file {input_file} is empty. Creating empty output file.")
+            print_log(
+                f"Warning: Input file {input_file} is empty. Creating empty output file."
+            )
             # Output file is already opened and will be empty when the context manager closes
             return
 
         # Reset file position to beginning
         inf.seek(pos)
-        
-        if debug: print_log("\tInitiating parsing...")
-        r0 = SeqIO.parse(inf, "fastq") # Read FASTQ
-        if debug: print_log("\tOrganizing read pairs...")
-        r = zip(r0,r0) # Join FASTQ pairs
-        if debug: print_log("\tIterating over read pairs...")
-        if debug: nread = 0
-        for fwd,rev in r:
+
+        if debug:
+            print_log("\tInitiating parsing...")
+        r0 = SeqIO.parse(inf, "fastq")  # Read FASTQ
+        if debug:
+            print_log("\tOrganizing read pairs...")
+        r = zip(r0, r0)  # Join FASTQ pairs
+        if debug:
+            print_log("\tIterating over read pairs...")
+        if debug:
+            nread = 0
+        for fwd, rev in r:
             if debug:
                 nread += 1
                 print_log("\t\tRead {}".format(nread))
             # Read in forward and reverse reads and generate joined sequence
             s1, q1 = str(fwd.seq), fwd.letter_annotations["phred_quality"]
-            s2, q2 = str(rev.seq.reverse_complement()), rev.letter_annotations["phred_quality"][::-1]
+            s2, q2 = (
+                str(rev.seq.reverse_complement()),
+                rev.letter_annotations["phred_quality"][::-1],
+            )
             joined_seq = Seq.Seq(s1 + gap + s2)
-            joined_qual = {"phred_quality": q1 + [0]*len(gap) + q2}
+            joined_qual = {"phred_quality": q1 + [0] * len(gap) + q2}
             # Modify the description to include "joined" without duplicating the ID
             description_parts = fwd.description.split(maxsplit=1)
             if len(description_parts) > 1 and description_parts[0] == fwd.id:
@@ -59,18 +76,42 @@ def join_paired_reads(input_file: str, output_file: str, gap: str = "N", debug: 
             else:
                 new_description = f"joined {fwd.description}"
             # Collate and return joined read object
-            joined_read = SeqIO.SeqRecord(joined_seq, id=fwd.id, name=fwd.name,
-                                          description=new_description,
-                                          letter_annotations=joined_qual)
+            joined_read = SeqIO.SeqRecord(
+                joined_seq,
+                id=fwd.id,
+                name=fwd.name,
+                description=new_description,
+                letter_annotations=joined_qual,
+            )
             SeqIO.write(joined_read, outf, "fastq")
+
 
 def main() -> None:
     # Parse arguments
-    parser = argparse.ArgumentParser(description="Join non-overlapping interleaved read pairs into single sequences.")
-    parser.add_argument("reads", help="Path to FASTQ file containing interleaved forward and reverse reads.")
-    parser.add_argument("output_file", help="Path to output FASTQ file containing joined reads.")
-    parser.add_argument("-g", "--gap", help="Gap sequence separating joined reads. (Default: N)", default="N", nargs=1)
-    parser.add_argument("-d", "--debug", help="Print additional information for debugging. (Default: false)", action="store_true", default=False)
+    parser = argparse.ArgumentParser(
+        description="Join non-overlapping interleaved read pairs into single sequences."
+    )
+    parser.add_argument(
+        "reads",
+        help="Path to FASTQ file containing interleaved forward and reverse reads.",
+    )
+    parser.add_argument(
+        "output_file", help="Path to output FASTQ file containing joined reads."
+    )
+    parser.add_argument(
+        "-g",
+        "--gap",
+        help="Gap sequence separating joined reads. (Default: N)",
+        default="N",
+        nargs=1,
+    )
+    parser.add_argument(
+        "-d",
+        "--debug",
+        help="Print additional information for debugging. (Default: false)",
+        action="store_true",
+        default=False,
+    )
     args = parser.parse_args()
     reads_path = args.reads
     out_path = args.output_file
@@ -86,11 +127,14 @@ def main() -> None:
     print_log("Debug mode: {}".format(debug))
     # Run joining function
     print_log("Joining reads...")
-    join_paired_reads(reads_path, out_path, gap, debug) # NB: Currently implemented serially. Will investigate paralellising if necessary.
+    join_paired_reads(
+        reads_path, out_path, gap, debug
+    )  # NB: Currently implemented serially. Will investigate paralellising if necessary.
     print_log("...done.")
     # Finish time tracking
     end_time = time.time()
     print_log("Total time elapsed: %.2f seconds" % (end_time - start_time))
+
 
 if __name__ == "__main__":
     main()

--- a/modules/local/joinFastq/resources/usr/bin/join_fastq_interleaved.py
+++ b/modules/local/joinFastq/resources/usr/bin/join_fastq_interleaved.py
@@ -50,7 +50,7 @@ def join_paired_reads(
         r0 = SeqIO.parse(inf, "fastq")  # Read FASTQ
         if debug:
             print_log("\tOrganizing read pairs...")
-        r = zip(r0, r0, strict=False)  # Join FASTQ pairs
+        r = zip(r0, r0, strict=True)  # Join FASTQ pairs
         if debug:
             print_log("\tIterating over read pairs...")
         if debug:

--- a/modules/local/joinFastq/resources/usr/bin/join_fastq_interleaved.py
+++ b/modules/local/joinFastq/resources/usr/bin/join_fastq_interleaved.py
@@ -2,13 +2,12 @@
 
 # Import modules
 import argparse
-import time
 import datetime
 import gzip
-from Bio import SeqIO
-from Bio import Seq
-import os
+import time
 from typing import IO, cast
+
+from Bio import Seq, SeqIO
 
 
 def print_log(message: str) -> None:
@@ -22,8 +21,7 @@ def open_by_suffix(filename: str, mode: str = "r", debug: bool = False) -> IO[st
         print_log(f"\tGZIP mode: {filename.endswith('.gz')}")
     if filename.endswith(".gz"):
         return cast(IO[str], gzip.open(filename, mode + "t"))
-    else:
-        return open(filename, mode)
+    return open(filename, mode)
 
 
 def join_paired_reads(
@@ -60,7 +58,7 @@ def join_paired_reads(
         for fwd, rev in r:
             if debug:
                 nread += 1
-                print_log("\t\tRead {}".format(nread))
+                print_log(f"\t\tRead {nread}")
             # Read in forward and reverse reads and generate joined sequence
             s1, q1 = str(fwd.seq), fwd.letter_annotations["phred_quality"]
             s2, q2 = (
@@ -121,10 +119,10 @@ def main() -> None:
     print_log("Starting process.")
     start_time = time.time()
     # Print parameters
-    print_log("Input reads file (interleaved): {}".format(reads_path))
-    print_log("Output reads file: {}".format(out_path))
-    print_log("Joining string: {}".format(gap))
-    print_log("Debug mode: {}".format(debug))
+    print_log(f"Input reads file (interleaved): {reads_path}")
+    print_log(f"Output reads file: {out_path}")
+    print_log(f"Joining string: {gap}")
+    print_log(f"Debug mode: {debug}")
     # Run joining function
     print_log("Joining reads...")
     join_paired_reads(

--- a/modules/local/joinTsvs/resources/usr/bin/join_tsvs.py
+++ b/modules/local/joinTsvs/resources/usr/bin/join_tsvs.py
@@ -13,11 +13,10 @@ side.
 
 # Import modules
 import argparse
-import time
 import gzip
-import os
 import logging
-from datetime import datetime, timezone
+import time
+from datetime import UTC, datetime
 from typing import IO, cast
 
 # =======================================================================
@@ -27,7 +26,7 @@ from typing import IO, cast
 
 class UTCFormatter(logging.Formatter):
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
-        dt = datetime.fromtimestamp(record.created, timezone.utc)
+        dt = datetime.fromtimestamp(record.created, UTC)
         return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
@@ -72,8 +71,7 @@ def open_by_suffix(filename: str, mode: str = "r") -> IO[str]:
     logger.debug(f"GZIP mode: {filename.endswith('.gz')}")
     if filename.endswith(".gz"):
         return cast(IO[str], gzip.open(filename, mode + "t"))
-    else:
-        return open(filename, mode)
+    return open(filename, mode)
 
 
 # =======================================================================
@@ -300,7 +298,7 @@ def join_tsvs(
                 write_line(merged_row, output)
                 if id_1_curr != id_1_next and id_2_curr != id_2_next:
                     logger.debug(
-                        f"Neither current ID matches next ID; advancing both files."
+                        "Neither current ID matches next ID; advancing both files."
                     )
                     line_1_curr, row_1_curr, id_1_curr = (
                         line_1_next,
@@ -332,7 +330,7 @@ def join_tsvs(
                     )
                 elif id_1_curr != id_1_next:
                     logger.debug(
-                        f"Current ID from file 2 matches next ID; advancing file 2 only."
+                        "Current ID from file 2 matches next ID; advancing file 2 only."
                     )
                     line_2_curr, row_2_curr, id_2_curr = (
                         line_2_next,
@@ -350,7 +348,7 @@ def join_tsvs(
                     )
                 elif id_2_curr != id_2_next:
                     logger.debug(
-                        f"Current ID from file 1 matches next ID; advancing file 1 only."
+                        "Current ID from file 1 matches next ID; advancing file 1 only."
                     )
                     line_1_curr, row_1_curr, id_1_curr = (
                         line_1_next,
@@ -381,12 +379,12 @@ def join_tsvs(
                     msg = f"Strict join failed: ID {id_1_curr} missing from file 2."
                     logger.error(msg)
                     raise ValueError(msg)
-                elif join_type in ("left", "outer"):
+                if join_type in ("left", "outer"):
                     merged_row = fill_right(row_1_curr, placeholder_file2)
                     write_line(merged_row, output)
                 else:
-                    logger.debug(f"Skipping line.")
-                logger.debug(f"Advancing file 1.")
+                    logger.debug("Skipping line.")
+                logger.debug("Advancing file 1.")
                 line_1_curr, row_1_curr, id_1_curr = line_1_next, row_1_next, id_1_next
                 line_1_next, row_1_next, id_1_next = get_line_id(file_1, field_index_1)
                 logger.debug(
@@ -404,7 +402,7 @@ def join_tsvs(
                     msg = f"Strict join failed: ID {id_2_curr} missing from file 1."
                     logger.error(msg)
                     raise ValueError(msg)
-                elif join_type in ("right", "outer"):
+                if join_type in ("right", "outer"):
                     merged_row = fill_left(
                         placeholder_file1,
                         row_2_curr,
@@ -414,8 +412,8 @@ def join_tsvs(
                     )
                     write_line(merged_row, output)
                 else:
-                    logger.debug(f"Skipping line.")
-                logger.debug(f"Advancing file 2.")
+                    logger.debug("Skipping line.")
+                logger.debug("Advancing file 2.")
                 line_2_curr, row_2_curr, id_2_curr = line_2_next, row_2_next, id_2_next
                 line_2_next, row_2_next, id_2_next = get_line_id(file_2, field_index_2)
                 logger.debug(
@@ -433,12 +431,12 @@ def join_tsvs(
                 msg = f"Strict join failed: ID {id_1_curr} missing from file 2."
                 logger.error(msg)
                 raise ValueError(msg)
-            elif join_type in ("left", "outer"):
+            if join_type in ("left", "outer"):
                 merged_row = fill_right(row_1_curr, placeholder_file2)
                 write_line(merged_row, output)
             else:
-                logger.debug(f"Skipping line.")
-            logger.debug(f"Advancing file 1.")
+                logger.debug("Skipping line.")
+            logger.debug("Advancing file 1.")
             line_1_curr, row_1_curr, id_1_curr = line_1_next, row_1_next, id_1_next
             line_1_next, row_1_next, id_1_next = get_line_id(file_1, field_index_1)
             logger.debug(f"Updated current line from file 1: {row_1_curr}, {id_1_curr}")
@@ -452,7 +450,7 @@ def join_tsvs(
                 msg = f"Strict join failed: ID {id_2_curr} missing from file 1."
                 logger.error(msg)
                 raise ValueError(msg)
-            elif join_type in ("right", "outer"):
+            if join_type in ("right", "outer"):
                 merged_row = fill_left(
                     placeholder_file1,
                     row_2_curr,
@@ -462,8 +460,8 @@ def join_tsvs(
                 )
                 write_line(merged_row, output)
             else:
-                logger.debug(f"Skipping line.")
-            logger.debug(f"Advancing file 2.")
+                logger.debug("Skipping line.")
+            logger.debug("Advancing file 2.")
             line_2_curr, row_2_curr, id_2_curr = line_2_next, row_2_next, id_2_next
             line_2_next, row_2_next, id_2_next = get_line_id(file_2, field_index_2)
             logger.debug(f"Updated current line from file 2: {row_2_curr}, {id_2_curr}")

--- a/modules/local/joinTsvs/resources/usr/bin/join_tsvs.py
+++ b/modules/local/joinTsvs/resources/usr/bin/join_tsvs.py
@@ -250,7 +250,7 @@ def join_tsvs(
         is_empty_2 = not header_line_2
         # Handle empty file cases if needed
         if is_empty_1 or is_empty_2:
-            return handle_empty_files(
+            handle_empty_files(
                 file_1,
                 file_2,
                 is_empty_1,
@@ -260,6 +260,7 @@ def join_tsvs(
                 header_line_2,
                 output,
             )
+            return
         # Otherwise, process normally
         header_1 = header_line_1.split("\t")
         header_2 = header_line_2.split("\t")
@@ -466,7 +467,6 @@ def join_tsvs(
             line_2_next, row_2_next, id_2_next = get_line_id(file_2, field_index_2)
             logger.debug(f"Updated current line from file 2: {row_2_curr}, {id_2_curr}")
             logger.debug(f"Updated next line from file 2: {row_2_next}, {id_2_next}")
-    return None
 
 
 # =======================================================================

--- a/modules/local/joinTsvs/resources/usr/bin/join_tsvs.py
+++ b/modules/local/joinTsvs/resources/usr/bin/join_tsvs.py
@@ -7,9 +7,9 @@ raise an error if there are any missing values in the join field on either
 side.
 """
 
-#=======================================================================
+# =======================================================================
 # Import libraries
-#=======================================================================
+# =======================================================================
 
 # Import modules
 import argparse
@@ -20,25 +20,29 @@ import logging
 from datetime import datetime, timezone
 from typing import IO, cast
 
-#=======================================================================
+# =======================================================================
 # Configure logging
-#=======================================================================
+# =======================================================================
+
 
 class UTCFormatter(logging.Formatter):
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
         dt = datetime.fromtimestamp(record.created, timezone.utc)
-        return dt.strftime('%Y-%m-%d %H:%M:%S UTC')
+        return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger()
 handler = logging.StreamHandler()
-formatter = UTCFormatter('[%(asctime)s] %(message)s')
+formatter = UTCFormatter("[%(asctime)s] %(message)s")
 handler.setFormatter(formatter)
 logger.handlers.clear()
 logger.addHandler(handler)
 
-#=======================================================================
+# =======================================================================
 # I/O functions
-#=======================================================================
+# =======================================================================
+
 
 def parse_args() -> argparse.Namespace:
     """Parse command-line arguments."""
@@ -49,13 +53,16 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("tsv1", help="Path to first TSV file.")
     parser.add_argument("tsv2", help="Path to second TSV file.")
     parser.add_argument("field", type=str, help="Field to join on.")
-    parser.add_argument("join_type",
-                        type=str,
-                        choices=("inner", "left", "right", "outer", "strict"),
-                        help="Type of join to perform (inner, left, right, outer, strict).")
+    parser.add_argument(
+        "join_type",
+        type=str,
+        choices=("inner", "left", "right", "outer", "strict"),
+        help="Type of join to perform (inner, left, right, outer, strict).",
+    )
     parser.add_argument("output_file", type=str, help="Path to output TSV file.")
     # Return parsed arguments
     return parser.parse_args()
+
 
 def open_by_suffix(filename: str, mode: str = "r") -> IO[str]:
     """Parse the suffix of a filename to determine the right open method
@@ -63,14 +70,16 @@ def open_by_suffix(filename: str, mode: str = "r") -> IO[str]:
     logger.debug(f"Opening file object: {filename}")
     logger.debug(f"Opening mode: {mode}")
     logger.debug(f"GZIP mode: {filename.endswith('.gz')}")
-    if filename.endswith('.gz'):
-        return cast(IO[str], gzip.open(filename, mode + 't'))
+    if filename.endswith(".gz"):
+        return cast(IO[str], gzip.open(filename, mode + "t"))
     else:
         return open(filename, mode)
 
-#=======================================================================
+
+# =======================================================================
 # Auxiliary functions
-#=======================================================================
+# =======================================================================
+
 
 def write_line(line_list: list[str], output_file: IO[str]) -> None:
     """Write a line to the output file."""
@@ -78,25 +87,38 @@ def write_line(line_list: list[str], output_file: IO[str]) -> None:
     logger.debug(f"Writing line to output: {line_joined}")
     output_file.write(line_joined + "\n")
 
+
 def fill_right(row_1: list[str], placeholder_2: list[str]) -> list[str]:
     """Fill in fields from file 2 with placeholder values."""
     new_row = row_1 + placeholder_2
     logger.debug(f"Filling right: {new_row}")
     return new_row
 
-def fill_left(placeholder_1: list[str], row_2: list[str], id_2: str, field_index_1: int, field_index_2: int) -> list[str]:
+
+def fill_left(
+    placeholder_1: list[str],
+    row_2: list[str],
+    id_2: str,
+    field_index_1: int,
+    field_index_2: int,
+) -> list[str]:
     """Fill in fields from file 1 with placeholder values."""
     # Put join field in appropriate position in columns from file 1
     if field_index_1 == 0:
         merged_row = [id_2] + placeholder_1
     else:
-        merged_row = placeholder_1[:field_index_1] + [id_2] + placeholder_1[field_index_1:]
+        merged_row = (
+            placeholder_1[:field_index_1] + [id_2] + placeholder_1[field_index_1:]
+        )
     # Add remainder of row_2 excluding join field
     merged_row += [val for i, val in enumerate(row_2) if i != field_index_2]
     logger.debug(f"Filling left: {merged_row}")
     return merged_row
 
-def process_headers(header_1: list[str], header_2: list[str], field: str) -> tuple[list[str], int, int]:
+
+def process_headers(
+    header_1: list[str], header_2: list[str], field: str
+) -> tuple[list[str], int, int]:
     """Read, join and check headers from both files."""
     # Log header fields
     logger.debug(f"Header 1: {header_1}")
@@ -127,19 +149,24 @@ def process_headers(header_1: list[str], header_2: list[str], field: str) -> tup
     logger.debug(f"Field index 1: {field_index_1}")
     logger.debug(f"Field index 2: {field_index_2}")
     # Prepare new header
-    merged_header = header_1 + \
-            [h for i, h in enumerate(header_2) if i != field_index_2]
+    merged_header = header_1 + [h for i, h in enumerate(header_2) if i != field_index_2]
     logger.debug(f"Merged header: {merged_header}")
     return merged_header, field_index_1, field_index_2
 
-def get_line_id(file: IO[str], field_index: int) -> tuple[str, list[str] | None, str | None]:
+
+def get_line_id(
+    file: IO[str], field_index: int
+) -> tuple[str, list[str] | None, str | None]:
     """Get the next line ID from a file."""
     line = file.readline()
     row = line.rstrip("\n").split("\t") if line else None
     id = row[field_index] if row else None
     return line, row, id
 
-def check_sorting(id_curr: str | None, id_next: str | None, file_str: str, input_path: str) -> None:
+
+def check_sorting(
+    id_curr: str | None, id_next: str | None, file_str: str, input_path: str
+) -> None:
     """Check that the file is sorted and raise an error if not."""
     logger.debug(f"Checking sorting for file {file_str}: {id_curr}, {id_next}")
     if id_next is not None and id_curr is not None and id_curr > id_next:
@@ -147,13 +174,24 @@ def check_sorting(id_curr: str | None, id_next: str | None, file_str: str, input
         logger.error(msg)
         raise ValueError(msg)
 
+
 def copy_file(file: IO[str], header: list[str], output: IO[str]) -> None:
     """Copy a file to the output file, starting with header."""
     write_line(header, output)
     for line in file:
         output.write(line)
 
-def handle_empty_files(file_1: IO[str], file_2: IO[str], is_empty_1: bool, is_empty_2: bool, join_type: str, header_1: str, header_2: str, output_file: IO[str]) -> None:
+
+def handle_empty_files(
+    file_1: IO[str],
+    file_2: IO[str],
+    is_empty_1: bool,
+    is_empty_2: bool,
+    join_type: str,
+    header_1: str,
+    header_2: str,
+    output_file: IO[str],
+) -> None:
     """Handle joining when one or both files are empty."""
     if not is_empty_1 and not is_empty_2:
         msg = "Error: called handle_empty_files with non-empty files"
@@ -163,7 +201,9 @@ def handle_empty_files(file_1: IO[str], file_2: IO[str], is_empty_1: bool, is_em
     if is_empty_1 and is_empty_2:
         logger.warning("Both input files are empty. Creating empty output file.")
         return
-    empty_file = file_1 if is_empty_1 else file_2 # Otherwise, get non-empty file for logging
+    empty_file = (
+        file_1 if is_empty_1 else file_2
+    )  # Otherwise, get non-empty file for logging
     # For strict joins, raise error if any single file is empty
     if join_type == "strict":
         msg = f"Strict join cannot be performed with empty file: {empty_file}"
@@ -174,25 +214,37 @@ def handle_empty_files(file_1: IO[str], file_2: IO[str], is_empty_1: bool, is_em
     nonempty_file_log = "right" if is_empty_1 else "left"
     match (join_type, is_empty_1):
         case ("inner", True) | ("inner", False) | ("left", True) | ("right", False):
-            logger.warning(f"{join_type} join with empty {empty_file_log} file. Creating empty output.")
+            logger.warning(
+                f"{join_type} join with empty {empty_file_log} file. Creating empty output."
+            )
             return
         case ("right", True) | ("outer", True):
-            logger.warning(f"{join_type} join with empty {empty_file_log} file. Using {nonempty_file_log} file as output.")
+            logger.warning(
+                f"{join_type} join with empty {empty_file_log} file. Using {nonempty_file_log} file as output."
+            )
             copy_file(file_2, header_2.split("\t"), output_file)
         case ("left", False) | ("outer", False):
-            logger.warning(f"{join_type} join with empty {empty_file_log} file. Using {nonempty_file_log} file as output.")
+            logger.warning(
+                f"{join_type} join with empty {empty_file_log} file. Using {nonempty_file_log} file as output."
+            )
             copy_file(file_1, header_1.split("\t"), output_file)
 
-#=======================================================================
-# Join function
-#=======================================================================
 
-def join_tsvs(input_path_1: str, input_path_2: str, field: str, join_type: str, output_path: str) -> None:
+# =======================================================================
+# Join function
+# =======================================================================
+
+
+def join_tsvs(
+    input_path_1: str, input_path_2: str, field: str, join_type: str, output_path: str
+) -> None:
     """Join two sorted TSV files linewise on a shared column."""
     # Open files for normal processing
-    with open_by_suffix(input_path_1, "r") as file_1, \
-         open_by_suffix(input_path_2, "r") as file_2, \
-         open_by_suffix(output_path, "w") as output:
+    with (
+        open_by_suffix(input_path_1, "r") as file_1,
+        open_by_suffix(input_path_2, "r") as file_2,
+        open_by_suffix(output_path, "w") as output,
+    ):
         # Read header lines and check for empty files
         header_line_1 = file_1.readline().strip()
         header_line_2 = file_2.readline().strip()
@@ -200,12 +252,22 @@ def join_tsvs(input_path_1: str, input_path_2: str, field: str, join_type: str, 
         is_empty_2 = not header_line_2
         # Handle empty file cases if needed
         if is_empty_1 or is_empty_2:
-            return handle_empty_files(file_1, file_2, is_empty_1, is_empty_2, join_type, header_line_1, header_line_2, output)
+            return handle_empty_files(
+                file_1,
+                file_2,
+                is_empty_1,
+                is_empty_2,
+                join_type,
+                header_line_1,
+                header_line_2,
+                output,
+            )
         # Otherwise, process normally
         header_1 = header_line_1.split("\t")
         header_2 = header_line_2.split("\t")
-        merged_header, field_index_1, field_index_2 = \
-                process_headers(header_1, header_2, field)
+        merged_header, field_index_1, field_index_2 = process_headers(
+            header_1, header_2, field
+        )
         write_line(merged_header, output)
         # Define placeholders for non-inner joins
         placeholder_file1 = ["NA"] * (len(header_1) - 1)
@@ -226,34 +288,84 @@ def join_tsvs(input_path_1: str, input_path_2: str, field: str, join_type: str, 
             # Verify that files are sorted
             check_sorting(id_1_curr, id_1_next, "1", input_path_1)
             check_sorting(id_2_curr, id_2_next, "2", input_path_2)
-            logger.debug(f"Comparing IDs between file 1 and file 2: {id_1_curr}, {id_2_curr}")
+            logger.debug(
+                f"Comparing IDs between file 1 and file 2: {id_1_curr}, {id_2_curr}"
+            )
             # If IDs match, write to output and check for one-to-many join
             if id_1_curr == id_2_curr:
                 logger.debug(f"IDs match: {id_1_curr}, {id_2_curr}")
-                merged_row = row_1_curr + [val for i, val in enumerate(row_2_curr) if i != field_index_2]
+                merged_row = row_1_curr + [
+                    val for i, val in enumerate(row_2_curr) if i != field_index_2
+                ]
                 write_line(merged_row, output)
                 if id_1_curr != id_1_next and id_2_curr != id_2_next:
-                    logger.debug(f"Neither current ID matches next ID; advancing both files.")
-                    line_1_curr, row_1_curr, id_1_curr = line_1_next, row_1_next, id_1_next
-                    line_1_next, row_1_next, id_1_next = get_line_id(file_1, field_index_1)
-                    logger.debug(f"Updated current line from file 1: {row_1_curr}, {id_1_curr}")
-                    logger.debug(f"Updated next line from file 1: {row_1_next}, {id_1_next}")
-                    line_2_curr, row_2_curr, id_2_curr = line_2_next, row_2_next, id_2_next
-                    line_2_next, row_2_next, id_2_next = get_line_id(file_2, field_index_2)
-                    logger.debug(f"Updated current line from file 2: {row_2_curr}, {id_2_curr}")
-                    logger.debug(f"Updated next line from file 2: {row_2_next}, {id_2_next}")
+                    logger.debug(
+                        f"Neither current ID matches next ID; advancing both files."
+                    )
+                    line_1_curr, row_1_curr, id_1_curr = (
+                        line_1_next,
+                        row_1_next,
+                        id_1_next,
+                    )
+                    line_1_next, row_1_next, id_1_next = get_line_id(
+                        file_1, field_index_1
+                    )
+                    logger.debug(
+                        f"Updated current line from file 1: {row_1_curr}, {id_1_curr}"
+                    )
+                    logger.debug(
+                        f"Updated next line from file 1: {row_1_next}, {id_1_next}"
+                    )
+                    line_2_curr, row_2_curr, id_2_curr = (
+                        line_2_next,
+                        row_2_next,
+                        id_2_next,
+                    )
+                    line_2_next, row_2_next, id_2_next = get_line_id(
+                        file_2, field_index_2
+                    )
+                    logger.debug(
+                        f"Updated current line from file 2: {row_2_curr}, {id_2_curr}"
+                    )
+                    logger.debug(
+                        f"Updated next line from file 2: {row_2_next}, {id_2_next}"
+                    )
                 elif id_1_curr != id_1_next:
-                    logger.debug(f"Current ID from file 2 matches next ID; advancing file 2 only.")
-                    line_2_curr, row_2_curr, id_2_curr = line_2_next, row_2_next, id_2_next
-                    line_2_next, row_2_next, id_2_next = get_line_id(file_2, field_index_2)
-                    logger.debug(f"Updated current line from file 2: {row_2_curr}, {id_2_curr}")
-                    logger.debug(f"Updated next line from file 2: {row_2_next}, {id_2_next}")
+                    logger.debug(
+                        f"Current ID from file 2 matches next ID; advancing file 2 only."
+                    )
+                    line_2_curr, row_2_curr, id_2_curr = (
+                        line_2_next,
+                        row_2_next,
+                        id_2_next,
+                    )
+                    line_2_next, row_2_next, id_2_next = get_line_id(
+                        file_2, field_index_2
+                    )
+                    logger.debug(
+                        f"Updated current line from file 2: {row_2_curr}, {id_2_curr}"
+                    )
+                    logger.debug(
+                        f"Updated next line from file 2: {row_2_next}, {id_2_next}"
+                    )
                 elif id_2_curr != id_2_next:
-                    logger.debug(f"Current ID from file 1 matches next ID; advancing file 1 only.")
-                    line_1_curr, row_1_curr, id_1_curr = line_1_next, row_1_next, id_1_next
-                    line_1_next, row_1_next, id_1_next = get_line_id(file_1, field_index_1)
-                    logger.debug(f"Updated current line from file 1: {row_1_curr}, {id_1_curr}")
-                    logger.debug(f"Updated next line from file 1: {row_1_next}, {id_1_next}")
+                    logger.debug(
+                        f"Current ID from file 1 matches next ID; advancing file 1 only."
+                    )
+                    line_1_curr, row_1_curr, id_1_curr = (
+                        line_1_next,
+                        row_1_next,
+                        id_1_next,
+                    )
+                    line_1_next, row_1_next, id_1_next = get_line_id(
+                        file_1, field_index_1
+                    )
+                    logger.debug(
+                        f"Updated current line from file 1: {row_1_curr}, {id_1_curr}"
+                    )
+                    logger.debug(
+                        f"Updated next line from file 1: {row_1_next}, {id_1_next}"
+                    )
                 else:
                     ids = f"{id_1_curr}, {id_1_next}, {id_2_curr}, {id_2_next}"
                     msg = f"Unsupported many-to-many join detected for ID {id_1_curr} ({ids})."
@@ -261,7 +373,9 @@ def join_tsvs(input_path_1: str, input_path_2: str, field: str, join_type: str, 
                     raise ValueError(msg)
             # If IDs don't match, handle on the basis of join type
             elif id_1_curr < id_2_curr:
-                logger.debug(f"File 1 ID is less than file 2 ID: {id_1_curr}, {id_2_curr}")
+                logger.debug(
+                    f"File 1 ID is less than file 2 ID: {id_1_curr}, {id_2_curr}"
+                )
                 # File 2 is missing ID present in file 1
                 if join_type == "strict":
                     msg = f"Strict join failed: ID {id_1_curr} missing from file 2."
@@ -275,25 +389,41 @@ def join_tsvs(input_path_1: str, input_path_2: str, field: str, join_type: str, 
                 logger.debug(f"Advancing file 1.")
                 line_1_curr, row_1_curr, id_1_curr = line_1_next, row_1_next, id_1_next
                 line_1_next, row_1_next, id_1_next = get_line_id(file_1, field_index_1)
-                logger.debug(f"Updated current line from file 1: {row_1_curr}, {id_1_curr}")
-                logger.debug(f"Updated next line from file 1: {row_1_next}, {id_1_next}")
+                logger.debug(
+                    f"Updated current line from file 1: {row_1_curr}, {id_1_curr}"
+                )
+                logger.debug(
+                    f"Updated next line from file 1: {row_1_next}, {id_1_next}"
+                )
             else:
                 # File 1 is missing ID present in file 2
-                logger.debug(f"File 2 ID is less than file 1 ID: {id_2_curr}, {id_1_curr}")
+                logger.debug(
+                    f"File 2 ID is less than file 1 ID: {id_2_curr}, {id_1_curr}"
+                )
                 if join_type == "strict":
                     msg = f"Strict join failed: ID {id_2_curr} missing from file 1."
                     logger.error(msg)
                     raise ValueError(msg)
                 elif join_type in ("right", "outer"):
-                    merged_row = fill_left(placeholder_file1, row_2_curr, id_2_curr, field_index_1, field_index_2)
+                    merged_row = fill_left(
+                        placeholder_file1,
+                        row_2_curr,
+                        id_2_curr,
+                        field_index_1,
+                        field_index_2,
+                    )
                     write_line(merged_row, output)
                 else:
                     logger.debug(f"Skipping line.")
                 logger.debug(f"Advancing file 2.")
                 line_2_curr, row_2_curr, id_2_curr = line_2_next, row_2_next, id_2_next
                 line_2_next, row_2_next, id_2_next = get_line_id(file_2, field_index_2)
-                logger.debug(f"Updated current line from file 2: {row_2_curr}, {id_2_curr}")
-                logger.debug(f"Updated next line from file 2: {row_2_next}, {id_2_next}")
+                logger.debug(
+                    f"Updated current line from file 2: {row_2_curr}, {id_2_curr}"
+                )
+                logger.debug(
+                    f"Updated next line from file 2: {row_2_next}, {id_2_next}"
+                )
         # Read out file 1
         while line_1_curr:
             assert row_1_curr is not None and id_1_curr is not None
@@ -323,7 +453,13 @@ def join_tsvs(input_path_1: str, input_path_2: str, field: str, join_type: str, 
                 logger.error(msg)
                 raise ValueError(msg)
             elif join_type in ("right", "outer"):
-                merged_row = fill_left(placeholder_file1, row_2_curr, id_2_curr, field_index_1, field_index_2)
+                merged_row = fill_left(
+                    placeholder_file1,
+                    row_2_curr,
+                    id_2_curr,
+                    field_index_1,
+                    field_index_2,
+                )
                 write_line(merged_row, output)
             else:
                 logger.debug(f"Skipping line.")
@@ -333,9 +469,11 @@ def join_tsvs(input_path_1: str, input_path_2: str, field: str, join_type: str, 
             logger.debug(f"Updated current line from file 2: {row_2_curr}, {id_2_curr}")
             logger.debug(f"Updated next line from file 2: {row_2_next}, {id_2_next}")
 
-#=======================================================================
+
+# =======================================================================
 # Main function
-#=======================================================================
+# =======================================================================
+
 
 def main() -> None:
     logger.info("Initializing script.")
@@ -351,6 +489,7 @@ def main() -> None:
     logger.info("Script completed successfully.")
     end_time = time.time()
     logger.info(f"Total time elapsed: {end_time - start_time} seconds")
+
 
 if __name__ == "__main__":
     main()

--- a/modules/local/joinTsvs/resources/usr/bin/join_tsvs.py
+++ b/modules/local/joinTsvs/resources/usr/bin/join_tsvs.py
@@ -466,6 +466,7 @@ def join_tsvs(
             line_2_next, row_2_next, id_2_next = get_line_id(file_2, field_index_2)
             logger.debug(f"Updated current line from file 2: {row_2_curr}, {id_2_curr}")
             logger.debug(f"Updated next line from file 2: {row_2_next}, {id_2_next}")
+    return None
 
 
 # =======================================================================

--- a/modules/local/joinTsvs/resources/usr/bin/test_join_tsvs.py
+++ b/modules/local/joinTsvs/resources/usr/bin/test_join_tsvs.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 
-import pytest
 import gzip
 from pathlib import Path
 from typing import Any
 
 import join_tsvs
+import pytest
 
 
 class TestJoinTsvs:

--- a/modules/local/joinTsvs/resources/usr/bin/test_join_tsvs.py
+++ b/modules/local/joinTsvs/resources/usr/bin/test_join_tsvs.py
@@ -11,7 +11,9 @@ import join_tsvs
 class TestJoinTsvs:
     """Test the join_tsvs module."""
 
-    def test_missing_join_field_in_file1(self, tsv_factory: Any, tmp_path: Path) -> None:
+    def test_missing_join_field_in_file1(
+        self, tsv_factory: Any, tmp_path: Path
+    ) -> None:
         """Test that missing join field in file 1 raises ValueError."""
         tsv1_content = "x\ty\tz\n0\t1\t2\n3\t4\t5\n"
         tsv2_content = "x\tv\tw\n0\t1\t2\n3\t4\t5\n"
@@ -22,7 +24,9 @@ class TestJoinTsvs:
         with pytest.raises(ValueError, match="Join field missing from file 1"):
             join_tsvs.join_tsvs(tsv1, tsv2, "v", "inner", output)
 
-    def test_missing_join_field_in_file2(self, tsv_factory: Any, tmp_path: Path) -> None:
+    def test_missing_join_field_in_file2(
+        self, tsv_factory: Any, tmp_path: Path
+    ) -> None:
         """Test that missing join field in file 2 raises ValueError."""
         tsv1_content = "x\ty\tz\n0\t1\t2\n3\t4\t5\n"
         tsv2_content = "x\tv\tw\n0\t1\t2\n3\t4\t5\n"
@@ -33,7 +37,9 @@ class TestJoinTsvs:
         with pytest.raises(ValueError, match="Join field missing from file 2"):
             join_tsvs.join_tsvs(tsv1, tsv2, "y", "inner", output)
 
-    def test_unsorted_file1_raises_error(self, tsv_factory: Any, tmp_path: Path) -> None:
+    def test_unsorted_file1_raises_error(
+        self, tsv_factory: Any, tmp_path: Path
+    ) -> None:
         """Test that unsorted file 1 raises ValueError."""
         tsv1_content = "x\tv\tw\n3\t4\t5\n6\t7\t8\n0\t1\t2\n"
         tsv2_content = "x\ty\tz\n0\t1\t2\n3\t4\t5\n6\t7\t8\n"
@@ -44,7 +50,9 @@ class TestJoinTsvs:
         with pytest.raises(ValueError, match="File 1 is not sorted"):
             join_tsvs.join_tsvs(tsv1, tsv2, "x", "inner", output)
 
-    def test_unsorted_file2_raises_error(self, tsv_factory: Any, tmp_path: Path) -> None:
+    def test_unsorted_file2_raises_error(
+        self, tsv_factory: Any, tmp_path: Path
+    ) -> None:
         """Test that unsorted file 2 raises ValueError."""
         tsv1_content = "x\ty\tz\n0\t1\t2\n3\t4\t5\n6\t7\t8\n"
         tsv2_content = "x\tv\tw\n3\t4\t5\n6\t7\t8\n0\t1\t2\n"
@@ -55,7 +63,9 @@ class TestJoinTsvs:
         with pytest.raises(ValueError, match="File 2 is not sorted"):
             join_tsvs.join_tsvs(tsv1, tsv2, "x", "inner", output)
 
-    def test_duplicate_column_names_raises_error(self, tsv_factory: Any, tmp_path: Path) -> None:
+    def test_duplicate_column_names_raises_error(
+        self, tsv_factory: Any, tmp_path: Path
+    ) -> None:
         """Test that duplicate column names across files raises ValueError."""
         tsv1_content = "x\ty\tz\n0\t1\t2\n3\t4\t5\n"
         tsv2_content = "x\ty\tw\n0\t1\t2\n3\t4\t5\n"
@@ -63,10 +73,14 @@ class TestJoinTsvs:
         tsv2 = tsv_factory.create_plain("tsv2.tsv", tsv2_content)
         output = str(tmp_path / "output.tsv")
 
-        with pytest.raises(ValueError, match="Duplicate non-join field name found across both files"):
+        with pytest.raises(
+            ValueError, match="Duplicate non-join field name found across both files"
+        ):
             join_tsvs.join_tsvs(tsv1, tsv2, "x", "inner", output)
 
-    def test_many_to_many_join_raises_error(self, tsv_factory: Any, tmp_path: Path) -> None:
+    def test_many_to_many_join_raises_error(
+        self, tsv_factory: Any, tmp_path: Path
+    ) -> None:
         """Test that many-to-many join raises ValueError."""
         # Both files have duplicate values in join column
         tsv1_content = "x\ty\tz\n0\t1\t2\n3\t4\t5\n3\t5\t6\n"
@@ -78,7 +92,9 @@ class TestJoinTsvs:
         with pytest.raises(ValueError, match="Unsupported many-to-many join detected"):
             join_tsvs.join_tsvs(tsv1, tsv2, "x", "inner", output)
 
-    def test_strict_join_with_missing_values_raises_error(self, tsv_factory: Any, tmp_path: Path) -> None:
+    def test_strict_join_with_missing_values_raises_error(
+        self, tsv_factory: Any, tmp_path: Path
+    ) -> None:
         """Test that strict join with missing values raises ValueError."""
         tsv1_content = "x\ty\tz\n0\t1\t2\n3\t4\t5\n"
         tsv2_content = "x\tv\tw\n0\t1\t2\n6\t4\t5\n"
@@ -137,7 +153,9 @@ class TestJoinTsvs:
         with gzip.open(output, "rt") as f:
             result = f.read()
 
-        expected = "x\ty\tz\tv\tw\n0\t1\t2\t10\t20\n3\t4\t5\t40\t50\n6\tNA\tNA\t70\t80\n"
+        expected = (
+            "x\ty\tz\tv\tw\n0\t1\t2\t10\t20\n3\t4\t5\t40\t50\n6\tNA\tNA\t70\t80\n"
+        )
         assert result == expected
 
     def test_outer_join_success(self, tsv_factory: Any, tmp_path: Path) -> None:
@@ -302,7 +320,9 @@ class TestJoinTsvs:
 
         assert result == tsv1_content
 
-    def test_empty_file1_strict_join_raises_error(self, tsv_factory: Any, tmp_path: Path) -> None:
+    def test_empty_file1_strict_join_raises_error(
+        self, tsv_factory: Any, tmp_path: Path
+    ) -> None:
         """Test strict join with empty first file raises error."""
         tsv1_content = ""
         tsv2_content = "x\tv\tw\n0\t10\t20\n3\t40\t50\n"
@@ -310,10 +330,14 @@ class TestJoinTsvs:
         tsv2 = tsv_factory.create_plain("tsv2.tsv", tsv2_content)
         output = str(tmp_path / "output.tsv.gz")
 
-        with pytest.raises(ValueError, match="Strict join cannot be performed with empty file"):
+        with pytest.raises(
+            ValueError, match="Strict join cannot be performed with empty file"
+        ):
             join_tsvs.join_tsvs(tsv1, tsv2, "x", "strict", output)
 
-    def test_empty_file2_strict_join_raises_error(self, tsv_factory: Any, tmp_path: Path) -> None:
+    def test_empty_file2_strict_join_raises_error(
+        self, tsv_factory: Any, tmp_path: Path
+    ) -> None:
         """Test strict join with empty second file raises error."""
         tsv1_content = "x\ty\tz\n0\t1\t2\n3\t4\t5\n"
         tsv2_content = ""
@@ -321,5 +345,7 @@ class TestJoinTsvs:
         tsv2 = tsv_factory.create_plain("tsv2.tsv", tsv2_content)
         output = str(tmp_path / "output.tsv.gz")
 
-        with pytest.raises(ValueError, match="Strict join cannot be performed with empty file"):
+        with pytest.raises(
+            ValueError, match="Strict join cannot be performed with empty file"
+        ):
             join_tsvs.join_tsvs(tsv1, tsv2, "x", "strict", output)

--- a/modules/local/lcaTsv/resources/usr/bin/lca_tsv.py
+++ b/modules/local/lcaTsv/resources/usr/bin/lca_tsv.py
@@ -340,7 +340,7 @@ def summarize_subgroup(
     # Otherwise, exclude unclassified taxids that are not joint top in score
     taxids_lca = set()
     taxids_lca_zip = zip(
-        subgroup.taxids, subgroup.taxids_classified, is_top_taxid, strict=False
+        subgroup.taxids, subgroup.taxids_classified, is_top_taxid, strict=True
     )
     for taxid, classified, is_top in taxids_lca_zip:
         if (top_taxid_classified and classified) or (

--- a/modules/local/lcaTsv/resources/usr/bin/lca_tsv.py
+++ b/modules/local/lcaTsv/resources/usr/bin/lca_tsv.py
@@ -6,9 +6,9 @@ return a TSV with a single row per group containing the lowest common ancestor
 taxid across all taxids in the group.
 """
 
-#=======================================================================
+# =======================================================================
 # Preamble
-#=======================================================================
+# =======================================================================
 
 # Import libraries
 import logging
@@ -18,15 +18,19 @@ import gzip
 from dataclasses import dataclass
 from collections import defaultdict
 from typing import IO, TextIO, cast
+
+
 # Configure logging
 class UTCFormatter(logging.Formatter):
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
         dt = datetime.fromtimestamp(record.created, timezone.utc)
-        return dt.strftime('%Y-%m-%d %H:%M:%S UTC')
+        return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger()
 handler = logging.StreamHandler()
-formatter = UTCFormatter('[%(asctime)s] %(message)s')
+formatter = UTCFormatter("[%(asctime)s] %(message)s")
 handler.setFormatter(formatter)
 logger.handlers.clear()
 logger.addHandler(handler)
@@ -34,15 +38,16 @@ logger.addHandler(handler)
 # Define constants
 TAXID_ROOT = 1
 
-#=======================================================================
+# =======================================================================
 # LCA functions
-#=======================================================================
+# =======================================================================
+
 
 def path_to_root(
-        taxid: int,
-        child_to_parent: dict[int, int],
-        path_cache: dict[int, list[int]],
-        ) -> tuple[list[int], dict[int, list[int]]]:
+    taxid: int,
+    child_to_parent: dict[int, int],
+    path_cache: dict[int, list[int]],
+) -> tuple[list[int], dict[int, list[int]]]:
     """
     Find the path from a taxid to the root of the taxonomy tree.
     Args:
@@ -58,7 +63,9 @@ def path_to_root(
     assert isinstance(taxid, int), "Taxid must be an integer."
     # If path is already cached, return it
     if taxid in path_cache:
-        logger.debug(f"Path to root for target taxid {taxid} already cached: {path_cache[taxid]}")
+        logger.debug(
+            f"Path to root for target taxid {taxid} already cached: {path_cache[taxid]}"
+        )
         return path_cache[taxid], path_cache
     # Initialize path
     path: list[int] = [taxid]
@@ -72,13 +79,17 @@ def path_to_root(
             parent = child_to_parent[path[-1]]
             # Should not encounter loops before reaching the root
             if parent == path[-1]:
-                msg = f"Taxid {taxid} has a self-loop in the child_to_parent dictionary."
+                msg = (
+                    f"Taxid {taxid} has a self-loop in the child_to_parent dictionary."
+                )
                 logger.warning(msg)
                 path.append(TAXID_ROOT)
                 break
             # Check if path for parent is already cached
             if parent in path_cache:
-                logger.debug(f"Path to root for ancestor taxid {parent} already cached: {path_cache[parent]}")
+                logger.debug(
+                    f"Path to root for ancestor taxid {parent} already cached: {path_cache[parent]}"
+                )
                 path.extend(path_cache[parent])
             # Otherwise, add parent to path
             else:
@@ -94,10 +105,11 @@ def path_to_root(
     logger.debug(f"Path to root for target taxid {taxid}: {path}")
     return path, path_cache
 
+
 def find_lca_paths(
-        path1: list[int],
-        path2: list[int],
-        ) -> int:
+    path1: list[int],
+    path2: list[int],
+) -> int:
     """
     Given two paths from a taxid to the root, find the lowest common ancestor
     shared by both paths.
@@ -122,12 +134,13 @@ def find_lca_paths(
         lca = ancestor1
     return lca
 
+
 def find_lca_pair(
-        taxid1: int,
-        taxid2: int,
-        child_to_parent: dict[int, int],
-        path_cache: dict[int, list[int]],
-        ) -> tuple[int, dict[int, list[int]]]:
+    taxid1: int,
+    taxid2: int,
+    child_to_parent: dict[int, int],
+    path_cache: dict[int, list[int]],
+) -> tuple[int, dict[int, list[int]]]:
     """
     Find the lowest common ancestor (LCA) of two taxids.
     Args:
@@ -154,11 +167,12 @@ def find_lca_pair(
     logger.debug(f"Found LCA for taxids {taxid1} and {taxid2}: {lca}")
     return lca, path_cache
 
+
 def find_lca_set(
-        taxids: set[int],
-        child_to_parent: dict[int, int],
-        path_cache: dict[int, list[int]],
-        ) -> tuple[int, dict[int, list[int]]]:
+    taxids: set[int],
+    child_to_parent: dict[int, int],
+    path_cache: dict[int, list[int]],
+) -> tuple[int, dict[int, list[int]]]:
     """
     Find the lowest common ancestor (LCA) of a set of taxids.
     Args:
@@ -171,7 +185,9 @@ def find_lca_set(
     """
     logger.debug(f"Finding LCA for taxids: {taxids}")
     taxids_start = taxids.copy()
-    assert isinstance(taxids, set), f"Taxids must be a set, got {type(taxids)} ({taxids})."
+    assert isinstance(taxids, set), (
+        f"Taxids must be a set, got {type(taxids)} ({taxids})."
+    )
     assert len(taxids) > 0, "Taxids must be non-empty."
     # If only one taxid, return it as LCA
     if len(taxids) == 1:
@@ -181,19 +197,25 @@ def find_lca_set(
     # If any taxid is not in the dictionary, raise a warning and return the root
     for taxid in taxids:
         if taxid not in child_to_parent:
-            logger.warning(f"Taxid {taxid} not found in child_to_parent dictionary; returning root.")
+            logger.warning(
+                f"Taxid {taxid} not found in child_to_parent dictionary; returning root."
+            )
             return TAXID_ROOT, path_cache
     # Otherwise, find iterated pairwise LCA
-    lca, path_cache = find_lca_pair(taxids.pop(), taxids.pop(), child_to_parent, path_cache)
+    lca, path_cache = find_lca_pair(
+        taxids.pop(), taxids.pop(), child_to_parent, path_cache
+    )
     while taxids:
         lca, path_cache = find_lca_pair(lca, taxids.pop(), child_to_parent, path_cache)
     # Return the LCA and the updated path cache
     logger.debug(f"Found LCA for taxids {taxids_start}: {lca}")
     return lca, path_cache
 
-#=======================================================================
+
+# =======================================================================
 # Subgroup class and functions
-#=======================================================================
+# =======================================================================
+
 
 @dataclass
 class Subgroup:
@@ -201,16 +223,18 @@ class Subgroup:
     A subgroup of a Group object, tracking information about a subset of
     entries, including taxids, scores, and the top taxid and LCA.
     """
+
     taxids: list[int]
     taxids_classified: list[bool]
     scores: list[float]
-    summary: dict[str, int|float|bool|None] | None
+    summary: dict[str, int | float | bool | None] | None
+
 
 def new_subgroup(
-        taxid: int | None,
-        score: float | None,
-        unclassified_taxids: set[int],
-    ) -> Subgroup:
+    taxid: int | None,
+    score: float | None,
+    unclassified_taxids: set[int],
+) -> Subgroup:
     """
     Create a new Subgroup object from minimal input information.
     Args:
@@ -221,18 +245,21 @@ def new_subgroup(
         Subgroup: New Subgroup object.
     """
     return Subgroup(
-        taxids = [taxid] if taxid is not None else [],
-        taxids_classified = [taxid not in unclassified_taxids] if taxid is not None else [],
-        scores = [score] if score is not None else [],
-        summary = None,
+        taxids=[taxid] if taxid is not None else [],
+        taxids_classified=[taxid not in unclassified_taxids]
+        if taxid is not None
+        else [],
+        scores=[score] if score is not None else [],
+        summary=None,
     )
 
+
 def update_subgroup(
-        subgroup: Subgroup,
-        taxid: int,
-        score: float,
-        unclassified_taxids: set[int],
-    ) -> Subgroup:
+    subgroup: Subgroup,
+    taxid: int,
+    score: float,
+    unclassified_taxids: set[int],
+) -> Subgroup:
     """
     Update a Subgroup object with new taxid and score information.
     Args:
@@ -249,20 +276,23 @@ def update_subgroup(
         scores = [score]
     else:
         taxids = subgroup.taxids + [taxid]
-        taxids_classified = subgroup.taxids_classified + [taxid not in unclassified_taxids]
+        taxids_classified = subgroup.taxids_classified + [
+            taxid not in unclassified_taxids
+        ]
         scores = subgroup.scores + [score]
     # Return updated Subgroup object
     return Subgroup(
-        taxids = taxids,
-        taxids_classified = taxids_classified,
-        scores = scores,
-        summary = None,
+        taxids=taxids,
+        taxids_classified=taxids_classified,
+        scores=scores,
+        summary=None,
     )
 
+
 def summarize_subgroup(
-        subgroup: Subgroup,
-        child_to_parent: dict[int, int],
-        path_cache: dict[int, list[int]],
+    subgroup: Subgroup,
+    child_to_parent: dict[int, int],
+    path_cache: dict[int, list[int]],
 ) -> tuple[Subgroup, dict[int, list[int]]]:
     """
     Summarize a Subgroup object into a dictionary of statistics.
@@ -297,7 +327,9 @@ def summarize_subgroup(
     # Out of all taxids with a joint max score, choose the first classified one if any,
     # otherwise choose the first unclassified one
     is_top_taxid = [score == max_score for score in subgroup.scores]
-    top_and_classified = [x and y for x, y in zip(is_top_taxid, subgroup.taxids_classified, strict=True)]
+    top_and_classified = [
+        x and y for x, y in zip(is_top_taxid, subgroup.taxids_classified, strict=True)
+    ]
     top_taxid_classified = any(top_and_classified)
     if top_taxid_classified:
         top_taxid = subgroup.taxids[top_and_classified.index(True)]
@@ -328,9 +360,10 @@ def summarize_subgroup(
     }
     return subgroup, path_cache
 
+
 def output_subgroup(
-        subgroup: Subgroup,
-        ) -> list[str]:
+    subgroup: Subgroup,
+) -> list[str]:
     """
     Process a Subgroup object into a list of fields for output.
     """
@@ -346,8 +379,9 @@ def output_subgroup(
         output_subgroup_element(subgroup.summary["mean_score"]),
     ]
 
+
 def output_subgroup_element(
-        element: int | float | str | None,
+    element: int | float | str | None,
 ) -> str:
     """
     Convert an element to a string, replacing None with "NA".
@@ -358,9 +392,11 @@ def output_subgroup_element(
     """
     return str(element) if element is not None else "NA"
 
-#=======================================================================
+
+# =======================================================================
 # Group class and functions
-#=======================================================================
+# =======================================================================
+
 
 @dataclass
 class Group:
@@ -368,18 +404,20 @@ class Group:
     A group of entries, including taxids, scores, and the top taxid and LCA,
     divided into natural and artificial subgroups.
     """
+
     group_id: str
     all: Subgroup
     natural: Subgroup
     artificial: Subgroup
 
+
 def new_group(
-        group_id: str,
-        taxid: int,
-        score: float,
-        artificial_taxids: set[int],
-        unclassified_taxids: set[int],
-        ) -> Group:
+    group_id: str,
+    taxid: int,
+    score: float,
+    artificial_taxids: set[int],
+    unclassified_taxids: set[int],
+) -> Group:
     """
     Create a new Group object from minimal input information.
     Args:
@@ -411,13 +449,14 @@ def new_group(
         artificial=subgroup_artificial,
     )
 
+
 def update_group(
-        group: Group,
-        taxid: int,
-        score: float,
-        artificial_taxids: set[int],
-        unclassified_taxids: set[int],
-        ) -> Group:
+    group: Group,
+    taxid: int,
+    score: float,
+    artificial_taxids: set[int],
+    unclassified_taxids: set[int],
+) -> Group:
     """
     Update a Group object with new taxid and score information.
     Args:
@@ -436,17 +475,22 @@ def update_group(
     group.all = update_subgroup(group.all, taxid, score, unclassified_taxids)
     # Update natural and artificial subgroups as appropriate
     if is_artificial:
-        group.artificial = update_subgroup(group.artificial, taxid, score, unclassified_taxids)
+        group.artificial = update_subgroup(
+            group.artificial, taxid, score, unclassified_taxids
+        )
     else:
-        group.natural = update_subgroup(group.natural, taxid, score, unclassified_taxids)
+        group.natural = update_subgroup(
+            group.natural, taxid, score, unclassified_taxids
+        )
     # Return updated Group object
     return group
 
+
 def summarize_group(
-        group: Group,
-        child_to_parent: dict[int, int],
-        path_cache: dict[int, list[int]],
-        ) -> tuple[Group, dict[int, list[int]]]:
+    group: Group,
+    child_to_parent: dict[int, int],
+    path_cache: dict[int, list[int]],
+) -> tuple[Group, dict[int, list[int]]]:
     """
     Summarize each Subgroup object in a Group object into a dictionary of
     statistics.
@@ -460,14 +504,19 @@ def summarize_group(
     """
     # Summarize subgroups
     group.all, path_cache = summarize_subgroup(group.all, child_to_parent, path_cache)
-    group.natural, path_cache = summarize_subgroup(group.natural, child_to_parent, path_cache)
-    group.artificial, path_cache = summarize_subgroup(group.artificial, child_to_parent, path_cache)
+    group.natural, path_cache = summarize_subgroup(
+        group.natural, child_to_parent, path_cache
+    )
+    group.artificial, path_cache = summarize_subgroup(
+        group.artificial, child_to_parent, path_cache
+    )
     # Return summarized Group object
     return group, path_cache
 
+
 def output_group(
-        group: Group,
-        ) -> list[str]:
+    group: Group,
+) -> list[str]:
     """
     Process a Group object into a list of fields for output.
     """
@@ -476,16 +525,18 @@ def output_group(
     fields_artificial = output_subgroup(group.artificial)
     return [group.group_id] + fields_all + fields_natural + fields_artificial
 
-#=======================================================================
+
+# =======================================================================
 # Functions for processing input and output
-#=======================================================================
+# =======================================================================
+
 
 def get_output_header(
-        prefix: str,
-        group_field: str,
-        taxid_field: str,
-        score_field: str,
-        ) -> list[str]:
+    prefix: str,
+    group_field: str,
+    taxid_field: str,
+    score_field: str,
+) -> list[str]:
     """
     Get the header for the output TSV.
     Args:
@@ -515,25 +566,28 @@ def get_output_header(
     fields_artificial = [f + "_artificial" for f in fields_prefixed]
     return [group_field] + fields_all + fields_prefixed + fields_artificial
 
+
 def write_output_line(
-        fields: list[str],
-        headers: list[str],
-        output_file: IO[str],
-        ) -> None:
+    fields: list[str],
+    headers: list[str],
+    output_file: IO[str],
+) -> None:
     """
     Write a line to the output file.
     """
-    assert len(fields) == len(headers), \
+    assert len(fields) == len(headers), (
         f"Number of fields ({len(fields)}) does not match number of headers ({len(headers)})."
+    )
     line = "\t".join(fields) + "\n"
     output_file.write(line)
 
+
 def parse_input_header(
-        header_fields: list[str],
-        group_field: str,
-        taxid_field: str,
-        score_field: str,
-        ) -> tuple[int, int, int]:
+    header_fields: list[str],
+    group_field: str,
+    taxid_field: str,
+    score_field: str,
+) -> tuple[int, int, int]:
     """
     Parse the header of an input TSV and return the indices of the group,
     taxid, and score fields.
@@ -547,24 +601,31 @@ def parse_input_header(
             taxid, and score fields.
     """
     # Confirm fields are present
-    assert group_field in header_fields, f"Group field not found in header: {group_field}"
-    assert taxid_field in header_fields, f"Taxid field not found in header: {taxid_field}"
-    assert score_field in header_fields, f"Score field not found in header: {score_field}"
+    assert group_field in header_fields, (
+        f"Group field not found in header: {group_field}"
+    )
+    assert taxid_field in header_fields, (
+        f"Taxid field not found in header: {taxid_field}"
+    )
+    assert score_field in header_fields, (
+        f"Score field not found in header: {score_field}"
+    )
     # Return indices
     group_idx = header_fields.index(group_field)
     taxid_idx = header_fields.index(taxid_field)
     score_idx = header_fields.index(score_field)
     return group_idx, taxid_idx, score_idx
 
+
 def process_input_line(
-        fields: list[str],
-        group_idx: int,
-        taxid_idx: int,
-        score_idx: int,
-        group_info: Group | None,
-        artificial_taxids: set[int],
-        unclassified_taxids: set[int],
-        ) -> Group:
+    fields: list[str],
+    group_idx: int,
+    taxid_idx: int,
+    score_idx: int,
+    group_info: Group | None,
+    artificial_taxids: set[int],
+    unclassified_taxids: set[int],
+) -> Group:
     """
     Process a single line of an input TSV and return an updated Group object
     containing information about the corresponding entry group.
@@ -586,30 +647,32 @@ def process_input_line(
     # Get group ID and confirm match with Group object
     group_id = fields[group_idx]
     if group_info is not None:
-        assert group_id == group_info.group_id, \
+        assert group_id == group_info.group_id, (
             f"Group ID mismatch: {group_id} != {group_info.group_id}"
+        )
     # Get taxid and score
     taxid = int(fields[taxid_idx])
     score = float(fields[score_idx])
     # If no Group object, create one
     if group_info is None:
-        return new_group(group_id, taxid, score, artificial_taxids,
-                         unclassified_taxids)
+        return new_group(group_id, taxid, score, artificial_taxids, unclassified_taxids)
     # Otherwise, update Group object
-    return update_group(group_info, taxid, score, artificial_taxids,
-                        unclassified_taxids)
+    return update_group(
+        group_info, taxid, score, artificial_taxids, unclassified_taxids
+    )
+
 
 def parse_input_tsv(
-        input_path: str,
-        output_path: str,
-        group_field: str,
-        taxid_field: str,
-        score_field: str,
-        child_to_parent: dict[int, int],
-        artificial_taxids: set[int],
-        unclassified_taxids: set[int],
-        prefix: str,
-        ) -> None:
+    input_path: str,
+    output_path: str,
+    group_field: str,
+    taxid_field: str,
+    score_field: str,
+    child_to_parent: dict[int, int],
+    artificial_taxids: set[int],
+    unclassified_taxids: set[int],
+    prefix: str,
+) -> None:
     """
     Iterate linewise over input TSV, calculating the LCA for each group
     of entries and writing the result to the output file.
@@ -638,10 +701,20 @@ def parse_input_tsv(
         write_output_line(output_header, output_header, outf)
         # Get indices of fields
         group_idx, taxid_idx, score_idx = parse_input_header(
-            header, group_field, taxid_field, score_field)
+            header, group_field, taxid_field, score_field
+        )
+
         def parse_line(fields: list[str], group_info: Group | None) -> Group:
-            return process_input_line(fields, group_idx, taxid_idx, score_idx, group_info,
-                                      artificial_taxids, unclassified_taxids)
+            return process_input_line(
+                fields,
+                group_idx,
+                taxid_idx,
+                score_idx,
+                group_info,
+                artificial_taxids,
+                unclassified_taxids,
+            )
+
         # Check for empty file
         fields = inf.readline().strip().split("\t")
         if len(fields) == 1 and fields[0] == "":
@@ -659,14 +732,17 @@ def parse_input_tsv(
             fields = line.strip().split("\t")
             # Get group ID and check sorting
             group_id_new = fields[group_idx]
-            assert group_id_new >= group_id, \
+            assert group_id_new >= group_id, (
                 f"Group ID out of order: {group_id_new} < {group_id}"
+            )
             # If group ID is unchanged, process line into existing Group object
             if group_id_new == group_id:
                 group_info = parse_line(fields, group_info)
             # Otherwise, write previous Group object to output and start new one
             else:
-                group_info, path_cache = summarize_group(group_info, child_to_parent, path_cache)
+                group_info, path_cache = summarize_group(
+                    group_info, child_to_parent, path_cache
+                )
                 out_line = output_group(group_info)
                 write_output_line(out_line, output_header, outf)
                 group_info = parse_line(fields, None)
@@ -674,17 +750,22 @@ def parse_input_tsv(
                 n_groups += 1
             n_entries += 1
         # Write last Group object to output
-        group_info, path_cache = summarize_group(group_info, child_to_parent, path_cache)
+        group_info, path_cache = summarize_group(
+            group_info, child_to_parent, path_cache
+        )
         out_line = output_group(group_info)
         write_output_line(out_line, output_header, outf)
         logger.info(f"Processed {n_entries} entries in {n_groups} groups.")
 
-#=======================================================================
-# Taxonomy DB functions
-#=======================================================================
 
-def parse_nodes_db(path: str, artificial_taxid: int
-                      ) -> tuple[dict[int, int], dict[int, set[int]]]:
+# =======================================================================
+# Taxonomy DB functions
+# =======================================================================
+
+
+def parse_nodes_db(
+    path: str, artificial_taxid: int
+) -> tuple[dict[int, int], dict[int, set[int]]]:
     """
     Parse taxonomy DB into two dictionaries: one mapping each taxid
     to its parent taxid, and one mapping each taxid to its children taxids.
@@ -707,19 +788,27 @@ def parse_nodes_db(path: str, artificial_taxid: int
             child_to_parent[taxid] = parent_taxid
             parent_to_children[parent_taxid].add(taxid)
     # Check that DB contains root as the topmost taxid
-    assert TAXID_ROOT in child_to_parent and TAXID_ROOT in parent_to_children, \
+    assert TAXID_ROOT in child_to_parent and TAXID_ROOT in parent_to_children, (
         "Taxonomy DB does not contain root."
+    )
     assert child_to_parent[TAXID_ROOT] == TAXID_ROOT, "Root taxid has a parent."
-    assert TAXID_ROOT in parent_to_children[TAXID_ROOT], "Root taxid must be its own child."
+    assert TAXID_ROOT in parent_to_children[TAXID_ROOT], (
+        "Root taxid must be its own child."
+    )
     # Check that DB contains artificial parent taxid
-    assert artificial_taxid in child_to_parent, \
+    assert artificial_taxid in child_to_parent, (
         f"Artificial parent taxid not found in child-to-parent DB: {artificial_taxid}, {child_to_parent}"
-    assert artificial_taxid in parent_to_children, \
+    )
+    assert artificial_taxid in parent_to_children, (
         f"Artificial parent taxid not found in parent-to-children DB: {artificial_taxid}, {parent_to_children}"
+    )
     # Return dictionaries
     return child_to_parent, parent_to_children
 
-def get_descendants(taxids: set[int], parent_to_children: dict[int, set[int]]) -> set[int]:
+
+def get_descendants(
+    taxids: set[int], parent_to_children: dict[int, set[int]]
+) -> set[int]:
     """
     Get a set of all descendants of a taxid.
     Args:
@@ -745,6 +834,7 @@ def get_descendants(taxids: set[int], parent_to_children: dict[int, set[int]]) -
     # Return set of descendants
     return descendants
 
+
 def parse_names_db(path: str) -> dict[int, set[str]]:
     """
     Parse taxonomy names DB into a dictionary mapping each taxid to a
@@ -763,6 +853,7 @@ def parse_names_db(path: str) -> dict[int, set[str]]:
             names_db[taxid].add(name)
     # Return dictionary
     return names_db
+
 
 def get_unclassified_taxids(names_db: dict[int, set[str]]) -> set[int]:
     """
@@ -784,42 +875,58 @@ def get_unclassified_taxids(names_db: dict[int, set[str]]) -> set[int]:
     # Return set of unclassified taxids
     return unclassified_taxids
 
-#=======================================================================
+
+# =======================================================================
 # I/O functions
-#=======================================================================
+# =======================================================================
+
 
 def parse_args() -> argparse.Namespace:
     """Parse command-line arguments."""
     # Create parser
-    desc = "Given a sorted TSV containing group, taxid, and score columns, " \
-           "return a TSV with a single row per group containing the lowest " \
-           "common ancestor taxid across all taxids in the group."
+    desc = (
+        "Given a sorted TSV containing group, taxid, and score columns, "
+        "return a TSV with a single row per group containing the lowest "
+        "common ancestor taxid across all taxids in the group."
+    )
     parser = argparse.ArgumentParser(description=desc)
     # Add arguments
     parser.add_argument("--input", "-i", help="Path to input TSV.")
     parser.add_argument("--output", "-o", help="Path to output TSV.")
-    parser.add_argument("--nodes-db", "-d", help="Path to taxonomy nodes DB (raw NCBI nodes.dmp file).")
-    parser.add_argument("--names-db", "-n", help="Path to taxonomy names DB (raw NCBI names.dmp file).")
+    parser.add_argument(
+        "--nodes-db", "-d", help="Path to taxonomy nodes DB (raw NCBI nodes.dmp file)."
+    )
+    parser.add_argument(
+        "--names-db", "-n", help="Path to taxonomy names DB (raw NCBI names.dmp file)."
+    )
     parser.add_argument("--group", "-g", help="Column header for group field.")
     parser.add_argument("--taxid", "-t", help="Column header for taxid field.")
     parser.add_argument("--score", "-s", help="Column header for score field.")
-    parser.add_argument("--artificial", "-a",
-                        help="Parent taxid for artificial sequences (to be handled separately).")
-    parser.add_argument("--prefix", "-p", default="", help="Column prefix for output columns.")
+    parser.add_argument(
+        "--artificial",
+        "-a",
+        help="Parent taxid for artificial sequences (to be handled separately).",
+    )
+    parser.add_argument(
+        "--prefix", "-p", default="", help="Column prefix for output columns."
+    )
     # Return parsed arguments
     return parser.parse_args()
+
 
 def open_by_suffix(filename: str, mode: str = "r", debug: bool = False) -> IO[str]:
     """Parse the suffix of a filename to determine the right open method
     to use, then open the file. Can handle .gz and uncompressed files."""
-    if filename.endswith('.gz'):
-        return cast(IO[str], gzip.open(filename, mode + 't'))
+    if filename.endswith(".gz"):
+        return cast(IO[str], gzip.open(filename, mode + "t"))
     else:
         return open(filename, mode)
 
-#=======================================================================
+
+# =======================================================================
 # Main function
-#=======================================================================
+# =======================================================================
+
 
 def main() -> None:
     logger.info("Initializing script.")
@@ -828,7 +935,9 @@ def main() -> None:
     args = parse_args()
     # Import taxonomy DB and process into dictionaries
     logger.info("Parsing taxonomy DB.")
-    child_to_parent, parent_to_children = parse_nodes_db(args.nodes_db, int(args.artificial))
+    child_to_parent, parent_to_children = parse_nodes_db(
+        args.nodes_db, int(args.artificial)
+    )
     logger.info(f"Parsed taxonomy information for {len(child_to_parent)} taxids.")
     # Parse names DB and get set of unclassified taxids
     logger.info("Parsing taxonomy names DB.")
@@ -837,19 +946,32 @@ def main() -> None:
     logger.info(f"Found {len(unclassified_taxids)} unclassified taxids.")
     # Get taxids descended from unclassified taxids
     logger.info("Getting taxids descended from unclassified taxids.")
-    unclassified_taxids_descendants = get_descendants(unclassified_taxids, parent_to_children)
-    logger.info(f"Found {len(unclassified_taxids_descendants)} taxids descended from unclassified taxids.")
+    unclassified_taxids_descendants = get_descendants(
+        unclassified_taxids, parent_to_children
+    )
+    logger.info(
+        f"Found {len(unclassified_taxids_descendants)} taxids descended from unclassified taxids."
+    )
     # Get set of artificial taxids
     logger.info("Getting set of artificial taxids.")
     artificial_taxids = get_descendants(set([int(args.artificial)]), parent_to_children)
     logger.info(f"Found {len(artificial_taxids)} artificial taxids.")
     # Parse input TSV and write LCA information to output TSV
     logger.info("Parsing input TSV.")
-    parse_input_tsv(args.input, args.output, args.group, args.taxid, args.score,
-                    child_to_parent, artificial_taxids, unclassified_taxids_descendants,
-                    args.prefix)
+    parse_input_tsv(
+        args.input,
+        args.output,
+        args.group,
+        args.taxid,
+        args.score,
+        child_to_parent,
+        artificial_taxids,
+        unclassified_taxids_descendants,
+        args.prefix,
+    )
     # Log completion
     logger.info("Script complete.")
+
 
 if __name__ == "__main__":
     main()

--- a/modules/local/lcaTsv/resources/usr/bin/lca_tsv.py
+++ b/modules/local/lcaTsv/resources/usr/bin/lca_tsv.py
@@ -11,19 +11,19 @@ taxid across all taxids in the group.
 # =======================================================================
 
 # Import libraries
-import logging
 import argparse
-from datetime import datetime, timezone
 import gzip
-from dataclasses import dataclass
+import logging
 from collections import defaultdict
-from typing import IO, TextIO, cast
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import IO, cast
 
 
 # Configure logging
 class UTCFormatter(logging.Formatter):
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
-        dt = datetime.fromtimestamp(record.created, timezone.utc)
+        dt = datetime.fromtimestamp(record.created, UTC)
         return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
@@ -919,8 +919,7 @@ def open_by_suffix(filename: str, mode: str = "r", debug: bool = False) -> IO[st
     to use, then open the file. Can handle .gz and uncompressed files."""
     if filename.endswith(".gz"):
         return cast(IO[str], gzip.open(filename, mode + "t"))
-    else:
-        return open(filename, mode)
+    return open(filename, mode)
 
 
 # =======================================================================

--- a/modules/local/lcaTsv/resources/usr/bin/lca_tsv.py
+++ b/modules/local/lcaTsv/resources/usr/bin/lca_tsv.py
@@ -343,11 +343,8 @@ def summarize_subgroup(
         subgroup.taxids, subgroup.taxids_classified, is_top_taxid, strict=False
     )
     for taxid, classified, is_top in taxids_lca_zip:
-        if (
-            top_taxid_classified
-            and classified
-            or not top_taxid_classified
-            and (classified or is_top)
+        if (top_taxid_classified and classified) or (
+            not top_taxid_classified and (classified or is_top)
         ):
             taxids_lca.add(taxid)
     lca, path_cache = find_lca_set(taxids_lca, child_to_parent, path_cache)

--- a/modules/local/lcaTsv/resources/usr/bin/lca_tsv.py
+++ b/modules/local/lcaTsv/resources/usr/bin/lca_tsv.py
@@ -339,13 +339,17 @@ def summarize_subgroup(
     # If top taxid is classified, exclude all unclassified taxids
     # Otherwise, exclude unclassified taxids that are not joint top in score
     taxids_lca = set()
-    taxids_lca_zip = zip(subgroup.taxids, subgroup.taxids_classified, is_top_taxid)
+    taxids_lca_zip = zip(
+        subgroup.taxids, subgroup.taxids_classified, is_top_taxid, strict=False
+    )
     for taxid, classified, is_top in taxids_lca_zip:
-        if top_taxid_classified and classified:
+        if (
+            top_taxid_classified
+            and classified
+            or not top_taxid_classified
+            and (classified or is_top)
+        ):
             taxids_lca.add(taxid)
-        elif not top_taxid_classified:
-            if classified or is_top:
-                taxids_lca.add(taxid)
     lca, path_cache = find_lca_set(taxids_lca, child_to_parent, path_cache)
     # Return summarized statistics
     subgroup.summary = {
@@ -953,7 +957,7 @@ def main() -> None:
     )
     # Get set of artificial taxids
     logger.info("Getting set of artificial taxids.")
-    artificial_taxids = get_descendants(set([int(args.artificial)]), parent_to_children)
+    artificial_taxids = get_descendants({int(args.artificial)}, parent_to_children)
     logger.info(f"Found {len(artificial_taxids)} artificial taxids.")
     # Parse input TSV and write LCA information to output TSV
     logger.info("Parsing input TSV.")

--- a/modules/local/lcaTsv/resources/usr/bin/test_lca_tsv.py
+++ b/modules/local/lcaTsv/resources/usr/bin/test_lca_tsv.py
@@ -4,13 +4,12 @@ Test module for lca_tsv.py
 
 import gzip
 import os
-import pytest
-import sys
 from pathlib import Path
 from typing import Any
 
 # Import the module being tested
 import lca_tsv
+import pytest
 
 
 class TestLcaTsv:

--- a/modules/local/lcaTsv/resources/usr/bin/test_lca_tsv.py
+++ b/modules/local/lcaTsv/resources/usr/bin/test_lca_tsv.py
@@ -21,8 +21,15 @@ class TestLcaTsv:
         """Fixture providing path to toy taxonomy data."""
         return os.path.join(
             os.path.dirname(__file__),
-            "..", "..", "..", "..", "..", "..",
-            "test-data", "toy-data", "lca-taxonomy"
+            "..",
+            "..",
+            "..",
+            "..",
+            "..",
+            "..",
+            "test-data",
+            "toy-data",
+            "lca-taxonomy",
         )
 
     @pytest.fixture
@@ -40,15 +47,30 @@ class TestLcaTsv:
         """Fixture providing expected output headers."""
         return [
             "seq_id",
-            "test_taxid_lca_combined", "test_n_assignments_combined", "test_n_assignments_classified_combined",
-            "test_taxid_top_combined", "test_taxid_top_classified_combined",
-            "test_test_score_min_combined", "test_test_score_max_combined", "test_test_score_mean_combined",
-            "test_taxid_lca", "test_n_assignments", "test_n_assignments_classified",
-            "test_taxid_top", "test_taxid_top_classified",
-            "test_test_score_min", "test_test_score_max", "test_test_score_mean",
-            "test_taxid_lca_artificial", "test_n_assignments_artificial", "test_n_assignments_classified_artificial",
-            "test_taxid_top_artificial", "test_taxid_top_classified_artificial",
-            "test_test_score_min_artificial", "test_test_score_max_artificial", "test_test_score_mean_artificial"
+            "test_taxid_lca_combined",
+            "test_n_assignments_combined",
+            "test_n_assignments_classified_combined",
+            "test_taxid_top_combined",
+            "test_taxid_top_classified_combined",
+            "test_test_score_min_combined",
+            "test_test_score_max_combined",
+            "test_test_score_mean_combined",
+            "test_taxid_lca",
+            "test_n_assignments",
+            "test_n_assignments_classified",
+            "test_taxid_top",
+            "test_taxid_top_classified",
+            "test_test_score_min",
+            "test_test_score_max",
+            "test_test_score_mean",
+            "test_taxid_lca_artificial",
+            "test_n_assignments_artificial",
+            "test_n_assignments_classified_artificial",
+            "test_taxid_top_artificial",
+            "test_taxid_top_classified_artificial",
+            "test_test_score_min_artificial",
+            "test_test_score_max_artificial",
+            "test_test_score_mean_artificial",
         ]
 
     @pytest.fixture
@@ -113,26 +135,41 @@ class TestLcaTsv:
         child_to_parent, parent_to_children = lca_tsv.parse_nodes_db(toy_nodes_db, 8000)
         names_db = lca_tsv.parse_names_db(toy_names_db)
         unclassified_taxids = lca_tsv.get_unclassified_taxids(names_db)
-        unclassified_taxids_descendants = lca_tsv.get_descendants(unclassified_taxids, parent_to_children)
+        unclassified_taxids_descendants = lca_tsv.get_descendants(
+            unclassified_taxids, parent_to_children
+        )
         artificial_taxids = lca_tsv.get_descendants(set([8000]), parent_to_children)
 
         return {
             "child_to_parent": child_to_parent,
             "parent_to_children": parent_to_children,
             "artificial_taxids": artificial_taxids,
-            "unclassified_taxids_descendants": unclassified_taxids_descendants
+            "unclassified_taxids_descendants": unclassified_taxids_descendants,
         }
 
-    def test_natural_input(self, tsv_factory: Any, natural_input_data: str, taxonomy_dbs: dict[str, Any], expected_headers: list[str], tmp_path: Path) -> None:
+    def test_natural_input(
+        self,
+        tsv_factory: Any,
+        natural_input_data: str,
+        taxonomy_dbs: dict[str, Any],
+        expected_headers: list[str],
+        tmp_path: Path,
+    ) -> None:
         """Test LCA computation on natural input."""
         input_file = tsv_factory.create_plain("input.tsv", natural_input_data)
         output_file = str(tmp_path / "output.tsv.gz")
 
         # Run LCA computation
         lca_tsv.parse_input_tsv(
-            input_file, output_file, "seq_id", "taxid", "test_score",
-            taxonomy_dbs["child_to_parent"], taxonomy_dbs["artificial_taxids"],
-            taxonomy_dbs["unclassified_taxids_descendants"], "test"
+            input_file,
+            output_file,
+            "seq_id",
+            "taxid",
+            "test_score",
+            taxonomy_dbs["child_to_parent"],
+            taxonomy_dbs["artificial_taxids"],
+            taxonomy_dbs["unclassified_taxids_descendants"],
+            "test",
         )
 
         # Read output
@@ -140,18 +177,23 @@ class TestLcaTsv:
             output_lines = [line.strip().split("\t") for line in f.readlines()]
 
         # Parse input to get expected values per group
-        input_lines = [line.strip().split("\t") for line in natural_input_data.strip().split("\n")[1:]]
+        input_lines = [
+            line.strip().split("\t")
+            for line in natural_input_data.strip().split("\n")[1:]
+        ]
         groups: dict[str, list[dict[str, int | float]]] = {}
         for fields in input_lines:
             group_id = fields[0]
             if group_id not in groups:
                 groups[group_id] = []
-            groups[group_id].append({
-                "taxid": int(fields[1]),
-                "score": float(fields[2]),
-                "exp_lca": int(fields[3]),
-                "exp_top_taxid": int(fields[4])
-            })
+            groups[group_id].append(
+                {
+                    "taxid": int(fields[1]),
+                    "score": float(fields[2]),
+                    "exp_lca": int(fields[3]),
+                    "exp_top_taxid": int(fields[4]),
+                }
+            )
 
         # Verify output
         headers = output_lines[0]
@@ -183,16 +225,29 @@ class TestLcaTsv:
             assert row[headers.index("test_taxid_lca_artificial")] == "NA"
             assert row[headers.index("test_n_assignments_artificial")] == "0"
 
-    def test_artificial_input(self, tsv_factory: Any, artificial_input_data: str, taxonomy_dbs: dict[str, Any], expected_headers: list[str], tmp_path: Path) -> None:
+    def test_artificial_input(
+        self,
+        tsv_factory: Any,
+        artificial_input_data: str,
+        taxonomy_dbs: dict[str, Any],
+        expected_headers: list[str],
+        tmp_path: Path,
+    ) -> None:
         """Test LCA computation with mixed natural and artificial sequences."""
         input_file = tsv_factory.create_plain("input.tsv", artificial_input_data)
         output_file = str(tmp_path / "output.tsv.gz")
 
         # Run LCA computation
         lca_tsv.parse_input_tsv(
-            input_file, output_file, "seq_id", "taxid", "test_score",
-            taxonomy_dbs["child_to_parent"], taxonomy_dbs["artificial_taxids"],
-            taxonomy_dbs["unclassified_taxids_descendants"], "test"
+            input_file,
+            output_file,
+            "seq_id",
+            "taxid",
+            "test_score",
+            taxonomy_dbs["child_to_parent"],
+            taxonomy_dbs["artificial_taxids"],
+            taxonomy_dbs["unclassified_taxids_descendants"],
+            "test",
         )
 
         # Read output
@@ -200,7 +255,10 @@ class TestLcaTsv:
             output_lines = [line.strip().split("\t") for line in f.readlines()]
 
         # Parse expected values from input
-        input_lines = [line.strip().split("\t") for line in artificial_input_data.strip().split("\n")[1:]]
+        input_lines = [
+            line.strip().split("\t")
+            for line in artificial_input_data.strip().split("\n")[1:]
+        ]
         groups: dict[str, dict[str, str]] = {}
         for fields in input_lines:
             group_id = fields[0]
@@ -222,20 +280,38 @@ class TestLcaTsv:
             assert row[0] == group_id
 
             exp = groups[group_id]
-            assert row[headers.index("test_taxid_lca_combined")] == exp["exp_lca_combined"]
+            assert (
+                row[headers.index("test_taxid_lca_combined")] == exp["exp_lca_combined"]
+            )
             assert row[headers.index("test_taxid_lca")] == exp["exp_lca"]
-            assert row[headers.index("test_taxid_lca_artificial")] == exp["exp_lca_artificial"]
+            assert (
+                row[headers.index("test_taxid_lca_artificial")]
+                == exp["exp_lca_artificial"]
+            )
 
-    def test_unclassified_input(self, tsv_factory: Any, unclassified_input_data: str, taxonomy_dbs: dict[str, Any], expected_headers: list[str], tmp_path: Path) -> None:
+    def test_unclassified_input(
+        self,
+        tsv_factory: Any,
+        unclassified_input_data: str,
+        taxonomy_dbs: dict[str, Any],
+        expected_headers: list[str],
+        tmp_path: Path,
+    ) -> None:
         """Test LCA computation with unclassified taxids."""
         input_file = tsv_factory.create_plain("input.tsv", unclassified_input_data)
         output_file = str(tmp_path / "output.tsv.gz")
 
         # Run LCA computation
         lca_tsv.parse_input_tsv(
-            input_file, output_file, "seq_id", "taxid", "test_score",
-            taxonomy_dbs["child_to_parent"], taxonomy_dbs["artificial_taxids"],
-            taxonomy_dbs["unclassified_taxids_descendants"], "test"
+            input_file,
+            output_file,
+            "seq_id",
+            "taxid",
+            "test_score",
+            taxonomy_dbs["child_to_parent"],
+            taxonomy_dbs["artificial_taxids"],
+            taxonomy_dbs["unclassified_taxids_descendants"],
+            "test",
         )
 
         # Read output
@@ -243,19 +319,24 @@ class TestLcaTsv:
             output_lines = [line.strip().split("\t") for line in f.readlines()]
 
         # Parse expected values from input
-        input_lines = [line.strip().split("\t") for line in unclassified_input_data.strip().split("\n")[1:]]
+        input_lines = [
+            line.strip().split("\t")
+            for line in unclassified_input_data.strip().split("\n")[1:]
+        ]
         groups: dict[str, list[dict[str, int | float | bool]]] = {}
         for fields in input_lines:
             group_id = fields[0]
             if group_id not in groups:
                 groups[group_id] = []
-            groups[group_id].append({
-                "exp_lca": int(fields[3]),
-                "exp_top_taxid": int(fields[4]),
-                "exp_top_taxid_classified": fields[5] == "True",
-                "exp_n_classified": int(fields[6]),
-                "score": float(fields[2])
-            })
+            groups[group_id].append(
+                {
+                    "exp_lca": int(fields[3]),
+                    "exp_top_taxid": int(fields[4]),
+                    "exp_top_taxid_classified": fields[5] == "True",
+                    "exp_n_classified": int(fields[6]),
+                    "score": float(fields[2]),
+                }
+            )
 
         # Verify output
         headers = output_lines[0]
@@ -276,14 +357,20 @@ class TestLcaTsv:
 
             assert row[headers.index("test_taxid_lca")] == str(exp["exp_lca"])
             assert row[headers.index("test_taxid_top")] == str(exp["exp_top_taxid"])
-            assert row[headers.index("test_taxid_top_classified")] == str(exp["exp_top_taxid_classified"])
+            assert row[headers.index("test_taxid_top_classified")] == str(
+                exp["exp_top_taxid_classified"]
+            )
             assert row[headers.index("test_n_assignments")] == str(exp_n_entries)
-            assert row[headers.index("test_n_assignments_classified")] == str(exp["exp_n_classified"])
+            assert row[headers.index("test_n_assignments_classified")] == str(
+                exp["exp_n_classified"]
+            )
             assert float(row[headers.index("test_test_score_min")]) == exp_min_score
             assert float(row[headers.index("test_test_score_max")]) == exp_max_score
             assert float(row[headers.index("test_test_score_mean")]) == exp_mean_score
 
-    def test_missing_group_field(self, tsv_factory: Any, taxonomy_dbs: dict[str, Any], tmp_path: Path) -> None:
+    def test_missing_group_field(
+        self, tsv_factory: Any, taxonomy_dbs: dict[str, Any], tmp_path: Path
+    ) -> None:
         """Test that missing group field raises assertion error."""
         input_content = "seq_id\ttaxid\ttest_score\nA\t9001\t100\n"
         input_file = tsv_factory.create_plain("input.tsv", input_content)
@@ -291,12 +378,20 @@ class TestLcaTsv:
 
         with pytest.raises(AssertionError, match="Group field not found in header"):
             lca_tsv.parse_input_tsv(
-                input_file, output_file, "missing", "taxid", "test_score",
-                taxonomy_dbs["child_to_parent"], taxonomy_dbs["artificial_taxids"],
-                taxonomy_dbs["unclassified_taxids_descendants"], "test"
+                input_file,
+                output_file,
+                "missing",
+                "taxid",
+                "test_score",
+                taxonomy_dbs["child_to_parent"],
+                taxonomy_dbs["artificial_taxids"],
+                taxonomy_dbs["unclassified_taxids_descendants"],
+                "test",
             )
 
-    def test_missing_taxid_field(self, tsv_factory: Any, taxonomy_dbs: dict[str, Any], tmp_path: Path) -> None:
+    def test_missing_taxid_field(
+        self, tsv_factory: Any, taxonomy_dbs: dict[str, Any], tmp_path: Path
+    ) -> None:
         """Test that missing taxid field raises assertion error."""
         input_content = "seq_id\ttaxid\ttest_score\nA\t9001\t100\n"
         input_file = tsv_factory.create_plain("input.tsv", input_content)
@@ -304,12 +399,20 @@ class TestLcaTsv:
 
         with pytest.raises(AssertionError, match="Taxid field not found in header"):
             lca_tsv.parse_input_tsv(
-                input_file, output_file, "seq_id", "missing", "test_score",
-                taxonomy_dbs["child_to_parent"], taxonomy_dbs["artificial_taxids"],
-                taxonomy_dbs["unclassified_taxids_descendants"], "test"
+                input_file,
+                output_file,
+                "seq_id",
+                "missing",
+                "test_score",
+                taxonomy_dbs["child_to_parent"],
+                taxonomy_dbs["artificial_taxids"],
+                taxonomy_dbs["unclassified_taxids_descendants"],
+                "test",
             )
 
-    def test_missing_score_field(self, tsv_factory: Any, taxonomy_dbs: dict[str, Any], tmp_path: Path) -> None:
+    def test_missing_score_field(
+        self, tsv_factory: Any, taxonomy_dbs: dict[str, Any], tmp_path: Path
+    ) -> None:
         """Test that missing score field raises assertion error."""
         input_content = "seq_id\ttaxid\ttest_score\nA\t9001\t100\n"
         input_file = tsv_factory.create_plain("input.tsv", input_content)
@@ -317,12 +420,20 @@ class TestLcaTsv:
 
         with pytest.raises(AssertionError, match="Score field not found in header"):
             lca_tsv.parse_input_tsv(
-                input_file, output_file, "seq_id", "taxid", "missing",
-                taxonomy_dbs["child_to_parent"], taxonomy_dbs["artificial_taxids"],
-                taxonomy_dbs["unclassified_taxids_descendants"], "test"
+                input_file,
+                output_file,
+                "seq_id",
+                "taxid",
+                "missing",
+                taxonomy_dbs["child_to_parent"],
+                taxonomy_dbs["artificial_taxids"],
+                taxonomy_dbs["unclassified_taxids_descendants"],
+                "test",
             )
 
-    def test_missing_root_in_taxonomy_db(self, tsv_factory: Any, toy_taxonomy_dir: str, tmp_path: Path) -> None:
+    def test_missing_root_in_taxonomy_db(
+        self, tsv_factory: Any, toy_taxonomy_dir: str, tmp_path: Path
+    ) -> None:
         """Test that missing root in taxonomy DB raises assertion error."""
         input_content = "seq_id\ttaxid\ttest_score\nA\t9001\t100\n"
         input_file = tsv_factory.create_plain("input.tsv", input_content)
@@ -332,9 +443,13 @@ class TestLcaTsv:
         truncated_nodes_db = os.path.join(toy_taxonomy_dir, "test-nodes-truncated.dmp")
 
         with pytest.raises(AssertionError, match="Taxonomy DB does not contain root"):
-            child_to_parent, parent_to_children = lca_tsv.parse_nodes_db(truncated_nodes_db, 8000)
+            child_to_parent, parent_to_children = lca_tsv.parse_nodes_db(
+                truncated_nodes_db, 8000
+            )
 
-    def test_unsorted_input(self, tsv_factory: Any, taxonomy_dbs: dict[str, Any], tmp_path: Path) -> None:
+    def test_unsorted_input(
+        self, tsv_factory: Any, taxonomy_dbs: dict[str, Any], tmp_path: Path
+    ) -> None:
         """Test that unsorted input raises assertion error."""
         # This input has groups out of order (B comes after C)
         input_content = (
@@ -350,21 +465,35 @@ class TestLcaTsv:
 
         with pytest.raises(AssertionError, match="Group ID out of order"):
             lca_tsv.parse_input_tsv(
-                input_file, output_file, "seq_id", "taxid", "test_score",
-                taxonomy_dbs["child_to_parent"], taxonomy_dbs["artificial_taxids"],
-                taxonomy_dbs["unclassified_taxids_descendants"], "test"
+                input_file,
+                output_file,
+                "seq_id",
+                "taxid",
+                "test_score",
+                taxonomy_dbs["child_to_parent"],
+                taxonomy_dbs["artificial_taxids"],
+                taxonomy_dbs["unclassified_taxids_descendants"],
+                "test",
             )
 
-    def test_empty_file_no_header(self, tsv_factory: Any, taxonomy_dbs: dict[str, Any], tmp_path: Path) -> None:
+    def test_empty_file_no_header(
+        self, tsv_factory: Any, taxonomy_dbs: dict[str, Any], tmp_path: Path
+    ) -> None:
         """Test that fully empty file produces empty output."""
         input_content = ""
         input_file = tsv_factory.create_plain("input.txt", input_content)
         output_file = str(tmp_path / "output.tsv.gz")
 
         lca_tsv.parse_input_tsv(
-            input_file, output_file, "seq_id", "taxid", "test_score",
-            taxonomy_dbs["child_to_parent"], taxonomy_dbs["artificial_taxids"],
-            taxonomy_dbs["unclassified_taxids_descendants"], "test"
+            input_file,
+            output_file,
+            "seq_id",
+            "taxid",
+            "test_score",
+            taxonomy_dbs["child_to_parent"],
+            taxonomy_dbs["artificial_taxids"],
+            taxonomy_dbs["unclassified_taxids_descendants"],
+            "test",
         )
 
         # Output file should be empty (no lines)
@@ -372,16 +501,28 @@ class TestLcaTsv:
             content = f.read()
         assert content == ""
 
-    def test_empty_file_header_only(self, tsv_factory: Any, taxonomy_dbs: dict[str, Any], expected_headers: list[str], tmp_path: Path) -> None:
+    def test_empty_file_header_only(
+        self,
+        tsv_factory: Any,
+        taxonomy_dbs: dict[str, Any],
+        expected_headers: list[str],
+        tmp_path: Path,
+    ) -> None:
         """Test that header-only file produces header-only output."""
         input_content = "seq_id\ttaxid\ttest_score\n"
         input_file = tsv_factory.create_plain("input.tsv", input_content)
         output_file = str(tmp_path / "output.tsv.gz")
 
         lca_tsv.parse_input_tsv(
-            input_file, output_file, "seq_id", "taxid", "test_score",
-            taxonomy_dbs["child_to_parent"], taxonomy_dbs["artificial_taxids"],
-            taxonomy_dbs["unclassified_taxids_descendants"], "test"
+            input_file,
+            output_file,
+            "seq_id",
+            "taxid",
+            "test_score",
+            taxonomy_dbs["child_to_parent"],
+            taxonomy_dbs["artificial_taxids"],
+            taxonomy_dbs["unclassified_taxids_descendants"],
+            "test",
         )
 
         # Output should have header only

--- a/modules/local/lcaTsv/resources/usr/bin/test_lca_tsv.py
+++ b/modules/local/lcaTsv/resources/usr/bin/test_lca_tsv.py
@@ -137,7 +137,7 @@ class TestLcaTsv:
         unclassified_taxids_descendants = lca_tsv.get_descendants(
             unclassified_taxids, parent_to_children
         )
-        artificial_taxids = lca_tsv.get_descendants(set([8000]), parent_to_children)
+        artificial_taxids = lca_tsv.get_descendants({8000}, parent_to_children)
 
         return {
             "child_to_parent": child_to_parent,
@@ -434,10 +434,6 @@ class TestLcaTsv:
         self, tsv_factory: Any, toy_taxonomy_dir: str, tmp_path: Path
     ) -> None:
         """Test that missing root in taxonomy DB raises assertion error."""
-        input_content = "seq_id\ttaxid\ttest_score\nA\t9001\t100\n"
-        input_file = tsv_factory.create_plain("input.tsv", input_content)
-        output_file = str(tmp_path / "output.tsv.gz")
-
         # Use truncated nodes DB that's missing root
         truncated_nodes_db = os.path.join(toy_taxonomy_dir, "test-nodes-truncated.dmp")
 

--- a/modules/local/partitionTsv/resources/usr/bin/partition_tsv.py
+++ b/modules/local/partitionTsv/resources/usr/bin/partition_tsv.py
@@ -2,10 +2,9 @@
 
 # Import modules
 import argparse
-import time
 import datetime
 import gzip
-import os
+import time
 from typing import IO, cast
 
 
@@ -20,8 +19,7 @@ def open_by_suffix(filename: str, mode: str = "r", debug: bool = False) -> IO[st
         print_log(f"\tGZIP mode: {filename.endswith('.gz')}")
     if filename.endswith(".gz"):
         return cast(IO[str], gzip.open(filename, mode + "t"))
-    else:
-        return open(filename, mode)
+    return open(filename, mode)
 
 
 def read_line(file: IO[str]) -> list[str] | None:
@@ -94,8 +92,8 @@ def main() -> None:
     print_log("Starting process.")
     start_time = time.time()
     # Print parameters
-    print_log("Input TSV file: {}".format(input_path))
-    print_log("Partition column header: {}".format(column))
+    print_log(f"Input TSV file: {input_path}")
+    print_log(f"Partition column header: {column}")
     # Run labeling function
     print_log("Partitioning TSV file...")
     partition(input_path, column)

--- a/modules/local/partitionTsv/resources/usr/bin/partition_tsv.py
+++ b/modules/local/partitionTsv/resources/usr/bin/partition_tsv.py
@@ -8,34 +8,42 @@ import gzip
 import os
 from typing import IO, cast
 
+
 def print_log(message: str) -> None:
     print("[", datetime.datetime.now(), "]  ", message, sep="")
+
 
 def open_by_suffix(filename: str, mode: str = "r", debug: bool = False) -> IO[str]:
     if debug:
         print_log(f"\tOpening file object: {filename}")
         print_log(f"\tOpening mode: {mode}")
         print_log(f"\tGZIP mode: {filename.endswith('.gz')}")
-    if filename.endswith('.gz'):
-        return cast(IO[str], gzip.open(filename, mode + 't'))
+    if filename.endswith(".gz"):
+        return cast(IO[str], gzip.open(filename, mode + "t"))
     else:
         return open(filename, mode)
+
 
 def read_line(file: IO[str]) -> list[str] | None:
     """Read and process a line from a file."""
     line = file.readline()
     return None if not line else line.rstrip("\n").split("\t")
 
+
 def write_line(file: IO[str], fields: list[str]) -> None:
     """Write a line to a file."""
     file.write("\t".join(fields) + "\n")
 
-def initialize_output_file(input_path: str, file_index: str, headers: list[str]) -> IO[str]:
+
+def initialize_output_file(
+    input_path: str, file_index: str, headers: list[str]
+) -> IO[str]:
     """Initialize an output file for partitioned data."""
     outf_path = f"partition_{file_index}_{input_path}"
     outf = open_by_suffix(outf_path, "w")
     write_line(outf, headers)
     return outf
+
 
 def partition(input_path: str, column: str) -> None:
     """Partition a TSV file based on a specified column header."""
@@ -49,7 +57,7 @@ def partition(input_path: str, column: str) -> None:
         column_index = headers.index(column)
         # Read first line of data and initialize first output file
         fields = read_line(inf)
-        if fields is None: # Empty apart from headers
+        if fields is None:  # Empty apart from headers
             print_log("Input file has no data rows, skipping partition.")
             return
         index = fields[column_index]
@@ -59,7 +67,7 @@ def partition(input_path: str, column: str) -> None:
         try:
             while fields is not None:
                 index = fields[column_index]
-                if index < file_index: # Throw sorting error
+                if index < file_index:  # Throw sorting error
                     msg = f"Input file is not sorted by partition column {column}; found {index} after {file_index}."
                     raise ValueError(msg)
                 if index != file_index:
@@ -71,9 +79,12 @@ def partition(input_path: str, column: str) -> None:
         finally:
             outf.close()
 
+
 def main() -> None:
     # Parse arguments
-    parser = argparse.ArgumentParser(description="Partition a TSV based on a specified column header.")
+    parser = argparse.ArgumentParser(
+        description="Partition a TSV based on a specified column header."
+    )
     parser.add_argument("--input_path", "-i", help="Path to input TSV file.")
     parser.add_argument("--column", "-c", help="Column header to partition on.")
     args = parser.parse_args()
@@ -92,6 +103,7 @@ def main() -> None:
     # Finish time tracking
     end_time = time.time()
     print_log("Total time elapsed: %.2f seconds" % (end_time - start_time))
+
 
 if __name__ == "__main__":
     main()

--- a/modules/local/partitionTsv/resources/usr/bin/test_partition_tsv.py
+++ b/modules/local/partitionTsv/resources/usr/bin/test_partition_tsv.py
@@ -27,7 +27,9 @@ class TestPartitionTsv:
         input_content = "x\ty\tz\n0\t1\t2\n3\t4\t5\n"
         input_file = tsv_factory.create_plain("input.tsv", input_content)
 
-        with pytest.raises(ValueError, match="Required column is missing from header line: test"):
+        with pytest.raises(
+            ValueError, match="Required column is missing from header line: test"
+        ):
             partition_tsv.partition(input_file, "test")
 
     def test_unsorted_file_raises_error(self, tsv_factory: Any, tmp_path: Path) -> None:
@@ -41,7 +43,9 @@ class TestPartitionTsv:
         os.chdir(input_dir)
 
         try:
-            with pytest.raises(ValueError, match="Input file is not sorted by partition column"):
+            with pytest.raises(
+                ValueError, match="Input file is not sorted by partition column"
+            ):
                 partition_tsv.partition(os.path.basename(input_file), "x")
         finally:
             os.chdir(original_cwd)
@@ -107,7 +111,11 @@ class TestPartitionTsv:
             partition_files = sorted(glob.glob("partition_*_input.tsv"))
             assert len(partition_files) == 3
 
-            expected_files = ["partition_0_input.tsv", "partition_3_input.tsv", "partition_6_input.tsv"]
+            expected_files = [
+                "partition_0_input.tsv",
+                "partition_3_input.tsv",
+                "partition_6_input.tsv",
+            ]
             assert partition_files == expected_files
 
             # Check content of each partition

--- a/modules/local/partitionTsv/resources/usr/bin/test_partition_tsv.py
+++ b/modules/local/partitionTsv/resources/usr/bin/test_partition_tsv.py
@@ -2,14 +2,13 @@
 
 # TODO: Add unit tests for individual functions in a future pass
 
+import glob
+import os
 from pathlib import Path
 from typing import Any
 
-import pytest
-import os
-import glob
-
 import partition_tsv
+import pytest
 
 
 class TestPartitionTsv:
@@ -88,7 +87,7 @@ class TestPartitionTsv:
             assert partition_files[0] == "partition_3_input.tsv"
 
             # Check that output matches input
-            with open(partition_files[0], "r") as f:
+            with open(partition_files[0]) as f:
                 content = f.read()
             assert content == input_content
         finally:
@@ -119,15 +118,15 @@ class TestPartitionTsv:
             assert partition_files == expected_files
 
             # Check content of each partition
-            with open("partition_0_input.tsv", "r") as f:
+            with open("partition_0_input.tsv") as f:
                 content_0 = f.read()
             assert content_0 == "x\ty\tz\n0\t1\t2\n"
 
-            with open("partition_3_input.tsv", "r") as f:
+            with open("partition_3_input.tsv") as f:
                 content_3 = f.read()
             assert content_3 == "x\ty\tz\n3\t4\t5\n3\t5\t6\n"
 
-            with open("partition_6_input.tsv", "r") as f:
+            with open("partition_6_input.tsv") as f:
                 content_6 = f.read()
             assert content_6 == "x\ty\tz\n6\t7\t8\n"
         finally:

--- a/modules/local/prepareViralMetadata/resources/usr/bin/prepare_viral_metadata.py
+++ b/modules/local/prepareViralMetadata/resources/usr/bin/prepare_viral_metadata.py
@@ -16,9 +16,13 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import IO, cast
 
+
 class UTCFormatter(logging.Formatter):
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
-        return datetime.fromtimestamp(record.created, UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
+        return datetime.fromtimestamp(record.created, UTC).strftime(
+            "%Y-%m-%d %H:%M:%S UTC"
+        )
+
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger()
@@ -27,10 +31,12 @@ handler.setFormatter(UTCFormatter("[%(asctime)s] %(message)s"))
 logger.handlers.clear()
 logger.addHandler(handler)
 
+
 def open_by_suffix(path: str, mode: str = "r") -> IO[str]:
     """Open a file, transparently handling .gz compression."""
     f = gzip.open(path, mode + "t") if path.endswith(".gz") else open(path, mode)
     return cast(IO[str], f)
+
 
 def build_species_taxid_map(virus_db_path: str) -> dict[str, str]:
     """Build taxid -> species_taxid mapping from virus taxonomy DB.
@@ -40,13 +46,20 @@ def build_species_taxid_map(virus_db_path: str) -> dict[str, str]:
         Dictionary mapping taxid to species-level taxid.
     """
     with open_by_suffix(virus_db_path) as f:
-        result = {row["taxid"]: row["taxid_species"] for row in csv.DictReader(f, delimiter="\t")}
+        result = {
+            row["taxid"]: row["taxid_species"]
+            for row in csv.DictReader(f, delimiter="\t")
+        }
     logger.info("Read %d entries from virus DB", len(result))
     return result
 
+
 ACCESSION_RE = re.compile(r"^(GC[AF]_\d+\.\d+)")
 
-def match_genomes_to_accessions(genome_dir: Path, accessions: list[str]) -> dict[str, str]:
+
+def match_genomes_to_accessions(
+    genome_dir: Path, accessions: list[str]
+) -> dict[str, str]:
     """Match genome .fna.gz files to assembly accessions by filename prefix.
     Args:
         genome_dir: Directory containing genome .fna.gz files.
@@ -62,9 +75,13 @@ def match_genomes_to_accessions(genome_dir: Path, accessions: list[str]) -> dict
             result[m.group(1)] = f.name
     return result
 
+
 def prepare_metadata(
-    merged_metadata_path: str, virus_db_path: str, genomes_dir: str,
-    output_metadata_path: str, output_genomes_dir: str,
+    merged_metadata_path: str,
+    virus_db_path: str,
+    genomes_dir: str,
+    output_metadata_path: str,
+    output_genomes_dir: str,
 ) -> None:
     """Read metadata + virus DB, add species_taxid and local_filename, symlink genomes.
     Args:
@@ -91,7 +108,9 @@ def prepare_metadata(
         return
     accessions = sorted({r["assembly_accession"] for r in rows})
     acc_to_file = match_genomes_to_accessions(genome_dir, accessions)
-    logger.info("Matched %d/%d accessions to genome files", len(acc_to_file), len(accessions))
+    logger.info(
+        "Matched %d/%d accessions to genome files", len(acc_to_file), len(accessions)
+    )
     # Symlink matched genomes into output directory
     for filename in acc_to_file.values():
         os.symlink(os.path.abspath(genome_dir / filename), output_dir / filename)
@@ -103,27 +122,41 @@ def prepare_metadata(
             if row["assembly_accession"] not in acc_to_file:
                 continue
             row["species_taxid"] = taxid_to_species.get(row["taxid"], "")
-            row["local_filename"] = f"{output_genomes_dir}/{acc_to_file[row['assembly_accession']]}"
+            row["local_filename"] = (
+                f"{output_genomes_dir}/{acc_to_file[row['assembly_accession']]}"
+            )
             writer.writerow(row)
             n_written += 1
-    logger.info("Wrote %d rows (dropped %d unmatched)", n_written, len(rows) - n_written)
+    logger.info(
+        "Wrote %d rows (dropped %d unmatched)", n_written, len(rows) - n_written
+    )
+
 
 def parse_arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("merged_metadata", help="Path to merged metadata TSV.")
     parser.add_argument("virus_db", help="Path to virus taxonomy DB TSV.")
     parser.add_argument("genomes_dir", help="Directory containing .fna.gz files.")
-    parser.add_argument("output_metadata", help="Output path for prepared metadata TSV.")
+    parser.add_argument(
+        "output_metadata", help="Output path for prepared metadata TSV."
+    )
     parser.add_argument("output_genomes_dir", help="Output directory for genome files.")
     return parser.parse_args()
+
 
 def main() -> None:
     start_time = time.time()
     logger.info("Starting prepare_viral_metadata.")
     args = parse_arguments()
-    prepare_metadata(args.merged_metadata, args.virus_db, args.genomes_dir,
-                     args.output_metadata, args.output_genomes_dir)
+    prepare_metadata(
+        args.merged_metadata,
+        args.virus_db,
+        args.genomes_dir,
+        args.output_metadata,
+        args.output_genomes_dir,
+    )
     logger.info("Total time elapsed: %.2f seconds", time.time() - start_time)
+
 
 if __name__ == "__main__":
     main()

--- a/modules/local/prepareViralMetadata/resources/usr/bin/prepare_viral_metadata.py
+++ b/modules/local/prepareViralMetadata/resources/usr/bin/prepare_viral_metadata.py
@@ -34,8 +34,9 @@ logger.addHandler(handler)
 
 def open_by_suffix(path: str, mode: str = "r") -> IO[str]:
     """Open a file, transparently handling .gz compression."""
-    f = gzip.open(path, mode + "t") if path.endswith(".gz") else open(path, mode)
-    return cast(IO[str], f)
+    if path.endswith(".gz"):
+        return cast(IO[str], gzip.open(path, mode + "t"))
+    return cast(IO[str], open(path, mode))
 
 
 def build_species_taxid_map(virus_db_path: str) -> dict[str, str]:

--- a/modules/local/prepareViralMetadata/resources/usr/bin/test_prepare_viral_metadata.py
+++ b/modules/local/prepareViralMetadata/resources/usr/bin/test_prepare_viral_metadata.py
@@ -5,7 +5,11 @@ import gzip
 from pathlib import Path
 
 import pytest
-from prepare_viral_metadata import build_species_taxid_map, match_genomes_to_accessions, prepare_metadata
+from prepare_viral_metadata import (
+    build_species_taxid_map,
+    match_genomes_to_accessions,
+    prepare_metadata,
+)
 
 ACCS = ["GCA_000001.1", "GCA_000002.1", "GCA_000003.1"]
 META_HEADER = ["assembly_accession", "taxid", "organism_name", "source_database"]
@@ -15,7 +19,12 @@ META_ROWS = [
     ["GCA_000003.1", "99999", "Virus C", "RefSeq"],
 ]
 DB_HEADER = ["taxid", "taxid_species", "name"]
-DB_ROWS = [["12345", "12345", "Virus A"], ["67890", "67000", "Virus B"], ["99999", "99000", "Virus C"]]
+DB_ROWS = [
+    ["12345", "12345", "Virus A"],
+    ["67890", "67000", "Virus B"],
+    ["99999", "99000", "Virus C"],
+]
+
 
 def _write_tsv(path: Path, header: list[str], rows: list[list[str]]) -> Path:
     with open(path, "w", newline="") as f:
@@ -24,6 +33,7 @@ def _write_tsv(path: Path, header: list[str], rows: list[list[str]]) -> Path:
         w.writerows(rows)
     return path
 
+
 def _make_genome_dir(tmp_path: Path, accessions: list[str]) -> Path:
     gdir = tmp_path / "genomes"
     gdir.mkdir(parents=True)
@@ -31,15 +41,20 @@ def _make_genome_dir(tmp_path: Path, accessions: list[str]) -> Path:
         (gdir / f"{acc}_genomic.fna.gz").write_bytes(b"dummy")
     return gdir
 
+
 def _read_tsv(path: Path) -> list[dict[str, str]]:
     with open(path) as f:
         return list(csv.DictReader(f, delimiter="\t"))
 
-def _run_prepare(tmp_path: Path, meta_path: Path, db_path: Path, gdir: Path) -> list[dict[str, str]]:
+
+def _run_prepare(
+    tmp_path: Path, meta_path: Path, db_path: Path, gdir: Path
+) -> list[dict[str, str]]:
     """Run prepare_metadata and return output rows."""
     out_meta, out_genomes = str(tmp_path / "out.txt"), str(tmp_path / "ncbi_genomes")
     prepare_metadata(str(meta_path), str(db_path), str(gdir), out_meta, out_genomes)
     return _read_tsv(Path(out_meta))
+
 
 @pytest.fixture()
 def standard_inputs(tmp_path: Path) -> tuple[Path, Path, Path]:
@@ -47,11 +62,16 @@ def standard_inputs(tmp_path: Path) -> tuple[Path, Path, Path]:
     db = _write_tsv(tmp_path / "db.tsv", DB_HEADER, DB_ROWS)
     return meta, db, _make_genome_dir(tmp_path, ACCS)
 
+
 class TestBuildSpeciesTaxidMap:
-    @pytest.mark.parametrize(("db_rows", "expected"), [
-        (DB_ROWS, {"12345": "12345", "67890": "67000", "99999": "99000"}),
-        ([], {}),
-    ], ids=["populated", "empty"])
+    @pytest.mark.parametrize(
+        ("db_rows", "expected"),
+        [
+            (DB_ROWS, {"12345": "12345", "67890": "67000", "99999": "99000"}),
+            ([], {}),
+        ],
+        ids=["populated", "empty"],
+    )
     def test_builds_map(self, tmp_path: Path, db_rows: list, expected: dict) -> None:
         db = _write_tsv(tmp_path / "db.tsv", DB_HEADER, db_rows)
         assert build_species_taxid_map(str(db)) == expected
@@ -63,35 +83,72 @@ class TestBuildSpeciesTaxidMap:
             w = csv.writer(f, delimiter="\t")
             w.writerow(DB_HEADER)
             w.writerows(DB_ROWS)
-        assert build_species_taxid_map(str(db_gz)) == {"12345": "12345", "67890": "67000", "99999": "99000"}
+        assert build_species_taxid_map(str(db_gz)) == {
+            "12345": "12345",
+            "67890": "67000",
+            "99999": "99000",
+        }
+
 
 class TestMatchGenomesToAccessions:
-    @pytest.mark.parametrize(("accessions", "dir_contents", "expected"), [
-        (["GCA_000001.1", "GCA_000002.1"], ["GCA_000001.1", "GCA_000002.1"],
-         {"GCA_000001.1": "GCA_000001.1_genomic.fna.gz", "GCA_000002.1": "GCA_000002.1_genomic.fna.gz"}),
-        (["GCA_000001.1", "GCA_MISSING.1"], ["GCA_000001.1"],
-         {"GCA_000001.1": "GCA_000001.1_genomic.fna.gz"}),
-        (["GCA_000001.1"], [], {}),
-        ([], ["GCA_000001.1"], {}),
-    ], ids=["all_match", "partial_match", "empty_dir", "empty_accessions"])
-    def test_match(self, tmp_path: Path, accessions: list[str],
-                   dir_contents: list[str], expected: dict[str, str]) -> None:
-        assert match_genomes_to_accessions(_make_genome_dir(tmp_path, dir_contents), accessions) == expected
+    @pytest.mark.parametrize(
+        ("accessions", "dir_contents", "expected"),
+        [
+            (
+                ["GCA_000001.1", "GCA_000002.1"],
+                ["GCA_000001.1", "GCA_000002.1"],
+                {
+                    "GCA_000001.1": "GCA_000001.1_genomic.fna.gz",
+                    "GCA_000002.1": "GCA_000002.1_genomic.fna.gz",
+                },
+            ),
+            (
+                ["GCA_000001.1", "GCA_MISSING.1"],
+                ["GCA_000001.1"],
+                {"GCA_000001.1": "GCA_000001.1_genomic.fna.gz"},
+            ),
+            (["GCA_000001.1"], [], {}),
+            ([], ["GCA_000001.1"], {}),
+        ],
+        ids=["all_match", "partial_match", "empty_dir", "empty_accessions"],
+    )
+    def test_match(
+        self,
+        tmp_path: Path,
+        accessions: list[str],
+        dir_contents: list[str],
+        expected: dict[str, str],
+    ) -> None:
+        assert (
+            match_genomes_to_accessions(
+                _make_genome_dir(tmp_path, dir_contents), accessions
+            )
+            == expected
+        )
+
 
 class TestPrepareMetadata:
-    def test_standard_output(self, tmp_path: Path, standard_inputs: tuple[Path, Path, Path]) -> None:
+    def test_standard_output(
+        self, tmp_path: Path, standard_inputs: tuple[Path, Path, Path]
+    ) -> None:
         meta_path, db_path, gdir = standard_inputs
         out_genomes = str(tmp_path / "ncbi_genomes")
         out_meta = str(tmp_path / "out.txt")
         prepare_metadata(str(meta_path), str(db_path), str(gdir), out_meta, out_genomes)
         rows = _read_tsv(Path(out_meta))
         assert len(rows) == 3
-        assert {r["taxid"]: r["species_taxid"] for r in rows} == {"12345": "12345", "67890": "67000", "99999": "99000"}
+        assert {r["taxid"]: r["species_taxid"] for r in rows} == {
+            "12345": "12345",
+            "67890": "67000",
+            "99999": "99000",
+        }
         assert all(r["local_filename"].startswith(out_genomes) for r in rows)
         symlinks = list(Path(out_genomes).glob("*.fna.gz"))
         assert len(symlinks) == 3 and all(s.is_symlink() for s in symlinks)
 
-    def test_empty_metadata_writes_header_only(self, tmp_path: Path, standard_inputs: tuple[Path, Path, Path]) -> None:
+    def test_empty_metadata_writes_header_only(
+        self, tmp_path: Path, standard_inputs: tuple[Path, Path, Path]
+    ) -> None:
         _, db_path, gdir = standard_inputs
         meta = _write_tsv(tmp_path / "empty.tsv", META_HEADER, [])
         out_meta = str(tmp_path / "out.txt")
@@ -103,20 +160,32 @@ class TestPrepareMetadata:
             header = f.readline().strip().split("\t")
         assert header == META_HEADER + ["species_taxid", "local_filename"]
 
-    def test_missing_genome_drops_row(self, tmp_path: Path, standard_inputs: tuple[Path, Path, Path]) -> None:
+    def test_missing_genome_drops_row(
+        self, tmp_path: Path, standard_inputs: tuple[Path, Path, Path]
+    ) -> None:
         _, db_path, _ = standard_inputs
-        meta = _write_tsv(tmp_path / "m.tsv", META_HEADER, [META_ROWS[0], ["GCA_MISSING.1", "67890", "B", "GenBank"]])
+        meta = _write_tsv(
+            tmp_path / "m.tsv",
+            META_HEADER,
+            [META_ROWS[0], ["GCA_MISSING.1", "67890", "B", "GenBank"]],
+        )
         gdir = _make_genome_dir(tmp_path / "sub", ["GCA_000001.1"])
         rows = _run_prepare(tmp_path / "run", meta, db_path, gdir)
         assert len(rows) == 1 and rows[0]["assembly_accession"] == "GCA_000001.1"
 
     def test_unmapped_taxid_gives_empty_species(self, tmp_path: Path) -> None:
-        meta = _write_tsv(tmp_path / "m.tsv", META_HEADER, [["GCA_000001.1", "00000", "X", "GenBank"]])
+        meta = _write_tsv(
+            tmp_path / "m.tsv", META_HEADER, [["GCA_000001.1", "00000", "X", "GenBank"]]
+        )
         db = _write_tsv(tmp_path / "db.tsv", DB_HEADER, [["12345", "12345", "V"]])
-        rows = _run_prepare(tmp_path / "run", meta, db, _make_genome_dir(tmp_path, ["GCA_000001.1"]))
+        rows = _run_prepare(
+            tmp_path / "run", meta, db, _make_genome_dir(tmp_path, ["GCA_000001.1"])
+        )
         assert rows[0]["species_taxid"] == ""
 
-    def test_gzipped_metadata_input(self, tmp_path: Path, standard_inputs: tuple[Path, Path, Path]) -> None:
+    def test_gzipped_metadata_input(
+        self, tmp_path: Path, standard_inputs: tuple[Path, Path, Path]
+    ) -> None:
         _, db_path, gdir = standard_inputs
         meta_gz = tmp_path / "meta.tsv.gz"
         with gzip.open(meta_gz, "wt", newline="") as f:

--- a/modules/local/processViralBowtie2Sam/resources/usr/bin/process_viral_bowtie2_sam.py
+++ b/modules/local/processViralBowtie2Sam/resources/usr/bin/process_viral_bowtie2_sam.py
@@ -4,9 +4,9 @@
 Given a sorted Bowtie2 SAM file, extract information about the alignments and write to a TSV.
 """
 
-#=======================================================================
+# =======================================================================
 # Import modules
-#=======================================================================
+# =======================================================================
 
 # Import modules
 import logging
@@ -26,65 +26,89 @@ from typing import IO, Sequence, cast
 type FieldValue = str | int | bool | float | None
 type FieldDict = dict[str, FieldValue]
 
-#=======================================================================
+# =======================================================================
 # Configure constants
-#=======================================================================
+# =======================================================================
 
 SAM_HEADERS_PAIRED = [
     "seq_id",
-    "genome_id", "genome_id_all",
-    "taxid", "taxid_all",
+    "genome_id",
+    "genome_id_all",
+    "taxid",
+    "taxid_all",
     "fragment_length",
-    "genome_id_fwd", "genome_id_rev",
-    "taxid_fwd", "taxid_rev",
-    "best_alignment_score", "best_alignment_score_rev",
-    "next_alignment_score", "next_alignment_score_rev",
-    "edit_distance", "edit_distance_rev",
-    "ref_start", "ref_start_rev",
-    "map_qual", "map_qual_rev",
-    "cigar", "cigar_rev",
-    "query_len", "query_len_rev",
-    "query_seq", "query_seq_rev",
-    "query_rc", "query_rc_rev",
-    "query_qual", "query_qual_rev",
-    "length_normalized_score_fwd", 
+    "genome_id_fwd",
+    "genome_id_rev",
+    "taxid_fwd",
+    "taxid_rev",
+    "best_alignment_score",
+    "best_alignment_score_rev",
+    "next_alignment_score",
+    "next_alignment_score_rev",
+    "edit_distance",
+    "edit_distance_rev",
+    "ref_start",
+    "ref_start_rev",
+    "map_qual",
+    "map_qual_rev",
+    "cigar",
+    "cigar_rev",
+    "query_len",
+    "query_len_rev",
+    "query_seq",
+    "query_seq_rev",
+    "query_rc",
+    "query_rc_rev",
+    "query_qual",
+    "query_qual_rev",
+    "length_normalized_score_fwd",
     "length_normalized_score_rev",
     "length_normalized_score",
     "pair_status",
-    "classification"
+    "classification",
 ]
 
 SAM_HEADERS_UNPAIRED = [
     "seq_id",
-    "genome_id", "taxid",
-    "best_alignment_score", "next_alignment_score",
-    "edit_distance", "ref_start",
-    "map_qual", "cigar",
-    "query_len", "query_seq",
-    "query_rc", "query_qual",
+    "genome_id",
+    "taxid",
+    "best_alignment_score",
+    "next_alignment_score",
+    "edit_distance",
+    "ref_start",
+    "map_qual",
+    "cigar",
+    "query_len",
+    "query_seq",
+    "query_rc",
+    "query_qual",
     "length_normalized_score",
-    "classification"
+    "classification",
 ]
 
-#=======================================================================
+# =======================================================================
 # Configure logging
-#=======================================================================
+# =======================================================================
+
 
 class UTCFormatter(logging.Formatter):
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
         dt = datetime.fromtimestamp(record.created, timezone.utc)
-        return dt.strftime('%Y-%m-%d %H:%M:%S UTC')
+        return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger()
 handler = logging.StreamHandler()
-formatter = UTCFormatter('[%(asctime)s] %(message)s')
+formatter = UTCFormatter("[%(asctime)s] %(message)s")
 handler.setFormatter(formatter)
 logger.handlers.clear()
 logger.addHandler(handler)
 
-#=======================================================================
+# =======================================================================
 # I/O functions
-#=======================================================================
+# =======================================================================
+
 
 def open_by_suffix(filename: str, mode: str = "r") -> IO[str]:
     """
@@ -98,26 +122,52 @@ def open_by_suffix(filename: str, mode: str = "r") -> IO[str]:
     logger.debug(f"\tOpening file object: {filename}")
     logger.debug(f"\tOpening mode: {mode}")
     logger.debug(f"\tGZIP mode: {filename.endswith('.gz')}")
-    if filename.endswith('.gz'):
-        return cast(IO[str], gzip.open(filename, mode + 't'))
+    if filename.endswith(".gz"):
+        return cast(IO[str], gzip.open(filename, mode + "t"))
     else:
         return open(filename, mode)
 
+
 def parse_args() -> argparse.Namespace:
     """Parse and return command-line arguments."""
-    parser = argparse.ArgumentParser(description="Process a sorted Bowtie2 SAM file into a TSV with additional information.")
-    parser.add_argument("-s", "--sam", type=lambda f: open_by_suffix(f, "r"), default=sys.stdin,
-                        help="Path to Bowtie2 SAM file (default: stdin).")
-    parser.add_argument("-m", "--metadata", required=True,
-                        help="Path to Genbank download metadata file containing genomeID and taxid information.")
-    parser.add_argument("-v", "--viral_db", required=True,
-                        help="Path to TSV containing viral taxonomic information.")
-    parser.add_argument("-o", "--output", type=lambda f: open_by_suffix(f, "w"), default=sys.stdout,
-                        help="Output path for processed data frame (default: stdout).")
-    parser.add_argument("--paired", action=argparse.BooleanOptionalAction, default=True,
-                        help="Processed SAM file as containing paired read alignments (default: True).")
+    parser = argparse.ArgumentParser(
+        description="Process a sorted Bowtie2 SAM file into a TSV with additional information."
+    )
+    parser.add_argument(
+        "-s",
+        "--sam",
+        type=lambda f: open_by_suffix(f, "r"),
+        default=sys.stdin,
+        help="Path to Bowtie2 SAM file (default: stdin).",
+    )
+    parser.add_argument(
+        "-m",
+        "--metadata",
+        required=True,
+        help="Path to Genbank download metadata file containing genomeID and taxid information.",
+    )
+    parser.add_argument(
+        "-v",
+        "--viral_db",
+        required=True,
+        help="Path to TSV containing viral taxonomic information.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=lambda f: open_by_suffix(f, "w"),
+        default=sys.stdout,
+        help="Output path for processed data frame (default: stdout).",
+    )
+    parser.add_argument(
+        "--paired",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Processed SAM file as containing paired read alignments (default: True).",
+    )
     args = parser.parse_args()
     return args
+
 
 def read_genbank_metadata(path: str) -> dict[str, tuple[str, str]]:
     """
@@ -128,11 +178,14 @@ def read_genbank_metadata(path: str) -> dict[str, tuple[str, str]]:
         dict[str, tuple[str, str]]: Dictionary mapping genome IDs to taxids.
     """
     meta_db = pd.read_csv(path, sep="\t", dtype=str)
-    gid_taxid_dict = {genome_id: (taxid, species_taxid)
-                      for genome_id, taxid, species_taxid in
-                      zip(meta_db["genome_id"],meta_db["taxid"],
-                          meta_db["species_taxid"])}
+    gid_taxid_dict = {
+        genome_id: (taxid, species_taxid)
+        for genome_id, taxid, species_taxid in zip(
+            meta_db["genome_id"], meta_db["taxid"], meta_db["species_taxid"]
+        )
+    }
     return gid_taxid_dict
+
 
 def get_viral_taxids(path: str) -> set[str]:
     """
@@ -145,6 +198,7 @@ def get_viral_taxids(path: str) -> set[str]:
     virus_db = pd.read_csv(path, sep="\t", dtype=str)
     return set(virus_db["taxid"].values)
 
+
 def join_line(fields: Sequence[FieldValue]) -> str:
     """
     Convert a list of arguments into a TSV string for output.
@@ -153,7 +207,8 @@ def join_line(fields: Sequence[FieldValue]) -> str:
     Returns:
         str: Joined fields.
     """
-    return("\t".join(map(str, fields)) + "\n")
+    return "\t".join(map(str, fields)) + "\n"
+
 
 def write_sam_headers(out_file: IO[str], paired: bool) -> None:
     """
@@ -169,23 +224,28 @@ def write_sam_headers(out_file: IO[str], paired: bool) -> None:
     out_file.write(header_line)
     return None
 
+
 def get_next_alignment(sam_file: IO[str]) -> str | None:
     """Iterate through SAM file lines until gets an alignment line, then returns."""
     while True:
-        l = next(sam_file, "EOF") # Get next line
-        if not l: continue # Skip empty lines
-        if l.startswith("@"): continue # Skip header lines
-        if l == "EOF": return None
-        return(l)
+        l = next(sam_file, "EOF")  # Get next line
+        if not l:
+            continue  # Skip empty lines
+        if l.startswith("@"):
+            continue  # Skip header lines
+        if l == "EOF":
+            return None
+        return l
 
-#=======================================================================
+
+# =======================================================================
 # Single-alignment processing functions
-#=======================================================================
+# =======================================================================
 
-def check_flag(flag_sum: int|str,
-               flag_dict: dict[str, bool],
-               flag_name: str,
-               flag_value: int) -> tuple[int, dict[str, bool]]:
+
+def check_flag(
+    flag_sum: int | str, flag_dict: dict[str, bool], flag_name: str, flag_value: int
+) -> tuple[int, dict[str, bool]]:
     """
     Check if a flag sum includes a specific flag and return adjusted flag sum.
     Args:
@@ -204,7 +264,8 @@ def check_flag(flag_sum: int|str,
         flag_dict[flag_name] = False
     return flag_sum, flag_dict
 
-def process_sam_flags(flag_sum: int|str) -> dict[str, bool]:
+
+def process_sam_flags(flag_sum: int | str) -> dict[str, bool]:
     """
     Extract individual flags from flag sum.
     Args:
@@ -223,11 +284,12 @@ def process_sam_flags(flag_sum: int|str) -> dict[str, bool]:
     flag_sum, flag_dict = check_flag(flag_sum, flag_dict, "no_single_alignments", 4)
     flag_sum, flag_dict = check_flag(flag_sum, flag_dict, "proper_paired_alignment", 2)
     flag_sum, flag_dict = check_flag(flag_sum, flag_dict, "in_pair", 1)
-    return(flag_dict)
+    return flag_dict
 
-def extract_option(opt_list: list[str],
-                   query_value: str,
-                   default: str|None = None) -> str|None:
+
+def extract_option(
+    opt_list: list[str], query_value: str, default: str | None = None
+) -> str | None:
     """
     Extract specific optional field from list of optional fields.
     Args:
@@ -238,12 +300,14 @@ def extract_option(opt_list: list[str],
         str|None: Extracted value or default value.
     """
     fields = [f for f in opt_list if query_value in f]
-    if len(fields) == 0: return(default)
+    if len(fields) == 0:
+        return default
     assert len(fields) == 1, f"Multiple fields found for {query_value}: {fields}"
     field = fields[0]
     pattern = "{}:.:(.*)".format(query_value)
     out_value: str = re.findall(pattern, field)[0]
-    return(out_value)
+    return out_value
+
 
 def extract_optional_fields(opt_list: list[str]) -> dict[str, str | None]:
     """
@@ -259,11 +323,12 @@ def extract_optional_fields(opt_list: list[str]) -> dict[str, str | None]:
     out["edit_distance"] = extract_option(opt_list, "NM")
     out["pair_status"] = extract_option(opt_list, "YT")
     out["mate_alignment_score"] = extract_option(opt_list, "YS")
-    return(out)
+    return out
 
-def extract_viral_taxid(genome_id: str,
-                        genbank_metadata: dict[str, tuple[str, str]],
-                        viral_taxids: set[str]) -> str:
+
+def extract_viral_taxid(
+    genome_id: str, genbank_metadata: dict[str, tuple[str, str]], viral_taxids: set[str]
+) -> str:
     """
     Extract taxid from the appropriate field of Genbank metadata.
     Args:
@@ -285,10 +350,13 @@ def extract_viral_taxid(genome_id: str,
         logger.error(msg)
         raise ValueError(msg)
 
-def process_sam_alignment(sam_line: str,
-                          genbank_metadata: dict[str, tuple[str, str]],
-                          viral_taxids: set[str],
-                          paired: bool) -> FieldDict:
+
+def process_sam_alignment(
+    sam_line: str,
+    genbank_metadata: dict[str, tuple[str, str]],
+    viral_taxids: set[str],
+    paired: bool,
+) -> FieldDict:
     """
     Process a SAM alignment line into a dictionary of fields.
     Args:
@@ -306,13 +374,15 @@ def process_sam_alignment(sam_line: str,
     out["seq_id"] = fields_in[0]
     out.update(process_sam_flags(fields_in[1]))
     out["genome_id"] = fields_in[2]
-    out["taxid"] = int(extract_viral_taxid(fields_in[2], genbank_metadata, viral_taxids))
-    out["ref_start"] = int(fields_in[3]) - 1 # Convert from 1-indexing to 0-indexing
+    out["taxid"] = int(
+        extract_viral_taxid(fields_in[2], genbank_metadata, viral_taxids)
+    )
+    out["ref_start"] = int(fields_in[3]) - 1  # Convert from 1-indexing to 0-indexing
     out["map_qual"] = int(fields_in[4])
     out["cigar"] = fields_in[5]
     if paired:
         out["mate_genome_id"] = fields_in[6]
-        out["mate_ref_start"] = int(fields_in[7]) - 1 # Convert as above
+        out["mate_ref_start"] = int(fields_in[7]) - 1  # Convert as above
         out["fragment_length"] = abs(int(fields_in[8]))
     out["query_seq"] = fields_in[9]
     out["query_qual"] = fields_in[10]
@@ -324,14 +394,15 @@ def process_sam_alignment(sam_line: str,
         out["query_qual"] = str(out["query_qual"])[::-1]
         out["query_rc"] = True
     out["query_len"] = len(str(out["query_seq"]))
-    return(out)
+    return out
 
-#=======================================================================
+
+# =======================================================================
 # Line processing functions
-#=======================================================================
+# =======================================================================
 
-def get_line(fields_dict: FieldDict,
-             paired: bool) -> str:
+
+def get_line(fields_dict: FieldDict, paired: bool) -> str:
     """
     Convert a dictionary of fields into an output line.
     Args:
@@ -343,16 +414,17 @@ def get_line(fields_dict: FieldDict,
     # First check all required fields are present
     headers = SAM_HEADERS_PAIRED if paired else SAM_HEADERS_UNPAIRED
     for header in headers:
-        assert header in fields_dict, \
+        assert header in fields_dict, (
             f"Required field is missing from dictionary: {header}, {fields_dict}"
+        )
     # Then convert dictionary into list of fields
     fields = [fields_dict[header] for header in headers]
     # Then join fields into line
     line = join_line(fields)
-    return(line)
+    return line
 
-def get_line_from_single(read_dict: FieldDict,
-                         paired: bool) -> str:
+
+def get_line_from_single(read_dict: FieldDict, paired: bool) -> str:
     """
     Generate an output line from a single SAM alignment dictionary.
     Args:
@@ -362,18 +434,23 @@ def get_line_from_single(read_dict: FieldDict,
         str: Output line.
     """
     # Calculate length-adjusted alignment score
-    adj_score = float(str(read_dict["alignment_score"])) / math.log(float(str(read_dict["query_len"])))
+    adj_score = float(str(read_dict["alignment_score"])) / math.log(
+        float(str(read_dict["query_len"]))
+    )
     # Prepare dictionary for output
     out_dict: FieldDict = {
-    "seq_id": read_dict["seq_id"],
-    "genome_id": read_dict["genome_id"],
-    "taxid": read_dict["taxid"],
-    "length_normalized_score": adj_score,
-    "pair_status": read_dict["pair_status"],
-    "classification": (
-        "supplementary"  if read_dict["is_supplementary"]
-        else "secondary" if read_dict["is_secondary"]
-        else "primary")
+        "seq_id": read_dict["seq_id"],
+        "genome_id": read_dict["genome_id"],
+        "taxid": read_dict["taxid"],
+        "length_normalized_score": adj_score,
+        "pair_status": read_dict["pair_status"],
+        "classification": (
+            "supplementary"
+            if read_dict["is_supplementary"]
+            else "secondary"
+            if read_dict["is_secondary"]
+            else "primary"
+        ),
     }
     if paired:
         # Additional fields for paired SAM
@@ -383,34 +460,88 @@ def get_line_from_single(read_dict: FieldDict,
         out_dict["fragment_length"] = "NA"
         # Additional fields based on forward/reverse status
         if read_dict["is_mate_1"]:
-            out_dict["genome_id_fwd"], out_dict["genome_id_rev"] = read_dict["genome_id"], "NA"
+            out_dict["genome_id_fwd"], out_dict["genome_id_rev"] = (
+                read_dict["genome_id"],
+                "NA",
+            )
             out_dict["taxid_fwd"], out_dict["taxid_rev"] = read_dict["taxid"], "NA"
-            out_dict["best_alignment_score"], out_dict["best_alignment_score_rev"] = read_dict["alignment_score"], "NA"
-            out_dict["next_alignment_score"], out_dict["next_alignment_score_rev"] = read_dict["next_best_alignment"], "NA"
-            out_dict["edit_distance"], out_dict["edit_distance_rev"] = read_dict["edit_distance"], "NA"
-            out_dict["ref_start"], out_dict["ref_start_rev"] = read_dict["ref_start"], "NA"
+            out_dict["best_alignment_score"], out_dict["best_alignment_score_rev"] = (
+                read_dict["alignment_score"],
+                "NA",
+            )
+            out_dict["next_alignment_score"], out_dict["next_alignment_score_rev"] = (
+                read_dict["next_best_alignment"],
+                "NA",
+            )
+            out_dict["edit_distance"], out_dict["edit_distance_rev"] = (
+                read_dict["edit_distance"],
+                "NA",
+            )
+            out_dict["ref_start"], out_dict["ref_start_rev"] = (
+                read_dict["ref_start"],
+                "NA",
+            )
             out_dict["map_qual"], out_dict["map_qual_rev"] = read_dict["map_qual"], "NA"
             out_dict["cigar"], out_dict["cigar_rev"] = read_dict["cigar"], "NA"
-            out_dict["query_len"], out_dict["query_len_rev"] = read_dict["query_len"], "NA"
-            out_dict["query_seq"], out_dict["query_seq_rev"] = read_dict["query_seq"], "NA"
+            out_dict["query_len"], out_dict["query_len_rev"] = (
+                read_dict["query_len"],
+                "NA",
+            )
+            out_dict["query_seq"], out_dict["query_seq_rev"] = (
+                read_dict["query_seq"],
+                "NA",
+            )
             out_dict["query_rc"], out_dict["query_rc_rev"] = read_dict["query_rc"], "NA"
-            out_dict["query_qual"], out_dict["query_qual_rev"] = read_dict["query_qual"], "NA"
-            out_dict["length_normalized_score_fwd"], out_dict["length_normalized_score_rev"] = adj_score, "NA"
-        else: # Is mate 2
-            out_dict["genome_id_fwd"], out_dict["genome_id_rev"] = "NA", read_dict["genome_id"]
+            out_dict["query_qual"], out_dict["query_qual_rev"] = (
+                read_dict["query_qual"],
+                "NA",
+            )
+            (
+                out_dict["length_normalized_score_fwd"],
+                out_dict["length_normalized_score_rev"],
+            ) = adj_score, "NA"
+        else:  # Is mate 2
+            out_dict["genome_id_fwd"], out_dict["genome_id_rev"] = (
+                "NA",
+                read_dict["genome_id"],
+            )
             out_dict["taxid_fwd"], out_dict["taxid_rev"] = "NA", read_dict["taxid"]
-            out_dict["best_alignment_score"], out_dict["best_alignment_score_rev"] = "NA", read_dict["alignment_score"]
-            out_dict["next_alignment_score"], out_dict["next_alignment_score_rev"] = "NA", read_dict["next_best_alignment"]
-            out_dict["edit_distance"], out_dict["edit_distance_rev"] = "NA", read_dict["edit_distance"]
-            out_dict["ref_start"], out_dict["ref_start_rev"] = "NA", read_dict["ref_start"]
+            out_dict["best_alignment_score"], out_dict["best_alignment_score_rev"] = (
+                "NA",
+                read_dict["alignment_score"],
+            )
+            out_dict["next_alignment_score"], out_dict["next_alignment_score_rev"] = (
+                "NA",
+                read_dict["next_best_alignment"],
+            )
+            out_dict["edit_distance"], out_dict["edit_distance_rev"] = (
+                "NA",
+                read_dict["edit_distance"],
+            )
+            out_dict["ref_start"], out_dict["ref_start_rev"] = (
+                "NA",
+                read_dict["ref_start"],
+            )
             out_dict["map_qual"], out_dict["map_qual_rev"] = "NA", read_dict["map_qual"]
             out_dict["cigar"], out_dict["cigar_rev"] = "NA", read_dict["cigar"]
-            out_dict["query_len"], out_dict["query_len_rev"] = "NA", read_dict["query_len"]
-            out_dict["query_seq"], out_dict["query_seq_rev"] = "NA", read_dict["query_seq"]
+            out_dict["query_len"], out_dict["query_len_rev"] = (
+                "NA",
+                read_dict["query_len"],
+            )
+            out_dict["query_seq"], out_dict["query_seq_rev"] = (
+                "NA",
+                read_dict["query_seq"],
+            )
             out_dict["query_rc"], out_dict["query_rc_rev"] = "NA", read_dict["query_rc"]
-            out_dict["query_qual"], out_dict["query_qual_rev"] = "NA", read_dict["query_qual"]
-            out_dict["length_normalized_score_fwd"], out_dict["length_normalized_score_rev"] = "NA", adj_score
-    else: # Is unpaired
+            out_dict["query_qual"], out_dict["query_qual_rev"] = (
+                "NA",
+                read_dict["query_qual"],
+            )
+            (
+                out_dict["length_normalized_score_fwd"],
+                out_dict["length_normalized_score_rev"],
+            ) = "NA", adj_score
+    else:  # Is unpaired
         out_dict["best_alignment_score"] = read_dict["alignment_score"]
         out_dict["next_alignment_score"] = read_dict["next_best_alignment"]
         out_dict["edit_distance"] = read_dict["edit_distance"]
@@ -423,8 +554,8 @@ def get_line_from_single(read_dict: FieldDict,
         out_dict["query_qual"] = read_dict["query_qual"]
     return get_line(out_dict, paired)
 
-def get_line_from_pair(dict_1: FieldDict,
-                       dict_2: FieldDict) -> str:
+
+def get_line_from_pair(dict_1: FieldDict, dict_2: FieldDict) -> str:
     """
     Generate an output line from two SAM alignment dictionaries.
     Args:
@@ -446,8 +577,12 @@ def get_line_from_pair(dict_1: FieldDict,
     rev_dict = dict_1 if not dict_1["is_mate_1"] else dict_2
     # Calculate length-adjusted alignment scores
     try:
-        adj_score_fwd = float(str(fwd_dict["alignment_score"])) / math.log(float(str(fwd_dict["query_len"])))
-        adj_score_rev = float(str(rev_dict["alignment_score"])) / math.log(float(str(rev_dict["query_len"])))
+        adj_score_fwd = float(str(fwd_dict["alignment_score"])) / math.log(
+            float(str(fwd_dict["query_len"]))
+        )
+        adj_score_rev = float(str(rev_dict["alignment_score"])) / math.log(
+            float(str(rev_dict["query_len"]))
+        )
         adj_score_max = max(adj_score_fwd, adj_score_rev)
         score_fwd_max = adj_score_fwd >= adj_score_rev
     except Exception as e:
@@ -463,7 +598,9 @@ def get_line_from_pair(dict_1: FieldDict,
         taxid_all = fwd_dict["taxid"]
         fragment_length = fwd_dict["fragment_length"]
     else:
-        genome_id_best = fwd_dict["genome_id"] if score_fwd_max else rev_dict["genome_id"]
+        genome_id_best = (
+            fwd_dict["genome_id"] if score_fwd_max else rev_dict["genome_id"]
+        )
         genome_id_list = [str(fwd_dict["genome_id"]), str(rev_dict["genome_id"])]
         genome_id_all = "/".join(genome_id_list)
         fragment_length = "NA"
@@ -511,15 +648,16 @@ def get_line_from_pair(dict_1: FieldDict,
         "length_normalized_score": adj_score_max,
         "pair_status": fwd_dict["pair_status"],
         "classification": "secondary" if fwd_dict["is_secondary"] else "primary",
-        }
+    }
     return get_line(out_dict, True)
 
-#=======================================================================
-# File processing functions
-#=======================================================================
 
-def check_pair_status(line_dict: FieldDict,
-                      paired: bool) -> None:
+# =======================================================================
+# File processing functions
+# =======================================================================
+
+
+def check_pair_status(line_dict: FieldDict, paired: bool) -> None:
     """
     Check if pair status is valid for SAM entry line.
     Args:
@@ -534,10 +672,13 @@ def check_pair_status(line_dict: FieldDict,
     elif not paired and pair_status != "UU":
         raise ValueError(f"Paired read in unpaired SAM file: {line_dict['seq_id']}")
 
-def process_paired_sam(inf: IO[str],
-                       outf: IO[str],
-                       genbank_metadata: dict[str, tuple[str, str]],
-                       viral_taxids: set[str]) -> None:
+
+def process_paired_sam(
+    inf: IO[str],
+    outf: IO[str],
+    genbank_metadata: dict[str, tuple[str, str]],
+    viral_taxids: set[str],
+) -> None:
     """
     Process paired SAM file into a TSV.
     Args:
@@ -561,8 +702,12 @@ def process_paired_sam(inf: IO[str],
     rev_line = get_next_alignment(inf)
     while True:
         if fwd_line is None:
-            if rev_line is not None: # Break if reverse line exists without forward line
-                rev_dict = process_sam_alignment(rev_line, genbank_metadata, viral_taxids, True)
+            if (
+                rev_line is not None
+            ):  # Break if reverse line exists without forward line
+                rev_dict = process_sam_alignment(
+                    rev_line, genbank_metadata, viral_taxids, True
+                )
                 msg = f"Invalid data: reverse line exists without forward line: {rev_dict['seq_id']}"
                 logger.error(msg)
                 raise ValueError(msg)
@@ -570,7 +715,9 @@ def process_paired_sam(inf: IO[str],
         # Extract forward read information and check pair status
         fwd_dict = process_sam_alignment(fwd_line, genbank_metadata, viral_taxids, True)
         check_pair_status(fwd_dict, True)
-        if rev_line is None: # If no reverse line, check pair status, then process forward line as unpaired
+        if (
+            rev_line is None
+        ):  # If no reverse line, check pair status, then process forward line as unpaired
             if fwd_dict["pair_status"] != "UP":
                 msg = f"Forward read is paired but reverse read is missing: {fwd_dict['seq_id']}"
                 logger.error(msg)
@@ -616,10 +763,13 @@ def process_paired_sam(inf: IO[str],
         rev_line = get_next_alignment(inf)
         continue
 
-def process_unpaired_sam(inf: IO[str],
-                         outf: IO[str],
-                         genbank_metadata: dict[str, tuple[str, str]],
-                         viral_taxids: set[str]) -> None:
+
+def process_unpaired_sam(
+    inf: IO[str],
+    outf: IO[str],
+    genbank_metadata: dict[str, tuple[str, str]],
+    viral_taxids: set[str],
+) -> None:
     """
     Process unpaired SAM file into a TSV.
     Args:
@@ -646,10 +796,14 @@ def process_unpaired_sam(inf: IO[str],
     logger.debug(f"Next line: {next_line}")
     # Iterate over input lines individually until end of file reached
     while input_line is not None:
-        read_dict = process_sam_alignment(input_line, genbank_metadata, viral_taxids, False)
+        read_dict = process_sam_alignment(
+            input_line, genbank_metadata, viral_taxids, False
+        )
         logger.debug(f"Read dict: {read_dict}")
-        if next_line is not None: # Check sorting
-            next_dict = process_sam_alignment(next_line, genbank_metadata, viral_taxids, False)
+        if next_line is not None:  # Check sorting
+            next_dict = process_sam_alignment(
+                next_line, genbank_metadata, viral_taxids, False
+            )
             if str(read_dict["seq_id"]) > str(next_dict["seq_id"]):
                 msg = f"Reads are not sorted: encountered {read_dict['seq_id']} before {next_dict['seq_id']}"
                 logger.error(msg)
@@ -665,9 +819,11 @@ def process_unpaired_sam(inf: IO[str],
         next_line = None if input_line is None else get_next_alignment(inf)
     return
 
-#=======================================================================
+
+# =======================================================================
 # Main function
-#=======================================================================
+# =======================================================================
+
 
 def main() -> None:
     logger.info("Initializing script.")
@@ -698,6 +854,7 @@ def main() -> None:
         args.output.close()
         end_time = time.time()
         logger.info(f"Total time elapsed: {end_time - start_time} seconds")
+
 
 if __name__ == "__main__":
     main()

--- a/modules/local/processViralBowtie2Sam/resources/usr/bin/process_viral_bowtie2_sam.py
+++ b/modules/local/processViralBowtie2Sam/resources/usr/bin/process_viral_bowtie2_sam.py
@@ -165,8 +165,7 @@ def parse_args() -> argparse.Namespace:
         default=True,
         help="Processed SAM file as containing paired read alignments (default: True).",
     )
-    args = parser.parse_args()
-    return args
+    return parser.parse_args()
 
 
 def read_genbank_metadata(path: str) -> dict[str, tuple[str, str]]:
@@ -178,13 +177,15 @@ def read_genbank_metadata(path: str) -> dict[str, tuple[str, str]]:
         dict[str, tuple[str, str]]: Dictionary mapping genome IDs to taxids.
     """
     meta_db = pd.read_csv(path, sep="\t", dtype=str)
-    gid_taxid_dict = {
+    return {
         genome_id: (taxid, species_taxid)
         for genome_id, taxid, species_taxid in zip(
-            meta_db["genome_id"], meta_db["taxid"], meta_db["species_taxid"]
+            meta_db["genome_id"],
+            meta_db["taxid"],
+            meta_db["species_taxid"],
+            strict=False,
         )
     }
-    return gid_taxid_dict
 
 
 def get_viral_taxids(path: str) -> set[str]:
@@ -420,8 +421,7 @@ def get_line(fields_dict: FieldDict, paired: bool) -> str:
     # Then convert dictionary into list of fields
     fields = [fields_dict[header] for header in headers]
     # Then join fields into line
-    line = join_line(fields)
-    return line
+    return join_line(fields)
 
 
 def get_line_from_single(read_dict: FieldDict, paired: bool) -> str:

--- a/modules/local/processViralBowtie2Sam/resources/usr/bin/process_viral_bowtie2_sam.py
+++ b/modules/local/processViralBowtie2Sam/resources/usr/bin/process_viral_bowtie2_sam.py
@@ -349,7 +349,7 @@ def extract_viral_taxid(
     except KeyError:
         msg = f"No matching genome ID found: {genome_id}"
         logger.error(msg)
-        raise ValueError(msg)
+        raise ValueError(msg) from None
 
 
 def process_sam_alignment(

--- a/modules/local/processViralBowtie2Sam/resources/usr/bin/process_viral_bowtie2_sam.py
+++ b/modules/local/processViralBowtie2Sam/resources/usr/bin/process_viral_bowtie2_sam.py
@@ -183,7 +183,7 @@ def read_genbank_metadata(path: str) -> dict[str, tuple[str, str]]:
             meta_db["genome_id"],
             meta_db["taxid"],
             meta_db["species_taxid"],
-            strict=False,
+            strict=True,
         )
     }
 

--- a/modules/local/processViralBowtie2Sam/resources/usr/bin/process_viral_bowtie2_sam.py
+++ b/modules/local/processViralBowtie2Sam/resources/usr/bin/process_viral_bowtie2_sam.py
@@ -9,18 +9,19 @@ Given a sorted Bowtie2 SAM file, extract information about the alignments and wr
 # =======================================================================
 
 # Import modules
-import logging
-from datetime import datetime, timezone
-import sys
-import re
 import argparse
-import pandas as pd
-import time
 import gzip
+import logging
 import math
+import re
+import sys
+import time
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from typing import IO, cast
+
+import pandas as pd
 from Bio import Seq
-import io
-from typing import IO, Sequence, cast
 
 # Type alias for SAM field dictionaries that contain mixed value types
 type FieldValue = str | int | bool | float | None
@@ -93,7 +94,7 @@ SAM_HEADERS_UNPAIRED = [
 
 class UTCFormatter(logging.Formatter):
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
-        dt = datetime.fromtimestamp(record.created, timezone.utc)
+        dt = datetime.fromtimestamp(record.created, UTC)
         return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
@@ -124,8 +125,7 @@ def open_by_suffix(filename: str, mode: str = "r") -> IO[str]:
     logger.debug(f"\tGZIP mode: {filename.endswith('.gz')}")
     if filename.endswith(".gz"):
         return cast(IO[str], gzip.open(filename, mode + "t"))
-    else:
-        return open(filename, mode)
+    return open(filename, mode)
 
 
 def parse_args() -> argparse.Namespace:
@@ -222,7 +222,7 @@ def write_sam_headers(out_file: IO[str], paired: bool) -> None:
     header_line = join_line(headers)
     logger.debug(f"Writing header line: {header_line}")
     out_file.write(header_line)
-    return None
+    return
 
 
 def get_next_alignment(sam_file: IO[str]) -> str | None:
@@ -304,7 +304,7 @@ def extract_option(
         return default
     assert len(fields) == 1, f"Multiple fields found for {query_value}: {fields}"
     field = fields[0]
-    pattern = "{}:.:(.*)".format(query_value)
+    pattern = f"{query_value}:.:(.*)"
     out_value: str = re.findall(pattern, field)[0]
     return out_value
 
@@ -346,7 +346,7 @@ def extract_viral_taxid(
             return species_taxid
         return taxid
     except KeyError:
-        msg = "No matching genome ID found: {}".format(genome_id)
+        msg = f"No matching genome ID found: {genome_id}"
         logger.error(msg)
         raise ValueError(msg)
 
@@ -667,9 +667,9 @@ def check_pair_status(line_dict: FieldDict, paired: bool) -> None:
     pair_status = line_dict["pair_status"]
     if pair_status not in ["UU", "UP", "CP", "DP"]:
         raise ValueError(f"Invalid pair status: {line_dict['seq_id']}, {pair_status}")
-    elif paired and pair_status == "UU":
+    if paired and pair_status == "UU":
         raise ValueError(f"Unpaired read in paired SAM file: {line_dict['seq_id']}")
-    elif not paired and pair_status != "UU":
+    if not paired and pair_status != "UU":
         raise ValueError(f"Paired read in unpaired SAM file: {line_dict['seq_id']}")
 
 

--- a/modules/local/processViralBowtie2Sam/resources/usr/bin/process_viral_bowtie2_sam.py
+++ b/modules/local/processViralBowtie2Sam/resources/usr/bin/process_viral_bowtie2_sam.py
@@ -229,14 +229,14 @@ def write_sam_headers(out_file: IO[str], paired: bool) -> None:
 def get_next_alignment(sam_file: IO[str]) -> str | None:
     """Iterate through SAM file lines until gets an alignment line, then returns."""
     while True:
-        l = next(sam_file, "EOF")  # Get next line
-        if not l:
+        line = next(sam_file, "EOF")  # Get next line
+        if not line:
             continue  # Skip empty lines
-        if l.startswith("@"):
+        if line.startswith("@"):
             continue  # Skip header lines
-        if l == "EOF":
+        if line == "EOF":
             return None
-        return l
+        return line
 
 
 # =======================================================================

--- a/modules/local/processViralBowtie2Sam/resources/usr/bin/test_process_viral_bowtie2_sam.py
+++ b/modules/local/processViralBowtie2Sam/resources/usr/bin/test_process_viral_bowtie2_sam.py
@@ -31,12 +31,16 @@ class TestProcessViralBowtie2Sam:
         output = tmp_path / "output.tsv.gz"
 
         # Read metadata
-        genbank_metadata_dict = process_viral_bowtie2_sam.read_genbank_metadata(str(genbank_metadata))
+        genbank_metadata_dict = process_viral_bowtie2_sam.read_genbank_metadata(
+            str(genbank_metadata)
+        )
         viral_taxids = process_viral_bowtie2_sam.get_viral_taxids(str(virus_db))
 
         # Process the empty SAM file (paired mode)
         with gzip.open(sam_input, "rt") as inf, gzip.open(output, "wt") as outf:
-            process_viral_bowtie2_sam.process_paired_sam(inf, outf, genbank_metadata_dict, viral_taxids)
+            process_viral_bowtie2_sam.process_paired_sam(
+                inf, outf, genbank_metadata_dict, viral_taxids
+            )
 
         # Read output
         with gzip.open(output, "rt") as f:
@@ -49,9 +53,11 @@ class TestProcessViralBowtie2Sam:
         headers = lines[0].strip().split("\t")
         expected_headers = [
             "seq_id",
-            "genome_id", "genome_id_all",
-            "taxid", "taxid_all",
-            "fragment_length"
+            "genome_id",
+            "genome_id_all",
+            "taxid",
+            "taxid_all",
+            "fragment_length",
         ]
 
         # Verify all expected headers are present and in the right order

--- a/modules/local/processViralBowtie2Sam/resources/usr/bin/test_process_viral_bowtie2_sam.py
+++ b/modules/local/processViralBowtie2Sam/resources/usr/bin/test_process_viral_bowtie2_sam.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
-from pathlib import Path
-
-import pytest
 import gzip
+from pathlib import Path
 
 import process_viral_bowtie2_sam
 

--- a/modules/local/processViralMinimap2Sam/resources/usr/bin/process_viral_minimap2_sam.py
+++ b/modules/local/processViralMinimap2Sam/resources/usr/bin/process_viral_minimap2_sam.py
@@ -5,15 +5,14 @@ import gzip
 import logging
 import math
 import sys
-from typing import Any
 import tempfile
 import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime
+from typing import Any
 
 import pandas as pd
 import pysam
 from Bio.Seq import Seq
-
 from sort_fastq import sort_fastq
 from sort_sam import sort_sam
 
@@ -23,7 +22,7 @@ class UTCFormatter(logging.Formatter):
 
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
         """Format log timestamps in UTC timezone."""
-        dt = datetime.fromtimestamp(record.created, timezone.utc)
+        dt = datetime.fromtimestamp(record.created, UTC)
         return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
 
 

--- a/modules/local/processViralMinimap2Sam/resources/usr/bin/process_viral_minimap2_sam.py
+++ b/modules/local/processViralMinimap2Sam/resources/usr/bin/process_viral_minimap2_sam.py
@@ -231,7 +231,7 @@ def main() -> None:
                 meta_db["genome_id"],
                 meta_db["taxid"],
                 meta_db["species_taxid"],
-                strict=False,
+                strict=True,
             )
         }
         virus_db = pd.read_csv(args.viral_db, sep="\t", dtype=str)

--- a/modules/local/processViralMinimap2Sam/resources/usr/bin/process_viral_minimap2_sam.py
+++ b/modules/local/processViralMinimap2Sam/resources/usr/bin/process_viral_minimap2_sam.py
@@ -75,7 +75,9 @@ def read_fastq_record(fh: Any) -> tuple[str, str, str] | None:
     return (read_id, seq, qual)
 
 
-def extract_viral_taxid(genome_id: str, genbank_metadata: dict[str, list[str]], viral_taxids: set[str]) -> str:
+def extract_viral_taxid(
+    genome_id: str, genbank_metadata: dict[str, list[str]], viral_taxids: set[str]
+) -> str:
     """Return taxid for a genome, preferring whichever of taxid/species_taxid is viral."""
     try:
         taxid, species_taxid = genbank_metadata[genome_id]
@@ -89,7 +91,11 @@ def extract_viral_taxid(genome_id: str, genbank_metadata: dict[str, list[str]], 
 
 
 def parse_sam_alignment(
-    read: Any, genbank_metadata: dict[str, list[str]], viral_taxids: set[str], clean_seq: str, clean_qual: str
+    read: Any,
+    genbank_metadata: dict[str, list[str]],
+    viral_taxids: set[str],
+    clean_seq: str,
+    clean_qual: str,
 ) -> dict[str, Any]:
     """Parse a Minimap2 SAM alignment into an output dict."""
     taxid = extract_viral_taxid(read.reference_name, genbank_metadata, viral_taxids)
@@ -123,13 +129,19 @@ def parse_sam_alignment(
         "classification": (
             "supplementary"
             if read.is_supplementary
-            else "secondary" if read.is_secondary else "primary"
+            else "secondary"
+            if read.is_secondary
+            else "primary"
         ),
     }
 
 
 def process_sam(
-    sam_file: str, out_file: str, genbank_metadata: dict[str, list[str]], viral_taxids: set[str], fastq_file: str
+    sam_file: str,
+    out_file: str,
+    genbank_metadata: dict[str, list[str]],
+    viral_taxids: set[str],
+    fastq_file: str,
 ) -> None:
     """Process a Minimap2 SAM file using streaming merge join with sorted FASTQ.
 
@@ -172,8 +184,7 @@ def process_sam(
                 )
             if num_reads == 0:
                 logger.warning(
-                    "Input SAM file is empty. "
-                    "Creating empty output with header only."
+                    "Input SAM file is empty. Creating empty output with header only."
                 )
 
 

--- a/modules/local/processViralMinimap2Sam/resources/usr/bin/process_viral_minimap2_sam.py
+++ b/modules/local/processViralMinimap2Sam/resources/usr/bin/process_viral_minimap2_sam.py
@@ -86,7 +86,7 @@ def extract_viral_taxid(
             return species_taxid
         return taxid
     except KeyError:
-        raise ValueError(f"No matching genome ID found: {genome_id}")
+        raise ValueError(f"No matching genome ID found: {genome_id}") from None
 
 
 def parse_sam_alignment(

--- a/modules/local/processViralMinimap2Sam/resources/usr/bin/process_viral_minimap2_sam.py
+++ b/modules/local/processViralMinimap2Sam/resources/usr/bin/process_viral_minimap2_sam.py
@@ -228,7 +228,10 @@ def main() -> None:
         genbank_metadata = {
             genome_id: [taxid, species_taxid]
             for genome_id, taxid, species_taxid in zip(
-                meta_db["genome_id"], meta_db["taxid"], meta_db["species_taxid"]
+                meta_db["genome_id"],
+                meta_db["taxid"],
+                meta_db["species_taxid"],
+                strict=False,
             )
         }
         virus_db = pd.read_csv(args.viral_db, sep="\t", dtype=str)

--- a/modules/local/processViralMinimap2Sam/resources/usr/bin/test_process_viral_minimap2_sam.py
+++ b/modules/local/processViralMinimap2Sam/resources/usr/bin/test_process_viral_minimap2_sam.py
@@ -257,7 +257,10 @@ class TestProcessSam:
         with gzip.open(out_path, "rt") as f:
             lines = f.readlines()
         header = lines[0].strip().split("\t")
-        rows = [dict(zip(header, line.strip().split("\t"))) for line in lines[1:]]
+        rows = [
+            dict(zip(header, line.strip().split("\t"), strict=False))
+            for line in lines[1:]
+        ]
 
         # 3 output rows: read_A x2 (multi-alignment hold), read_C x1; read_B skipped
         seq_ids = [r["seq_id"] for r in rows]
@@ -338,7 +341,10 @@ class TestProcessSam:
 
         assert len(lines) == 3  # header + 2 reads
         header = lines[0].strip().split("\t")
-        rows = [dict(zip(header, line.strip().split("\t"))) for line in lines[1:]]
+        rows = [
+            dict(zip(header, line.strip().split("\t"), strict=False))
+            for line in lines[1:]
+        ]
         assert rows[0]["seq_id"] == "read_A"
         assert rows[1]["seq_id"] == "read_C"
         # Verify clean seq/qual came from FASTQ, not SAM

--- a/modules/local/processViralMinimap2Sam/resources/usr/bin/test_process_viral_minimap2_sam.py
+++ b/modules/local/processViralMinimap2Sam/resources/usr/bin/test_process_viral_minimap2_sam.py
@@ -22,7 +22,6 @@ def ref_data() -> tuple[dict[str, list[str]], set[str]]:
 
 
 class TestReadFastqRecord:
-
     def test_basic_record(self) -> None:
         fh = io.StringIO("@readA\nACGT\n+\nFFFF\n")
         result = process_viral_minimap2_sam.read_fastq_record(fh)
@@ -55,7 +54,6 @@ class TestReadFastqRecord:
 
 
 class TestExtractViralTaxid:
-
     METADATA = {"g1": ["111", "222"]}
 
     @pytest.mark.parametrize(
@@ -85,7 +83,6 @@ class TestExtractViralTaxid:
 
 
 class TestParseSamAlignment:
-
     def _make_read(self, tmp_path: Path, sam_line: str) -> "Any":
         """Create a pysam AlignedSegment from a SAM text line."""
         import pysam
@@ -99,7 +96,9 @@ class TestParseSamAlignment:
         with pysam.AlignmentFile(str(sam_path), "r") as f:
             return next(iter(f))
 
-    def test_supplementary_classification(self, tmp_path: Path, ref_data: tuple[dict[str, list[str]], set[str]]) -> None:
+    def test_supplementary_classification(
+        self, tmp_path: Path, ref_data: tuple[dict[str, list[str]], set[str]]
+    ) -> None:
         """Flag 2048 produces classification 'supplementary'."""
         genbank_metadata, viral_taxids = ref_data
         read = self._make_read(
@@ -111,7 +110,9 @@ class TestParseSamAlignment:
         )
         assert result["classification"] == "supplementary"
 
-    def test_length_one_sequence(self, tmp_path: Path, ref_data: tuple[dict[str, list[str]], set[str]]) -> None:
+    def test_length_one_sequence(
+        self, tmp_path: Path, ref_data: tuple[dict[str, list[str]], set[str]]
+    ) -> None:
         """Length-1 sequence produces length_normalized_score of 0."""
         genbank_metadata, viral_taxids = ref_data
         read = self._make_read(
@@ -124,7 +125,9 @@ class TestParseSamAlignment:
         assert result["length_normalized_score"] == 0
         assert result["query_len"] == 1
 
-    def test_primary_forward_all_fields(self, tmp_path: Path, ref_data: tuple[dict[str, list[str]], set[str]]) -> None:
+    def test_primary_forward_all_fields(
+        self, tmp_path: Path, ref_data: tuple[dict[str, list[str]], set[str]]
+    ) -> None:
         """Primary forward-strand alignment populates all expected fields."""
         genbank_metadata, viral_taxids = ref_data
         read = self._make_read(
@@ -150,7 +153,9 @@ class TestParseSamAlignment:
         assert result["classification"] == "primary"
         assert result["length_normalized_score"] == pytest.approx(30 / math.log(8))
 
-    def test_reverse_complement(self, tmp_path: Path, ref_data: tuple[dict[str, list[str]], set[str]]) -> None:
+    def test_reverse_complement(
+        self, tmp_path: Path, ref_data: tuple[dict[str, list[str]], set[str]]
+    ) -> None:
         """Reverse-strand alignment (flag 16) reverse-complements seq and reverses qual."""
         genbank_metadata, viral_taxids = ref_data
         read = self._make_read(
@@ -169,13 +174,14 @@ class TestParseSamAlignment:
 
 
 class TestProcessSam:
-
-    def test_empty_sam_produces_header_only_output(self, tmp_path: Path, ref_data: tuple[dict[str, list[str]], set[str]]) -> None:
+    def test_empty_sam_produces_header_only_output(
+        self, tmp_path: Path, ref_data: tuple[dict[str, list[str]], set[str]]
+    ) -> None:
         """Empty SAM file produces output with header line only."""
         genbank_metadata, viral_taxids = ref_data
 
         sam_path = tmp_path / "empty.sam"
-        sam_path.write_text("@HD\tVN:1.6\tSO:queryname\n" "@SQ\tSN:genome1\tLN:10000\n")
+        sam_path.write_text("@HD\tVN:1.6\tSO:queryname\n@SQ\tSN:genome1\tLN:10000\n")
 
         fastq_path = tmp_path / "empty.fastq"
         fastq_path.write_text("")
@@ -189,7 +195,9 @@ class TestProcessSam:
             lines = f.readlines()
         assert len(lines) == 1  # Header only
 
-    def test_unmapped_reads_skipped(self, tmp_path: Path, ref_data: tuple[dict[str, list[str]], set[str]]) -> None:
+    def test_unmapped_reads_skipped(
+        self, tmp_path: Path, ref_data: tuple[dict[str, list[str]], set[str]]
+    ) -> None:
         """Unmapped reads (flag 4) are skipped in output."""
         genbank_metadata, viral_taxids = ref_data
 
@@ -218,7 +226,9 @@ class TestProcessSam:
         assert "read_mapped" in lines[1]
         assert "read_unmapped" not in "".join(lines)
 
-    def test_multi_alignment_and_fastq_superset(self, tmp_path: Path, ref_data: tuple[dict[str, list[str]], set[str]]) -> None:
+    def test_multi_alignment_and_fastq_superset(
+        self, tmp_path: Path, ref_data: tuple[dict[str, list[str]], set[str]]
+    ) -> None:
         """Merge join holds FASTQ position for multi-alignment reads and skips FASTQ-only reads."""
         genbank_metadata, viral_taxids = ref_data
 
@@ -261,7 +271,9 @@ class TestProcessSam:
         assert rows[2]["query_seq"] == "GTACGTACGT"
         assert rows[2]["query_rc"] == "True"
 
-    def test_sam_read_missing_from_fastq_raises_error(self, tmp_path: Path, ref_data: tuple[dict[str, list[str]], set[str]]) -> None:
+    def test_sam_read_missing_from_fastq_raises_error(
+        self, tmp_path: Path, ref_data: tuple[dict[str, list[str]], set[str]]
+    ) -> None:
         """Raises ValueError when SAM contains a read not in FASTQ."""
         genbank_metadata, viral_taxids = ref_data
 
@@ -273,7 +285,7 @@ class TestProcessSam:
         )
 
         fastq_path = tmp_path / "test.fastq"
-        fastq_path.write_text("@read_A\n" "ACGTACGTAC\n" "+\n" "FFFFFFFFFF\n")
+        fastq_path.write_text("@read_A\nACGTACGTAC\n+\nFFFFFFFFFF\n")
 
         out_path = str(tmp_path / "output.tsv.gz")
         with pytest.raises(ValueError, match="read_X"):
@@ -285,7 +297,9 @@ class TestProcessSam:
                 str(fastq_path),
             )
 
-    def test_unsorted_gzipped_inputs_via_sort_helpers(self, tmp_path: Path, ref_data: tuple[dict[str, list[str]], set[str]]) -> None:
+    def test_unsorted_gzipped_inputs_via_sort_helpers(
+        self, tmp_path: Path, ref_data: tuple[dict[str, list[str]], set[str]]
+    ) -> None:
         """Integration test: unsorted gzipped inputs are sorted then processed."""
         genbank_metadata, viral_taxids = ref_data
 
@@ -305,7 +319,7 @@ class TestProcessSam:
         # Unsorted gzipped FASTQ
         fastq_gz = tmp_path / "unsorted.fastq.gz"
         with gzip.open(str(fastq_gz), "wt") as f:
-            f.write("@read_C\nCCCCC\n+\nHHHHH\n" "@read_A\nAAAAA\n+\nFFFFF\n")
+            f.write("@read_C\nCCCCC\n+\nHHHHH\n@read_A\nAAAAA\n+\nFFFFF\n")
 
         # Sort
         sorted_sam = str(tmp_path / "sorted.sam")

--- a/modules/local/processViralMinimap2Sam/resources/usr/bin/test_process_viral_minimap2_sam.py
+++ b/modules/local/processViralMinimap2Sam/resources/usr/bin/test_process_viral_minimap2_sam.py
@@ -258,7 +258,7 @@ class TestProcessSam:
             lines = f.readlines()
         header = lines[0].strip().split("\t")
         rows = [
-            dict(zip(header, line.strip().split("\t"), strict=False))
+            dict(zip(header, line.strip().split("\t"), strict=True))
             for line in lines[1:]
         ]
 
@@ -342,7 +342,7 @@ class TestProcessSam:
         assert len(lines) == 3  # header + 2 reads
         header = lines[0].strip().split("\t")
         rows = [
-            dict(zip(header, line.strip().split("\t"), strict=False))
+            dict(zip(header, line.strip().split("\t"), strict=True))
             for line in lines[1:]
         ]
         assert rows[0]["seq_id"] == "read_A"

--- a/modules/local/processViralMinimap2Sam/resources/usr/bin/test_process_viral_minimap2_sam.py
+++ b/modules/local/processViralMinimap2Sam/resources/usr/bin/test_process_viral_minimap2_sam.py
@@ -6,8 +6,8 @@ import math
 from pathlib import Path
 from typing import Any
 
-import pytest
 import process_viral_minimap2_sam
+import pytest
 
 
 @pytest.fixture
@@ -303,8 +303,8 @@ class TestProcessSam:
         """Integration test: unsorted gzipped inputs are sorted then processed."""
         genbank_metadata, viral_taxids = ref_data
 
-        from sort_sam import sort_sam
         from sort_fastq import sort_fastq
+        from sort_sam import sort_sam
 
         # Unsorted gzipped SAM
         sam_gz = tmp_path / "unsorted.sam.gz"

--- a/modules/local/processViralMinimap2Sam/resources/usr/bin/test_sort_fastq.py
+++ b/modules/local/processViralMinimap2Sam/resources/usr/bin/test_sort_fastq.py
@@ -17,12 +17,13 @@ def _read_lines(path: Path) -> list[str]:
         return f.readlines()
 
 
-def _make_fastq_record(read_id: str, seq: str = "ACGTACGT", qual: str = "IIIIIIII") -> str:
+def _make_fastq_record(
+    read_id: str, seq: str = "ACGTACGT", qual: str = "IIIIIIII"
+) -> str:
     return f"@{read_id}\n{seq}\n+\n{qual}\n"
 
 
 class TestSortFastq:
-
     def test_empty_fastq(self, tmp_path: Path) -> None:
         """Empty FASTQ produces empty output."""
         inp = tmp_path / "input.fastq.gz"
@@ -42,7 +43,9 @@ class TestSortFastq:
         ],
         ids=["already_sorted", "reverse_sorted"],
     )
-    def test_sort_order(self, tmp_path: Path, order: list[str], expected: list[str]) -> None:
+    def test_sort_order(
+        self, tmp_path: Path, order: list[str], expected: list[str]
+    ) -> None:
         """Reads are sorted by read ID regardless of input order."""
         inp = tmp_path / "input.fastq.gz"
         out = tmp_path / "sorted.fastq"

--- a/modules/local/processViralMinimap2Sam/resources/usr/bin/test_sort_sam.py
+++ b/modules/local/processViralMinimap2Sam/resources/usr/bin/test_sort_sam.py
@@ -20,7 +20,6 @@ def _read_lines(path: Path) -> list[str]:
 
 
 class TestSortSam:
-
     def test_empty_sam_header_only(self, tmp_path: Path) -> None:
         """Header-only SAM produces output with just headers."""
         inp = tmp_path / "input.sam.gz"
@@ -41,7 +40,9 @@ class TestSortSam:
         ],
         ids=["already_sorted", "reverse_sorted"],
     )
-    def test_sort_order(self, tmp_path: Path, order: list[str], expected: list[str]) -> None:
+    def test_sort_order(
+        self, tmp_path: Path, order: list[str], expected: list[str]
+    ) -> None:
         """Alignments are sorted by QNAME regardless of input order."""
         inp = tmp_path / "input.sam.gz"
         out = tmp_path / "sorted.sam"

--- a/modules/local/processViralMinimap2Sam/resources/usr/bin/test_sort_sam.py
+++ b/modules/local/processViralMinimap2Sam/resources/usr/bin/test_sort_sam.py
@@ -30,7 +30,7 @@ class TestSortSam:
 
         lines = _read_lines(out)
         assert len(lines) == 2
-        assert all(l.startswith("@") for l in lines)
+        assert all(line.startswith("@") for line in lines)
 
     @pytest.mark.parametrize(
         "order,expected",
@@ -54,7 +54,7 @@ class TestSortSam:
         sort_sam.sort_sam(str(inp), str(out))
 
         lines = _read_lines(out)
-        qnames = [l.split("\t")[0] for l in lines if not l.startswith("@")]
+        qnames = [line.split("\t")[0] for line in lines if not line.startswith("@")]
         assert qnames == expected
 
     def test_multiple_alignments_per_read(self, tmp_path: Path) -> None:
@@ -72,7 +72,7 @@ class TestSortSam:
         sort_sam.sort_sam(str(inp), str(out))
 
         lines = _read_lines(out)
-        qnames = [l.split("\t")[0] for l in lines if not l.startswith("@")]
+        qnames = [line.split("\t")[0] for line in lines if not line.startswith("@")]
         assert qnames == ["readA", "readA", "readB"]
 
     def test_header_preservation(self, tmp_path: Path) -> None:
@@ -92,7 +92,7 @@ class TestSortSam:
         sort_sam.sort_sam(str(inp), str(out))
 
         lines = _read_lines(out)
-        header_lines = [l for l in lines if l.startswith("@")]
+        header_lines = [line for line in lines if line.startswith("@")]
         assert len(header_lines) == 5
         assert header_lines[0].startswith("@HD")
         assert header_lines[1].startswith("@SQ")

--- a/modules/local/raiseTaxonomyRanks/resources/usr/bin/raise_taxonomy_ranks.py
+++ b/modules/local/raiseTaxonomyRanks/resources/usr/bin/raise_taxonomy_ranks.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-#=======================================================================
+# =======================================================================
 # Preamble
-#=======================================================================
+# =======================================================================
 
 # Import libraries
 import pandas as pd
@@ -11,30 +11,48 @@ from collections import defaultdict
 import logging
 from datetime import datetime, timezone
 
+
 # Configure logging
 class UTCFormatter(logging.Formatter):
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
         dt = datetime.fromtimestamp(record.created, timezone.utc)
-        return dt.strftime('%Y-%m-%d %H:%M:%S UTC')
+        return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger()
 handler = logging.StreamHandler()
-formatter = UTCFormatter('[%(asctime)s] %(message)s')
+formatter = UTCFormatter("[%(asctime)s] %(message)s")
 handler.setFormatter(formatter)
 logger.handlers.clear()
 logger.addHandler(handler)
 
 # Define constants
-RANKS = ["subspecies", "species", "subgenus", "genus", "subfamily", "family",
-         "suborder", "order", "class", "subphylum", "phylum", "kingdom",
-         "superkingdom", "acellular root"]
+RANKS = [
+    "subspecies",
+    "species",
+    "subgenus",
+    "genus",
+    "subfamily",
+    "family",
+    "suborder",
+    "order",
+    "class",
+    "subphylum",
+    "phylum",
+    "kingdom",
+    "superkingdom",
+    "acellular root",
+]
 
-#=======================================================================
+# =======================================================================
 # Auxiliary functions
-#=======================================================================
+# =======================================================================
 
-def raise_rank_single(taxids: pd.Series, target_rank: str,
-                      db: pd.DataFrame) -> tuple[pd.Series, bool]:
+
+def raise_rank_single(
+    taxids: pd.Series, target_rank: str, db: pd.DataFrame
+) -> tuple[pd.Series, bool]:
     """
     Given a Series of taxids and a target rank, perform a single
     rank-raise operation. Taxids below the target rank are replaced
@@ -53,7 +71,7 @@ def raise_rank_single(taxids: pd.Series, target_rank: str,
     # Get assigned ranks for each taxid
     ranks = db.loc[taxids, "rank"]
     # If all ranks are equal to or above target rank, return unmodified
-    ranks_above = RANKS[RANKS.index(target_rank):]
+    ranks_above = RANKS[RANKS.index(target_rank) :]
     if ranks.isin(ranks_above).all():
         return taxids, False
     # Otherwise, return the parent taxid for each taxid below target
@@ -62,8 +80,8 @@ def raise_rank_single(taxids: pd.Series, target_rank: str,
     taxids_out = taxids.where(ranks.isin(ranks_above), parent_taxids)
     return taxids_out, True
 
-def raise_rank(taxids: pd.Series, target_rank: str,
-               db: pd.DataFrame) -> pd.Series:
+
+def raise_rank(taxids: pd.Series, target_rank: str, db: pd.DataFrame) -> pd.Series:
     """
     Given a Series of taxids and a target rank, traverse the taxid
     hierarchy to find the corresponding taxids at the target rank.
@@ -86,10 +104,11 @@ def raise_rank(taxids: pd.Series, target_rank: str,
     while iter_next:
         taxids, iter_next = raise_rank_single(taxids, target_rank, db)
     # Replace taxids above the target rank with pd.NA
-    ranks_high = RANKS[RANKS.index(target_rank)+1:]
+    ranks_high = RANKS[RANKS.index(target_rank) + 1 :]
     ranks = db.loc[taxids, "rank"]
     taxids_out = taxids.where(~ranks.isin(ranks_high), pd.NA)  # type: ignore[call-overload]
     return taxids_out  # type: ignore[no-any-return]
+
 
 def raise_rank_db(db: pd.DataFrame, target_rank: str) -> pd.DataFrame:
     """
@@ -108,6 +127,7 @@ def raise_rank_db(db: pd.DataFrame, target_rank: str) -> pd.DataFrame:
     db[new_col_name] = new_col_values
     return db
 
+
 def raise_ranks_db(db: pd.DataFrame, target_ranks: list[str]) -> pd.DataFrame:
     """
     Given a DataFrame of taxids and their parent taxids, add columns
@@ -124,18 +144,26 @@ def raise_ranks_db(db: pd.DataFrame, target_ranks: list[str]) -> pd.DataFrame:
         db = raise_rank_db(db, target_rank)
     return db
 
-#=======================================================================
+
+# =======================================================================
 # Main function
-#=======================================================================
+# =======================================================================
+
 
 def main() -> None:
     logger.info("Initializing script.")
     # Define argument parsing
-    desc = "Given a TSV of taxids and their parent taxids, add columns " \
-           "containing the corresponding taxids at each target taxonomic rank."
+    desc = (
+        "Given a TSV of taxids and their parent taxids, add columns "
+        "containing the corresponding taxids at each target taxonomic rank."
+    )
     parser = argparse.ArgumentParser(description=desc)
-    parser.add_argument("taxonomy_db", help="Path to TSV of taxids, parent taxids and ranks.")
-    parser.add_argument("target_ranks", help="Space-delimited list of target ranks to raise to.")
+    parser.add_argument(
+        "taxonomy_db", help="Path to TSV of taxids, parent taxids and ranks."
+    )
+    parser.add_argument(
+        "target_ranks", help="Space-delimited list of target ranks to raise to."
+    )
     parser.add_argument("output_db", help="Path to output TSV.")
     args = parser.parse_args()
     # Import TSV and set taxids as index (while keeping taxid column)
@@ -159,9 +187,9 @@ def main() -> None:
     logger.info(f"Columns: {taxonomy_db.columns.tolist()}")
     # Write output
     logger.info("Writing output.")
-    taxonomy_db.to_csv(args.output_db, sep="\t", index=False,
-                       na_rep="NA", header=True)
+    taxonomy_db.to_csv(args.output_db, sep="\t", index=False, na_rep="NA", header=True)
     logger.info("Script complete.")
+
 
 if __name__ == "__main__":
     main()

--- a/modules/local/raiseTaxonomyRanks/resources/usr/bin/raise_taxonomy_ranks.py
+++ b/modules/local/raiseTaxonomyRanks/resources/usr/bin/raise_taxonomy_ranks.py
@@ -5,17 +5,17 @@
 # =======================================================================
 
 # Import libraries
-import pandas as pd
 import argparse
-from collections import defaultdict
 import logging
-from datetime import datetime, timezone
+from datetime import UTC, datetime
+
+import pandas as pd
 
 
 # Configure logging
 class UTCFormatter(logging.Formatter):
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
-        dt = datetime.fromtimestamp(record.created, timezone.utc)
+        dt = datetime.fromtimestamp(record.created, UTC)
         return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
 
 

--- a/modules/local/raiseTaxonomyRanks/resources/usr/bin/raise_taxonomy_ranks.py
+++ b/modules/local/raiseTaxonomyRanks/resources/usr/bin/raise_taxonomy_ranks.py
@@ -106,8 +106,7 @@ def raise_rank(taxids: pd.Series, target_rank: str, db: pd.DataFrame) -> pd.Seri
     # Replace taxids above the target rank with pd.NA
     ranks_high = RANKS[RANKS.index(target_rank) + 1 :]
     ranks = db.loc[taxids, "rank"]
-    taxids_out = taxids.where(~ranks.isin(ranks_high), pd.NA)  # type: ignore[call-overload]
-    return taxids_out  # type: ignore[no-any-return]
+    return taxids.where(~ranks.isin(ranks_high), pd.NA)  # type: ignore[call-overload]
 
 
 def raise_rank_db(db: pd.DataFrame, target_rank: str) -> pd.DataFrame:

--- a/modules/local/raiseTaxonomyRanks/resources/usr/bin/raise_taxonomy_ranks.py
+++ b/modules/local/raiseTaxonomyRanks/resources/usr/bin/raise_taxonomy_ranks.py
@@ -106,7 +106,7 @@ def raise_rank(taxids: pd.Series, target_rank: str, db: pd.DataFrame) -> pd.Seri
     # Replace taxids above the target rank with pd.NA
     ranks_high = RANKS[RANKS.index(target_rank) + 1 :]
     ranks = db.loc[taxids, "rank"]
-    return taxids.where(~ranks.isin(ranks_high), pd.NA)  # type: ignore[call-overload]
+    return taxids.where(~ranks.isin(ranks_high), pd.NA)  # type: ignore[call-overload, no-any-return]
 
 
 def raise_rank_db(db: pd.DataFrame, target_rank: str) -> pd.DataFrame:

--- a/modules/local/raiseTaxonomyRanks/resources/usr/bin/test_raise_taxonomy_ranks.py
+++ b/modules/local/raiseTaxonomyRanks/resources/usr/bin/test_raise_taxonomy_ranks.py
@@ -19,8 +19,19 @@ class TestRaiseTaxonomyRanks:
         input_data = {
             "taxid": ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"],
             "parent_taxid": ["-1", "0", "1", "2", "3", "4", "5", "6", "7", "5", "5"],
-            "rank": ["acellular root", "kingdom", "phylum", "class", "order",
-                    "family", "genus", "species", "subspecies", "none", "species"],
+            "rank": [
+                "acellular root",
+                "kingdom",
+                "phylum",
+                "class",
+                "order",
+                "family",
+                "genus",
+                "species",
+                "subspecies",
+                "none",
+                "species",
+            ],
         }
 
         taxonomy_db = pd.DataFrame(input_data)
@@ -38,7 +49,9 @@ class TestRaiseTaxonomyRanks:
 
         # Verify structure
         assert result.shape[0] == len(input_data["taxid"])  # Same number of rows
-        assert result.shape[1] == original_col_count + len(target_ranks)  # 3 extra columns
+        assert result.shape[1] == original_col_count + len(
+            target_ranks
+        )  # 3 extra columns
 
         # Verify original columns are preserved
         for col in original_cols:
@@ -50,9 +63,45 @@ class TestRaiseTaxonomyRanks:
             assert new_col in result.columns
 
         # Verify expected values (based on test-taxonomy-ranked.tsv)
-        expected_species = [pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, "7", "7", pd.NA, "10"]
-        expected_genus = [pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, "6", "6", "6", pd.NA, pd.NA]
-        expected_family = [pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, "5", "5", "5", "5", "5", "5"]
+        expected_species = [
+            pd.NA,
+            pd.NA,
+            pd.NA,
+            pd.NA,
+            pd.NA,
+            pd.NA,
+            pd.NA,
+            "7",
+            "7",
+            pd.NA,
+            "10",
+        ]
+        expected_genus = [
+            pd.NA,
+            pd.NA,
+            pd.NA,
+            pd.NA,
+            pd.NA,
+            pd.NA,
+            "6",
+            "6",
+            "6",
+            pd.NA,
+            pd.NA,
+        ]
+        expected_family = [
+            pd.NA,
+            pd.NA,
+            pd.NA,
+            pd.NA,
+            pd.NA,
+            "5",
+            "5",
+            "5",
+            "5",
+            "5",
+            "5",
+        ]
 
         # Convert pd.NA to string "NA" for comparison (matching CSV output)
         result_species = result["taxid_species"].fillna("NA").tolist()

--- a/modules/local/raiseTaxonomyRanks/resources/usr/bin/test_raise_taxonomy_ranks.py
+++ b/modules/local/raiseTaxonomyRanks/resources/usr/bin/test_raise_taxonomy_ranks.py
@@ -4,9 +4,7 @@
 
 from pathlib import Path
 
-import pytest
 import pandas as pd
-
 import raise_taxonomy_ranks
 
 

--- a/modules/local/reheadTsv/resources/usr/bin/rehead_tsv.py
+++ b/modules/local/reheadTsv/resources/usr/bin/rehead_tsv.py
@@ -2,10 +2,9 @@
 
 # Import modules
 import argparse
-import time
 import datetime
 import gzip
-import os
+import time
 from typing import IO, cast
 
 
@@ -20,8 +19,7 @@ def open_by_suffix(filename: str, mode: str = "r", debug: bool = False) -> IO[st
         print_log(f"\tGZIP mode: {filename.endswith('.gz')}")
     if filename.endswith(".gz"):
         return cast(IO[str], gzip.open(filename, mode + "t"))
-    else:
-        return open(filename, mode)
+    return open(filename, mode)
 
 
 def rename_columns(
@@ -85,10 +83,10 @@ def main() -> None:
     print_log("Starting process.")
     start_time = time.time()
     # Print parameters
-    print_log("Input TSV file: {}".format(input_path))
-    print_log("Input fields: {}".format(input_fields))
-    print_log("Output fields: {}".format(output_fields))
-    print_log("Output TSV file: {}".format(out_path))
+    print_log(f"Input TSV file: {input_path}")
+    print_log(f"Input fields: {input_fields}")
+    print_log(f"Output fields: {output_fields}")
+    print_log(f"Output TSV file: {out_path}")
     # Run labeling function
     print_log("Renaming columns in TSV...")
     rename_columns(input_path, input_fields, output_fields, out_path)

--- a/modules/local/reheadTsv/resources/usr/bin/rehead_tsv.py
+++ b/modules/local/reheadTsv/resources/usr/bin/rehead_tsv.py
@@ -8,61 +8,73 @@ import gzip
 import os
 from typing import IO, cast
 
+
 def print_log(message: str) -> None:
     print("[", datetime.datetime.now(), "]  ", message, sep="")
+
 
 def open_by_suffix(filename: str, mode: str = "r", debug: bool = False) -> IO[str]:
     if debug:
         print_log(f"\tOpening file object: {filename}")
         print_log(f"\tOpening mode: {mode}")
         print_log(f"\tGZIP mode: {filename.endswith('.gz')}")
-    if filename.endswith('.gz'):
-        return cast(IO[str], gzip.open(filename, mode + 't'))
+    if filename.endswith(".gz"):
+        return cast(IO[str], gzip.open(filename, mode + "t"))
     else:
         return open(filename, mode)
 
-def rename_columns(input_path: str, input_fields: list[str], output_fields: list[str], out_path: str) -> None:
+
+def rename_columns(
+    input_path: str, input_fields: list[str], output_fields: list[str], out_path: str
+) -> None:
     """Rename columns in TSV file."""
     if len(input_fields) != len(output_fields):
         raise ValueError("Input and output field lists must be the same length.")
-    
+
     with open_by_suffix(input_path) as inf, open_by_suffix(out_path, "w") as outf:
         # Read the header line
         header_line = inf.readline().strip()
-        
+
         # Check if file is empty
         if not header_line:
             print_log("Warning: Input file is empty. Creating empty output file.")
             outf.write("")  # Write empty string to create the file
             return
-        
+
         # Process header fields
         headers_in = header_line.split("\t")
-        
+
         # Verify all input fields exist in the header
         for field in input_fields:
             if field not in headers_in:
                 raise ValueError(f"Input field not found in file header: {field}")
-        
+
         # Rename header fields
         headers_out = headers_in.copy()
         for i in range(len(input_fields)):
             headers_out[headers_in.index(input_fields[i])] = output_fields[i]
-        
+
         # Write new header
         new_header_line = "\t".join(headers_out)
         outf.write(new_header_line + "\n")
-        
+
         # Write entire remainder of input file to output
         for line in inf:
             outf.write(line)
 
+
 def main() -> None:
     # Parse arguments
-    parser = argparse.ArgumentParser(description="Rename one or more columns in a TSV file.")
+    parser = argparse.ArgumentParser(
+        description="Rename one or more columns in a TSV file."
+    )
     parser.add_argument("input_path", help="Path to input TSV file.")
-    parser.add_argument("input_fields", help="Comma-separated list of input field names.")
-    parser.add_argument("output_fields", help="Comma-separated list of output field names.")
+    parser.add_argument(
+        "input_fields", help="Comma-separated list of input field names."
+    )
+    parser.add_argument(
+        "output_fields", help="Comma-separated list of output field names."
+    )
     parser.add_argument("output_file", help="Path to output TSV.")
     args = parser.parse_args()
     input_path = args.input_path
@@ -84,6 +96,7 @@ def main() -> None:
     # Finish time tracking
     end_time = time.time()
     print_log("Total time elapsed: %.2f seconds" % (end_time - start_time))
+
 
 if __name__ == "__main__":
     main()

--- a/modules/local/reheadTsv/resources/usr/bin/test_rehead_tsv.py
+++ b/modules/local/reheadTsv/resources/usr/bin/test_rehead_tsv.py
@@ -18,7 +18,9 @@ class TestReheadTsv:
         input_file = tsv_factory.create_plain("input.tsv", input_content)
         output_file = tsv_factory.get_path("output.tsv")
 
-        with pytest.raises(ValueError, match="Input field not found in file header: xyz"):
+        with pytest.raises(
+            ValueError, match="Input field not found in file header: xyz"
+        ):
             rehead_tsv.rename_columns(input_file, ["xyz"], ["abc"], output_file)
 
     def test_missing_later_input_field_raises_error(self, tsv_factory: Any) -> None:
@@ -27,8 +29,12 @@ class TestReheadTsv:
         input_file = tsv_factory.create_plain("input.tsv", input_content)
         output_file = tsv_factory.get_path("output.tsv")
 
-        with pytest.raises(ValueError, match="Input field not found in file header: xyz"):
-            rehead_tsv.rename_columns(input_file, ["x", "xyz"], ["a", "abc"], output_file)
+        with pytest.raises(
+            ValueError, match="Input field not found in file header: xyz"
+        ):
+            rehead_tsv.rename_columns(
+                input_file, ["x", "xyz"], ["a", "abc"], output_file
+            )
 
     def test_more_input_fields_than_output_raises_error(self, tsv_factory: Any) -> None:
         """Test that mismatched field list lengths raises ValueError."""
@@ -36,7 +42,9 @@ class TestReheadTsv:
         input_file = tsv_factory.create_plain("input.tsv", input_content)
         output_file = tsv_factory.get_path("output.tsv")
 
-        with pytest.raises(ValueError, match="Input and output field lists must be the same length"):
+        with pytest.raises(
+            ValueError, match="Input and output field lists must be the same length"
+        ):
             rehead_tsv.rename_columns(input_file, ["x", "y"], ["a"], output_file)
 
     def test_more_output_fields_than_input_raises_error(self, tsv_factory: Any) -> None:
@@ -45,7 +53,9 @@ class TestReheadTsv:
         input_file = tsv_factory.create_plain("input.tsv", input_content)
         output_file = tsv_factory.get_path("output.tsv")
 
-        with pytest.raises(ValueError, match="Input and output field lists must be the same length"):
+        with pytest.raises(
+            ValueError, match="Input and output field lists must be the same length"
+        ):
             rehead_tsv.rename_columns(input_file, ["x"], ["a", "b"], output_file)
 
     def test_no_change_when_headers_match_one_field(self, tsv_factory: Any) -> None:
@@ -59,7 +69,9 @@ class TestReheadTsv:
         result = tsv_factory.read_plain(output_file)
         assert result == input_content
 
-    def test_no_change_when_headers_match_multiple_fields(self, tsv_factory: Any) -> None:
+    def test_no_change_when_headers_match_multiple_fields(
+        self, tsv_factory: Any
+    ) -> None:
         """Test that output matches input when old and new headers are same (multiple fields)."""
         input_content = "x\ty\tz\n0\t1\t2\n3\t4\t5\n3\t5\t6\n6\t7\t8\n"
         input_file = tsv_factory.create_plain("input.tsv", input_content)

--- a/modules/local/reheadTsv/resources/usr/bin/test_rehead_tsv.py
+++ b/modules/local/reheadTsv/resources/usr/bin/test_rehead_tsv.py
@@ -5,7 +5,6 @@
 from typing import Any
 
 import pytest
-
 import rehead_tsv
 
 

--- a/modules/local/selectTsvColumns/resources/usr/bin/select_tsv_columns.py
+++ b/modules/local/selectTsvColumns/resources/usr/bin/select_tsv_columns.py
@@ -108,7 +108,7 @@ def get_header_index(headers: list[str], field: str, mode: str = "keep") -> int 
         msg = f"Field not found in header: {field}"
         if mode == "keep":
             logger.error(msg)
-            raise ValueError(msg)
+            raise ValueError(msg) from None
         logger.warning(msg)
         return None
 

--- a/modules/local/selectTsvColumns/resources/usr/bin/select_tsv_columns.py
+++ b/modules/local/selectTsvColumns/resources/usr/bin/select_tsv_columns.py
@@ -7,9 +7,9 @@ return a new TSV containing either:
 2. All columns except the specified ones, with only the latter dropped ("drop" mode)
 """
 
-#=======================================================================
+# =======================================================================
 # Import modules
-#=======================================================================
+# =======================================================================
 
 import logging
 from datetime import datetime, timezone
@@ -19,25 +19,29 @@ import gzip
 import io
 from typing import IO, cast
 
-#=======================================================================
+# =======================================================================
 # Configure logging
-#=======================================================================
+# =======================================================================
+
 
 class UTCFormatter(logging.Formatter):
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
         dt = datetime.fromtimestamp(record.created, timezone.utc)
-        return dt.strftime('%Y-%m-%d %H:%M:%S UTC')
+        return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger()
 handler = logging.StreamHandler()
-formatter = UTCFormatter('[%(asctime)s] %(message)s')
+formatter = UTCFormatter("[%(asctime)s] %(message)s")
 handler.setFormatter(formatter)
 logger.handlers.clear()
 logger.addHandler(handler)
 
-#=======================================================================
+# =======================================================================
 # I/O functions
-#=======================================================================
+# =======================================================================
+
 
 def parse_args() -> argparse.Namespace:
     """Parse command-line arguments."""
@@ -52,12 +56,18 @@ def parse_args() -> argparse.Namespace:
     # Add arguments
     parser.add_argument("--input", "-i", help="Path to input TSV.")
     parser.add_argument("--output", "-o", help="Path to output TSV.")
-    parser.add_argument("--fields", "-f", help="Comma-separated list of fields to select.")
-    parser.add_argument("--mode", "-m", 
-                        choices=["keep", "drop"],
-                        help="Mode to select columns: 'keep' or 'drop'.")
+    parser.add_argument(
+        "--fields", "-f", help="Comma-separated list of fields to select."
+    )
+    parser.add_argument(
+        "--mode",
+        "-m",
+        choices=["keep", "drop"],
+        help="Mode to select columns: 'keep' or 'drop'.",
+    )
     # Return parsed arguments
     return parser.parse_args()
+
 
 def open_by_suffix(filename: str, mode: str = "r") -> IO[str]:
     """
@@ -71,20 +81,18 @@ def open_by_suffix(filename: str, mode: str = "r") -> IO[str]:
     logger.debug(f"\tOpening file object: {filename}")
     logger.debug(f"\tOpening mode: {mode}")
     logger.debug(f"\tGZIP mode: {filename.endswith('.gz')}")
-    if filename.endswith('.gz'):
-        return cast(IO[str], gzip.open(filename, mode + 't'))
+    if filename.endswith(".gz"):
+        return cast(IO[str], gzip.open(filename, mode + "t"))
     else:
         return open(filename, mode)
 
-#=======================================================================
-# TSV processing functions
-#=======================================================================
 
-def get_header_index(
-    headers: list[str],
-    field: str,
-    mode: str = "keep"
-) -> int | None:
+# =======================================================================
+# TSV processing functions
+# =======================================================================
+
+
+def get_header_index(headers: list[str], field: str, mode: str = "keep") -> int | None:
     """
     Get the index of a field in a header line. If the field is not found,
     raise an error (if mode is "keep") or raise a warning and return None
@@ -106,16 +114,21 @@ def get_header_index(
         else:
             logger.warning(msg)
             return None
-    
+
+
 def join_line(inputs: list[str]) -> str:
     """Join a list of strings with tabs followed by a newline."""
     return "\t".join(inputs) + "\n"
+
 
 def subset_line(inputs: list[str], indices: list[int]) -> list[str]:
     """Subset a list of strings to a list of indices."""
     return [inputs[i] for i in indices]
 
-def select_columns(input_path: str, output_path: str, fields: list[str], mode: str) -> None:
+
+def select_columns(
+    input_path: str, output_path: str, fields: list[str], mode: str
+) -> None:
     """Select columns in TSV file."""
     with open_by_suffix(input_path) as inf, open_by_suffix(output_path, "w") as outf:
         # Read the header line
@@ -123,7 +136,9 @@ def select_columns(input_path: str, output_path: str, fields: list[str], mode: s
         logger.debug(f"Input header: {header_line}")
         if not header_line:
             # No header = empty file, log and create empty output
-            logger.warning("Input file is empty (no header). Creating empty output file.")
+            logger.warning(
+                "Input file is empty (no header). Creating empty output file."
+            )
             return
         headers_in = header_line.split("\t")
         # Get indices of selected fields
@@ -149,9 +164,11 @@ def select_columns(input_path: str, output_path: str, fields: list[str], mode: s
             line_split_subset = subset_line(line.split("\t"), indices_keep)
             outf.write(join_line(line_split_subset))
 
-#=======================================================================
+
+# =======================================================================
 # Main function
-#=======================================================================
+# =======================================================================
+
 
 def main() -> None:
     logger.info("Initializing script.")
@@ -178,6 +195,7 @@ def main() -> None:
     logger.info("Script completed successfully.")
     end_time = time.time()
     logger.info(f"Total time elapsed: {end_time - start_time} seconds")
+
 
 if __name__ == "__main__":
     main()

--- a/modules/local/selectTsvColumns/resources/usr/bin/select_tsv_columns.py
+++ b/modules/local/selectTsvColumns/resources/usr/bin/select_tsv_columns.py
@@ -11,12 +11,11 @@ return a new TSV containing either:
 # Import modules
 # =======================================================================
 
-import logging
-from datetime import datetime, timezone
 import argparse
-import time
 import gzip
-import io
+import logging
+import time
+from datetime import UTC, datetime
 from typing import IO, cast
 
 # =======================================================================
@@ -26,7 +25,7 @@ from typing import IO, cast
 
 class UTCFormatter(logging.Formatter):
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
-        dt = datetime.fromtimestamp(record.created, timezone.utc)
+        dt = datetime.fromtimestamp(record.created, UTC)
         return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
@@ -83,8 +82,7 @@ def open_by_suffix(filename: str, mode: str = "r") -> IO[str]:
     logger.debug(f"\tGZIP mode: {filename.endswith('.gz')}")
     if filename.endswith(".gz"):
         return cast(IO[str], gzip.open(filename, mode + "t"))
-    else:
-        return open(filename, mode)
+    return open(filename, mode)
 
 
 # =======================================================================
@@ -111,9 +109,8 @@ def get_header_index(headers: list[str], field: str, mode: str = "keep") -> int 
         if mode == "keep":
             logger.error(msg)
             raise ValueError(msg)
-        else:
-            logger.warning(msg)
-            return None
+        logger.warning(msg)
+        return None
 
 
 def join_line(inputs: list[str]) -> str:

--- a/modules/local/selectTsvColumns/resources/usr/bin/test_select_tsv_columns.py
+++ b/modules/local/selectTsvColumns/resources/usr/bin/test_select_tsv_columns.py
@@ -3,7 +3,6 @@
 from typing import Any
 
 import pytest
-
 import select_tsv_columns
 
 

--- a/modules/local/selectTsvColumns/resources/usr/bin/test_select_tsv_columns.py
+++ b/modules/local/selectTsvColumns/resources/usr/bin/test_select_tsv_columns.py
@@ -62,7 +62,9 @@ class TestSubsetLine:
         ],
         ids=["basic", "single", "reorder"],
     )
-    def test_subset_line(self, inputs: list[str], indices: list[int], expected: list[str]) -> None:
+    def test_subset_line(
+        self, inputs: list[str], indices: list[int], expected: list[str]
+    ) -> None:
         """Test subsetting a list by indices."""
         result = select_tsv_columns.subset_line(inputs, indices)
         assert result == expected
@@ -77,9 +79,18 @@ class TestSelectColumns:
             ("keep", ["col1", "col3"], "col1\tcol3\nval1\tval3\n"),
             ("drop", ["col2", "col4"], "col1\tcol3\nval1\tval3\n"),
             ("keep", ["col2"], "col2\nval2\n"),
-            ("keep", ["col1", "col2", "col3", "col4"], "col1\tcol2\tcol3\tcol4\nval1\tval2\tval3\tval4\n"),
+            (
+                "keep",
+                ["col1", "col2", "col3", "col4"],
+                "col1\tcol2\tcol3\tcol4\nval1\tval2\tval3\tval4\n",
+            ),
         ],
-        ids=["keep_mode_basic", "drop_mode_basic", "keep_single_column", "keep_all_columns"],
+        ids=[
+            "keep_mode_basic",
+            "drop_mode_basic",
+            "keep_single_column",
+            "keep_all_columns",
+        ],
     )
     def test_select_columns_success_cases(
         self, tsv_factory: Any, mode: str, columns: list[str], expected_output: str
@@ -105,7 +116,12 @@ class TestSelectColumns:
         ids=["empty_file", "header_only_file_keep", "header_only_file_drop"],
     )
     def test_select_columns_edge_cases(
-        self, tsv_factory: Any, input_content: str, columns: list[str], mode: str, expected_output: str
+        self,
+        tsv_factory: Any,
+        input_content: str,
+        columns: list[str],
+        mode: str,
+        expected_output: str,
     ) -> None:
         """Test edge cases for column selection."""
         input_file = tsv_factory.create_plain("input.tsv", input_content)
@@ -121,7 +137,9 @@ class TestSelectColumns:
         ["plain", "gzip"],
         ids=["plain_tsv", "gzipped_tsv"],
     )
-    def test_select_columns_file_formats(self, tsv_factory: Any, file_format: str) -> None:
+    def test_select_columns_file_formats(
+        self, tsv_factory: Any, file_format: str
+    ) -> None:
         """Test column selection with different file formats."""
         input_content = "col1\tcol2\tcol3\nval1\tval2\tval3\n"
         expected = "col1\tcol3\nval1\tval3\n"

--- a/modules/local/sortTsv/resources/usr/bin/sort_tsv.py
+++ b/modules/local/sortTsv/resources/usr/bin/sort_tsv.py
@@ -8,19 +8,18 @@ Sort a TSV file by a specific column header using GNU sort.
 # Import modules
 # =======================================================================
 
-import os
-import sys
-import gzip
 import argparse
-import subprocess
+import gzip
 import logging
-from datetime import datetime, timezone
-import time
-import tempfile
-import io
-from typing import IO, cast
-import shutil
 import math
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import UTC, datetime
+from typing import IO, cast
 
 # =======================================================================
 # Configure logging
@@ -29,7 +28,7 @@ import math
 
 class UTCFormatter(logging.Formatter):
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
-        dt = datetime.fromtimestamp(record.created, timezone.utc)
+        dt = datetime.fromtimestamp(record.created, UTC)
         return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
@@ -77,8 +76,7 @@ def open_by_suffix(filename: str, mode: str = "r") -> IO[str]:
     logger.debug(f"GZIP mode: {filename.endswith('.gz')}")
     if filename.endswith(".gz"):
         return cast(IO[str], gzip.open(filename, mode + "t"))
-    else:
-        return open(filename, mode)
+    return open(filename, mode)
 
 
 def process_header(header_line: str, sort_field: str) -> int | None:
@@ -92,7 +90,7 @@ def process_header(header_line: str, sort_field: str) -> int | None:
     """
     # Check if file is empty (no header)
     if not header_line:
-        logger.warning(f"Input file is empty. Creating empty output file.")
+        logger.warning("Input file is empty. Creating empty output file.")
         return None
     # Split the header line into fields
     header_fields = header_line.split("\t")
@@ -145,8 +143,8 @@ def sort_tsv_file(
         col_index = process_header(header, sort_field)
         if col_index is None:  # If no header, write empty output file
             return
-        else:  # Otherwise, write header to output
-            outfile.write(header + "\n")
+        # Otherwise, write header to output
+        outfile.write(header + "\n")
         # Check if there are any data rows by reading the first data line
         first_data_line = infile.readline().strip()
         if not first_data_line:  # If no data rows, stop here
@@ -238,5 +236,5 @@ def main() -> None:
 if __name__ == "__main__":
     try:
         main()
-    except Exception as e:
+    except Exception:
         sys.exit(1)

--- a/modules/local/sortTsv/resources/usr/bin/sort_tsv.py
+++ b/modules/local/sortTsv/resources/usr/bin/sort_tsv.py
@@ -4,9 +4,9 @@
 Sort a TSV file by a specific column header using GNU sort.
 """
 
-#=======================================================================
+# =======================================================================
 # Import modules
-#=======================================================================
+# =======================================================================
 
 import os
 import sys
@@ -22,36 +22,45 @@ from typing import IO, cast
 import shutil
 import math
 
-#=======================================================================
+# =======================================================================
 # Configure logging
-#=======================================================================
+# =======================================================================
+
 
 class UTCFormatter(logging.Formatter):
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
         dt = datetime.fromtimestamp(record.created, timezone.utc)
-        return dt.strftime('%Y-%m-%d %H:%M:%S UTC')
+        return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger()
 handler = logging.StreamHandler()
-formatter = UTCFormatter('[%(asctime)s] %(message)s')
+formatter = UTCFormatter("[%(asctime)s] %(message)s")
 handler.setFormatter(formatter)
 logger.handlers.clear()
 logger.addHandler(handler)
 
-#=======================================================================
+# =======================================================================
 # I/O functions
-#=======================================================================
+# =======================================================================
+
 
 def parse_args() -> argparse.Namespace:
     """Parse command-line arguments."""
     # Create parser
-    parser = argparse.ArgumentParser(description="Sort a TSV file by a specific column header.")
+    parser = argparse.ArgumentParser(
+        description="Sort a TSV file by a specific column header."
+    )
     parser.add_argument("input_file", help="Input TSV file path")
     parser.add_argument("sort_field", help="Column header to sort by")
     parser.add_argument("output_file", help="Output TSV file path")
-    parser.add_argument("--memory-limit", "-m", type=int, help="Memory limit in GB", required=True)
+    parser.add_argument(
+        "--memory-limit", "-m", type=int, help="Memory limit in GB", required=True
+    )
     # Return parsed arguments
     return parser.parse_args()
+
 
 def open_by_suffix(filename: str, mode: str = "r") -> IO[str]:
     """
@@ -66,10 +75,11 @@ def open_by_suffix(filename: str, mode: str = "r") -> IO[str]:
     logger.debug(f"Opening file object: {filename}")
     logger.debug(f"Opening mode: {mode}")
     logger.debug(f"GZIP mode: {filename.endswith('.gz')}")
-    if filename.endswith('.gz'):
-        return cast(IO[str], gzip.open(filename, mode + 't'))
+    if filename.endswith(".gz"):
+        return cast(IO[str], gzip.open(filename, mode + "t"))
     else:
         return open(filename, mode)
+
 
 def process_header(header_line: str, sort_field: str) -> int | None:
     """
@@ -85,24 +95,27 @@ def process_header(header_line: str, sort_field: str) -> int | None:
         logger.warning(f"Input file is empty. Creating empty output file.")
         return None
     # Split the header line into fields
-    header_fields = header_line.split('\t')
+    header_fields = header_line.split("\t")
     # Look for the sort field in the header fields
     if sort_field not in header_fields:
         msg = f"Could not find sort field in input header: '{sort_field}', {header_fields}"
         logger.error(msg)
         raise ValueError(msg)
     index = header_fields.index(sort_field)
-    logger.info(f"Found '{sort_field}' in column {index+1} (1-indexed). Sorting by column {index+1}.")
+    logger.info(
+        f"Found '{sort_field}' in column {index + 1} (1-indexed). Sorting by column {index + 1}."
+    )
     return index
 
-#=======================================================================
-# Sorting function
-#=======================================================================
 
-def sort_tsv_file(input_file: str,
-                  output_file: str,
-                  sort_field: str,
-                  memory_limit: int) -> None:
+# =======================================================================
+# Sorting function
+# =======================================================================
+
+
+def sort_tsv_file(
+    input_file: str, output_file: str, sort_field: str, memory_limit: int
+) -> None:
     """
     Sort a TSV file by a specific column header.
     Args:
@@ -111,14 +124,16 @@ def sort_tsv_file(input_file: str,
         sort_field (str): The column header to sort by.
     """
     # Create local temp directory base if it doesn't exist
-    temp_base = 'sort_tsv_tmp'
+    temp_base = "sort_tsv_tmp"
     temp_base_exists = os.path.exists(temp_base)
     os.makedirs(temp_base, exist_ok=True)
     logger.debug(f"Using temporary directory base: {temp_base}")
     # Use local directory to avoid memory-based tmpfs
-    with tempfile.TemporaryDirectory(dir=temp_base) as temp_dir, \
-            open_by_suffix(input_file) as infile, \
-            open_by_suffix(output_file, "w") as outfile:
+    with (
+        tempfile.TemporaryDirectory(dir=temp_base) as temp_dir,
+        open_by_suffix(input_file) as infile,
+        open_by_suffix(output_file, "w") as outfile,
+    ):
         # Define temporary file paths
         logger.debug(f"Temporary directory: {temp_dir}")
         temp_body = os.path.join(temp_dir, "body.tsv")
@@ -128,13 +143,13 @@ def sort_tsv_file(input_file: str,
         header = infile.readline().strip()
         logger.debug(f"Header: {header}")
         col_index = process_header(header, sort_field)
-        if col_index is None: # If no header, write empty output file
+        if col_index is None:  # If no header, write empty output file
             return
-        else: # Otherwise, write header to output
+        else:  # Otherwise, write header to output
             outfile.write(header + "\n")
         # Check if there are any data rows by reading the first data line
         first_data_line = infile.readline().strip()
-        if not first_data_line: # If no data rows, stop here
+        if not first_data_line:  # If no data rows, stop here
             logger.warning("No data rows to sort, writing header only")
             return
         # Otherwise, write data lines to temp file
@@ -152,11 +167,10 @@ def sort_tsv_file(input_file: str,
     if not temp_base_exists:
         shutil.rmtree(temp_base)
 
-def run_sort(input_file: str,
-             output_file: str,
-             sort_index: int,
-             temp_dir: str,
-             memory_limit: int) -> None:
+
+def run_sort(
+    input_file: str, output_file: str, sort_index: int, temp_dir: str, memory_limit: int
+) -> None:
     """
     Run the sort command on a TSV file with a specified field separator,
     handling errors and logging, and write to an output file.
@@ -173,13 +187,16 @@ def run_sort(input_file: str,
     logger.debug(f"Created sort temporary directory: {sort_temp_dir}")
     # Build sort command with memory limits and proper temporary directory
     sort_cmd = [
-        "sort", 
-        "-t", "\t",  # Tab delimiter
-        "-k", f"{sort_index+1},{sort_index+1}",  # Sort key
+        "sort",
+        "-t",
+        "\t",  # Tab delimiter
+        "-k",
+        f"{sort_index + 1},{sort_index + 1}",  # Sort key
         f"--temporary-directory={sort_temp_dir}",  # Temporary directory
         f"--buffer-size={memory_limit}G",  # Memory limit
-        "-o", output_file,  # Output file
-        input_file  # Input file
+        "-o",
+        output_file,  # Output file
+        input_file,  # Input file
     ]
     logger.debug(f"Running sort command: {sort_cmd}")
     try:
@@ -192,9 +209,11 @@ def run_sort(input_file: str,
         logger.error(f"Error running sort command: {e}")
         raise
 
-#=======================================================================
+
+# =======================================================================
 # Main function
-#=======================================================================
+# =======================================================================
+
 
 def main() -> None:
     logger.info("Initializing script.")
@@ -214,6 +233,7 @@ def main() -> None:
     logger.info("Script completed successfully.")
     end_time = time.time()
     logger.info(f"Total time elapsed: {end_time - start_time} seconds")
+
 
 if __name__ == "__main__":
     try:

--- a/modules/local/sortTsv/resources/usr/bin/test_sort_tsv.py
+++ b/modules/local/sortTsv/resources/usr/bin/test_sort_tsv.py
@@ -5,7 +5,6 @@
 from typing import Any
 
 import pytest
-
 import sort_tsv
 
 

--- a/modules/local/sortTsv/resources/usr/bin/test_sort_tsv.py
+++ b/modules/local/sortTsv/resources/usr/bin/test_sort_tsv.py
@@ -18,7 +18,9 @@ class TestSortTsv:
         input_file = tsv_factory.create_plain("input.tsv", input_content)
         output_file = tsv_factory.get_path("output.tsv")
 
-        with pytest.raises(ValueError, match="Could not find sort field in input header"):
+        with pytest.raises(
+            ValueError, match="Could not find sort field in input header"
+        ):
             sort_tsv.sort_tsv_file(input_file, output_file, "a", memory_limit=1)
 
     def test_already_sorted_plaintext(self, tsv_factory: Any) -> None:

--- a/post-processing/tests/test_similarity_duplicate_marking.py
+++ b/post-processing/tests/test_similarity_duplicate_marking.py
@@ -32,6 +32,7 @@ def binary_path():
 
     return str(bin_path)
 
+
 @pytest.fixture
 def tsv_factory(tmp_path):
     """Factory fixture for TSV file operations.
@@ -108,8 +109,8 @@ def run_binary_and_get_output(binary_path, input_file, output_file):
     if result.returncode != 0:
         raise RuntimeError(f"Binary failed: {result.stderr}")
 
-    with gzip.open(output_file, 'rt') as f:
-        reader = csv.DictReader(f, delimiter='\t')
+    with gzip.open(output_file, "rt") as f:
+        reader = csv.DictReader(f, delimiter="\t")
         fieldnames = reader.fieldnames
         rows = list(reader)
 
@@ -126,10 +127,12 @@ class TestEndToEnd:
         qual1 = "I" * 76
         qual2 = "H" * 76
 
-        content = create_test_tsv_content([
-            ("read1", seq1, qual1, "read1"),
-            ("read2", seq2, qual2, "read2"),
-        ])
+        content = create_test_tsv_content(
+            [
+                ("read1", seq1, qual1, "read1"),
+                ("read2", seq2, qual2, "read2"),
+            ]
+        )
         input_file = tsv_factory.create_gzip("input.tsv.gz", content)
         output_file = tsv_factory.get_path("output.tsv.gz")
 
@@ -149,11 +152,13 @@ class TestEndToEnd:
         seq3 = "GGCC" * 19
         qual = "I" * 76
 
-        content = create_test_tsv_content([
-            ("read1", seq1, qual, "read1"),
-            ("read2", seq2, qual, "read1"),  # alignment duplicate of read1
-            ("read3", seq3, qual, "read3"),
-        ])
+        content = create_test_tsv_content(
+            [
+                ("read1", seq1, qual, "read1"),
+                ("read2", seq2, qual, "read1"),  # alignment duplicate of read1
+                ("read3", seq3, qual, "read3"),
+            ]
+        )
         input_file = tsv_factory.create_gzip("input.tsv.gz", content)
         output_file = tsv_factory.get_path("output.tsv.gz")
 
@@ -170,7 +175,9 @@ class TestEndToEnd:
         # Alignment dup gets NA
         assert rows[1]["sim_dup_group_size"] == "NA"
 
-    def test_similarity_duplicates_among_alignment_unique(self, binary_path, tsv_factory):
+    def test_similarity_duplicates_among_alignment_unique(
+        self, binary_path, tsv_factory
+    ):
         """Test similarity deduplication among alignment-unique reads."""
         # read1 and read3 are identical (similarity duplicates)
         seq1 = "A" * 76
@@ -178,11 +185,13 @@ class TestEndToEnd:
         qual1 = "I" * 76
         qual2 = "H" * 76
 
-        content = create_test_tsv_content([
-            ("read1", seq1, qual1, "read1"),
-            ("read2", seq2, qual2, "read1"),  # Alignment duplicate of read1
-            ("read3", seq1, qual1, "read3"),  # Identical to read1
-        ])
+        content = create_test_tsv_content(
+            [
+                ("read1", seq1, qual1, "read1"),
+                ("read2", seq2, qual2, "read1"),  # Alignment duplicate of read1
+                ("read3", seq1, qual1, "read3"),  # Identical to read1
+            ]
+        )
         input_file = tsv_factory.create_gzip("input.tsv.gz", content)
         output_file = tsv_factory.get_path("output.tsv.gz")
 
@@ -212,7 +221,9 @@ class TestEndToEnd:
         input_file = tsv_factory.create_gzip("input.tsv.gz", content)
         output_file = tsv_factory.get_path("output.tsv.gz")
 
-        rows, fieldnames = run_binary_and_get_output(binary_path, input_file, output_file)
+        rows, fieldnames = run_binary_and_get_output(
+            binary_path, input_file, output_file
+        )
 
         # Verify output has header but no data rows
         assert len(rows) == 0
@@ -224,9 +235,11 @@ class TestEndToEnd:
         seq = "ACGT" * 12
         qual = "I" * 48
 
-        content = create_test_tsv_content([
-            ("read1", seq, qual, "read1"),
-        ])
+        content = create_test_tsv_content(
+            [
+                ("read1", seq, qual, "read1"),
+            ]
+        )
         input_file = tsv_factory.create_gzip("input.tsv.gz", content)
         output_file = tsv_factory.get_path("output.tsv.gz")
 
@@ -250,13 +263,23 @@ class TestEndToEnd:
         input_file = tsv_factory.create_gzip("input.tsv.gz", content)
         output_file = tsv_factory.get_path("output.tsv.gz")
 
-        rows, fieldnames = run_binary_and_get_output(binary_path, input_file, output_file)
+        rows, fieldnames = run_binary_and_get_output(
+            binary_path, input_file, output_file
+        )
 
         # Check column order: original columns + sim_dup_exemplar at end
         expected_fields = [
-            "extra1", "seq_id", "extra2", "query_seq", "query_seq_rev",
-            "query_qual", "query_qual_rev", "prim_align_dup_exemplar",
-            "extra3", "sim_dup_exemplar", "sim_dup_group_size",
+            "extra1",
+            "seq_id",
+            "extra2",
+            "query_seq",
+            "query_seq_rev",
+            "query_qual",
+            "query_qual_rev",
+            "prim_align_dup_exemplar",
+            "extra3",
+            "sim_dup_exemplar",
+            "sim_dup_group_size",
         ]
         assert fieldnames == expected_fields
 
@@ -270,11 +293,13 @@ class TestEndToEnd:
         seq = "ACGT" * 12
         qual = "I" * 48
 
-        content = create_test_tsv_content([
-            ("read1", seq, qual, "read1"),
-            ("read2", seq, qual, "read1"),  # alignment dup
-            ("read3", seq, qual, "read1"),  # alignment dup
-        ])
+        content = create_test_tsv_content(
+            [
+                ("read1", seq, qual, "read1"),
+                ("read2", seq, qual, "read1"),  # alignment dup
+                ("read3", seq, qual, "read1"),  # alignment dup
+            ]
+        )
         input_file = tsv_factory.create_gzip("input.tsv.gz", content)
         output_file = tsv_factory.get_path("output.tsv.gz")
 
@@ -302,20 +327,24 @@ class TestEndToEnd:
         qual_high = "I" * 76
         qual_low = "5" * 76
 
-        content = create_test_tsv_content([
-            # Alignment group 1: read1 (exemplar) + read2 (align dup)
-            ("read1", seq, qual_high, "read1"),
-            ("read2", seq, qual_low, "read1"),
-            # Alignment group 2: read3 (exemplar) + read4, read5 (align dups)
-            ("read3", seq, qual_low, "read3"),
-            ("read4", seq, qual_low, "read3"),
-            ("read5", seq, qual_low, "read3"),
-        ])
+        content = create_test_tsv_content(
+            [
+                # Alignment group 1: read1 (exemplar) + read2 (align dup)
+                ("read1", seq, qual_high, "read1"),
+                ("read2", seq, qual_low, "read1"),
+                # Alignment group 2: read3 (exemplar) + read4, read5 (align dups)
+                ("read3", seq, qual_low, "read3"),
+                ("read4", seq, qual_low, "read3"),
+                ("read5", seq, qual_low, "read3"),
+            ]
+        )
         input_file = tsv_factory.create_gzip("input.tsv.gz", content)
         output_file = tsv_factory.get_path("output.tsv.gz")
 
         rows, fieldnames = run_binary_and_get_output(
-            binary_path, input_file, output_file,
+            binary_path,
+            input_file,
+            output_file,
         )
 
         assert "sim_dup_group_size" in fieldnames

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,9 @@ exclude = [
     "__pycache__",
     "build",
     "dist",
+    ".venv",
+    "tmp",
+    "post-processing/deps",
 ]
 
 # Target Python version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,6 @@ lint.select = [
     "C4",  # comprehensions (better list/dict comprehensions)
     "UP",  # pyupgrade (modernize Python code)
     "N",   # naming (PEP8 naming conventions)
-    "COM", # commas (trailing commas)
     "PIE", # misc. lints (unnecessary code)
     "RET", # return statements (consistent returns)
     "SIM", # simplify (code simplification)
@@ -82,6 +81,8 @@ exclude = [
     "dist",
     ".venv",
     "tmp",
+    ".nf-test",
+    "test-data/tiny-index/output/logging",
     "post-processing/deps",
 ]
 


### PR DESCRIPTION
> **Stacked PR — depends on #748.** This branch is built on top of `feature/will/lint` (PR #748, Nextflow lint cleanup) and now targets that branch directly. Once PR #748 merges into `dev`, GitHub will retarget this PR to `dev` automatically. Please review/merge #748 first.

> **CI note.** The `check-nextflow-version` job is currently failing on this PR because the pipeline pin lags the latest Nextflow release (25.10.4 vs 26.04.0). This is unrelated to this PR's contents and is being addressed by PR #745.

Brings the Python codebase into compliance with the configured Ruff rules and applies a one-time `ruff format` sweep, so that a follow-up PR can add Ruff to CI in **read-only** mode (`ruff check .` + `ruff format --check .`) without an avalanche of failures on day one.

**Behaviour deltas (all small, all flagged for human review):**

- One **latent bug fix** in `bin/prepare_tiny_test_data.py::upload_to_s3`. `s3_uri.lstrip("s3://")` was treating its argument as a character set rather than a prefix, so any combination of `{s, 3, :, /}` could be consumed from the left of the bucket name (e.g. `s3://sssbucket/key` → bucket `bucket`, not `sssbucket`). Now covered by the new `bin/test_prepare_tiny_test_data.py` regression test.
- Slightly different **traceback formatting** on the ten error paths where `B904` was fixed with `raise … from e` (chains the underlying exception) or `raise … from None` (suppresses it). No change in which exceptions propagate or where.
- `UP017` rewrites use `datetime.UTC`, which requires **Python 3.11+** at runtime. The project already pins `requires-python = ">=3.12"` in `pyproject.toml`, so no consumer impact.
- `B905` autofixes added explicit `strict=…` to all `zip()` calls. After review, all eight production-and-test call sites have been audited and switched to `strict=True` (the autofix initially used `strict=False` to preserve historical behaviour). The iterables at every site are guaranteed equal-length by construction (paired R1/R2 FASTQ records, columns of one `pd.read_csv()` DataFrame, statically-equal lists, etc.), so `strict=True` is a behaviour change *only* in the regression-error case: a future bug that breaks the equal-length invariant will now raise `ValueError` immediately instead of silently truncating.

**Changes:**

- **`pyproject.toml` — Ruff config tightening:**
  - Add `post-processing/deps` (git submodule), `tmp` (gitignored scratch), and `.venv` to the Ruff exclude list. These either aren't ours to lint or are local-only.
  - Drop `COM` (trailing-comma) from `lint.select`. Ruff itself warns that `COM812` conflicts with `ruff format`, which already manages trailing commas. Removing the rule family eliminates the conflict without losing meaningful coverage.
  - Add `.nf-test` and `test-data/tiny-index/output/logging` to the exclude list. Both contain `pyproject.toml` files with stale `[tool.ruff]` blocks (test artifacts and a checked-in test fixture); Ruff's hierarchical config discovery was picking them up and re-triggering the COM812-conflict warning.

- **One-time mechanical sweeps (separate commits for reviewability):**
  - `ruff format .` across ~88 files (whitespace, quote style, line wrapping at 88 chars).
  - `ruff check --fix .` for the autofix-safe rules: import sorting (`I001`), pyupgrade (`UP006`/`UP007`/`UP015`/`UP017`/`UP032`/`UP035`/`UP045`), unused-import removal (`F401`), drop superfluous `else` after return/raise/continue (`RET505`/`RET506`/`RET507`), etc.
  - `ruff check --fix --unsafe-fixes .` for the autofix-but-not-100%-safe rules (`B905`, `B007`, `C401`/`C405`/`C408`, `F841`, `PIE810`, `RET504`, `SIM117`, `SIM118`, `UP040`), with manual review for any cases where the autofix left dead expressions.

- **Manual fixes by rule family (one commit each, for reviewability):**
  - `B904` (10 cases) — chain (`raise … from e`, 4 cases in `bin/build_ecr_container.py` where the underlying `subprocess.CalledProcessError` carries the diagnostic) or suppress (`raise … from None`, 6 cases in `KeyError`/`ValueError` wrappers where the inner exception is a generic sentinel like "X not in list").
  - `SIM117`/`SIM102`/`B007` — combine nested `with`/`if` statements; rename one unused loop control var.
  - `E741` — rename ambiguous loop var `l` → `line` in 5 spots (purely local, no call-site impact).
  - `SIM115` — restructure `prepare_viral_metadata.py::open_by_suffix` from a ternary expression to two-branch returns, matching the canonical form already used elsewhere in the repo (`bin/build_tiny_test_databases.py`). Ruff recognizes the two-branch form as an intentional open-and-return helper.

- **Latent bug fix (`B005`):** described in the "Behaviour deltas" section above. Replaced `lstrip("s3://")` with `removeprefix("s3://")` in `bin/prepare_tiny_test_data.py::upload_to_s3`.

- **`zip(strict=True)` audit:** described in the "Behaviour deltas" section above. All eight `zip()` call sites switched from `strict=False` (autofix default) to `strict=True` after per-site verification.

- **Mypy follow-up:** the `RET504` autofix for `raise_taxonomy_ranks.py:109` collapsed two lines into one return but only kept one of the two `# type: ignore` comments. Combined both error codes (`call-overload`, `no-any-return`) into a single inline ignore on the merged line.

- **Review-iteration follow-ups (in response to automated review):**
  - Q1: added explicit grouping parens in `lca_tsv.py:343` so the SIM114-collapsed boolean is easier to verify at a glance.
  - Q2: dropped the trailing `return None` cruft in `join_tsvs.py`; converted the earlier `return handle_empty_files(...)` to a bare-call + `return` so all return paths are consistent.
  - T1: extracted URI parsing into `parse_s3_uri(...)` and added `bin/test_prepare_tiny_test_data.py` covering the standard parsing cases, the `B005` regression cases, and invalid-URI rejection.
  - D1: added `ruff format` invocations to the dev-tooling block in `docs/developer.md`.

- **CHANGELOG.md:** entry added under `# v3.2.1.5-dev`. No version bump needed — point-level work merging into existing point-level dev.

Generated with [Claude Code](https://claude.com/claude-code)
