### PR TITLE
Temporarily ignore two HIGH Trivy CVEs in libcap2 and libgnutls30

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -85,3 +85,12 @@ CVE-2026-29111 exp:2026-06-30
 # Check for a Debian fix at:
 #   https://security-tracker.debian.org/tracker/CVE-2026-41989
 CVE-2026-41989 exp:2026-06-30
+
+# libcap2: TOCTOU race in cap_set_file() allowing local privilege escalation
+# (no Debian fix available as of 2026-05-01). Exploitation requires a local
+# unprivileged user with write access to a parent directory of a setcap target;
+# our pipeline containers run a single non-interactive job with no other local
+# users, so the practical attack surface is nil.
+# Check for a Debian fix at:
+#   https://security-tracker.debian.org/tracker/CVE-2026-4878
+CVE-2026-4878 exp:2026-06-30

--- a/.trivyignore
+++ b/.trivyignore
@@ -86,9 +86,11 @@ CVE-2026-29111 exp:2026-06-30
 #   https://security-tracker.debian.org/tracker/CVE-2026-41989
 CVE-2026-41989 exp:2026-06-30
 
-# libcap2: setcap (cap_set_file) exploit usable by non-root users. Not
-# applicable to our containers, which run as root and do not call this
-# library. (No Debian fix available as of 2026-05-01.)
+# libcap2: setcap (cap_set_file) exploit usable by non-root users.
+# (No Debian fix available as of 2026-05-01.) Our pipeline containers do
+# not invoke setcap/cap_set_file, so we do not call the affected code;
+# additionally, they run as root, which puts them outside the non-root
+# threat model of this CVE.
 # Check for a Debian fix at:
 #   https://security-tracker.debian.org/tracker/CVE-2026-4878
 CVE-2026-4878 exp:2026-06-30

--- a/.trivyignore
+++ b/.trivyignore
@@ -93,11 +93,9 @@ CVE-2026-41989 exp:2026-06-30
 #   https://security-tracker.debian.org/tracker/CVE-2026-4878
 CVE-2026-4878 exp:2026-06-30
 
-# libgnutls30: DoS / out-of-bounds read in DTLS handshake fragment reassembly
-# (fixed upstream in GnuTLS 3.8.13; Debian bookworm still ships 3.7.9 with no
-# backport as of 2026-05-02). DTLS-only — TLS over TCP does not exercise the
-# vulnerable reassembly path. Our containers do not run DTLS endpoints; they
-# only make outbound HTTPS-over-TCP calls, so the affected code is unreachable.
+# libgnutls30: DoS / out-of-bounds read in DTLS handshake fragment reassembly.
+# (No Debian fix available as of 2026-05-02). Our pipeline containers do not
+# run DTLS, only HTTPS, so we do not call the affected code.
 # Check for a Debian fix at:
 #   https://security-tracker.debian.org/tracker/CVE-2026-33845
 CVE-2026-33845 exp:2026-06-30

--- a/.trivyignore
+++ b/.trivyignore
@@ -86,11 +86,9 @@ CVE-2026-29111 exp:2026-06-30
 #   https://security-tracker.debian.org/tracker/CVE-2026-41989
 CVE-2026-41989 exp:2026-06-30
 
-# libcap2: TOCTOU race in cap_set_file() allowing local privilege escalation
-# (no Debian fix available as of 2026-05-01). Exploitation requires a local
-# unprivileged user with write access to a parent directory of a setcap target;
-# our pipeline containers run a single non-interactive job with no other local
-# users, so the practical attack surface is nil.
+# libcap2: setcap (cap_set_file) exploit usable by non-root users. Not
+# applicable to our containers, which run as root and do not call this
+# library. (No Debian fix available as of 2026-05-01.)
 # Check for a Debian fix at:
 #   https://security-tracker.debian.org/tracker/CVE-2026-4878
 CVE-2026-4878 exp:2026-06-30

--- a/.trivyignore
+++ b/.trivyignore
@@ -92,3 +92,12 @@ CVE-2026-41989 exp:2026-06-30
 # Check for a Debian fix at:
 #   https://security-tracker.debian.org/tracker/CVE-2026-4878
 CVE-2026-4878 exp:2026-06-30
+
+# libgnutls30: DoS / out-of-bounds read in DTLS handshake fragment reassembly
+# (fixed upstream in GnuTLS 3.8.13; Debian bookworm still ships 3.7.9 with no
+# backport as of 2026-05-02). DTLS-only — TLS over TCP does not exercise the
+# vulnerable reassembly path. Our containers do not run DTLS endpoints; they
+# only make outbound HTTPS-over-TCP calls, so the affected code is unreachable.
+# Check for a Debian fix at:
+#   https://security-tracker.debian.org/tracker/CVE-2026-33845
+CVE-2026-33845 exp:2026-06-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v3.2.1.5-dev
 
-- Add CVE-2026-4878 (libcap2) to `.trivyignore`; no Debian fix available and not exercised by our pipeline.
+- Add CVE-2026-4878 (libcap2) and CVE-2026-33845 (libgnutls30) to `.trivyignore`; no Debian fix available for either, and neither is exercised by our pipeline.
 
 # v3.2.1.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v3.2.1.5-dev
+
+- Add CVE-2026-4878 (libcap2) to `.trivyignore`; no Debian fix available and not exercised by our pipeline.
+
 # v3.2.1.4
 
 - Tolerate viral taxa with no linked NCBI assemblies in `DOWNLOAD_VIRAL_GENOMES`, emitting a header-only `${taxid}_metadata.tsv` and an empty `${taxid}_genomes/` (now declared `optional`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mgs-workflow"
-version = "3.2.1.4"
+version = "3.2.1.5-dev"
 requires-python = ">=3.12"
 dependencies = [
     "biopython>=1.85",


### PR DESCRIPTION
Two new HIGH-severity Trivy findings are failing CI with no Debian fix available. This PR adds them to `.trivyignore` with `exp:2026-06-30` to be reviewed alongside the existing batch.

**Changes:**
- [CVE-2026-4878](https://security-tracker.debian.org/tracker/CVE-2026-4878) (libcap2): `setcap` / `cap_set_file` exploit usable by non-root users. Our containers do not invoke `setcap`/`cap_set_file`, so the affected code path is not exercised; they also run as root, outside the non-root threat model of this CVE. No Debian fix available as of 2026-05-01.
- [CVE-2026-33845](https://security-tracker.debian.org/tracker/CVE-2026-33845) (libgnutls30): DoS / out-of-bounds read in DTLS handshake fragment reassembly. Fixed upstream in GnuTLS 3.8.13, but Debian bookworm has no fix as of 2026-05-02. The vulnerability is DTLS-only. Our containers do not run DTLS, only HTTPS, so the affected code is not exercised.

Generated with [Claude Code](https://claude.com/claude-code)