### PR TITLE
Bump BBDuk resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v3.2.1.5-dev
+
+- Reserve CPUs for streaming pipeline processes in BBDuk to prevent thread thrashing, and add a new `medium` resource label (12 CPU, 24 GB).
+
 # v3.2.1.4
 
 - Tolerate viral taxa with no linked NCBI assemblies in `DOWNLOAD_VIRAL_GENOMES`, emitting a header-only `${taxid}_metadata.tsv` and an empty `${taxid}_genomes/` (now declared `optional`).

--- a/configs/resources.config
+++ b/configs/resources.config
@@ -57,6 +57,10 @@ process {
         cpus = 8
         memory = 16.GB
     }
+    withLabel: medium {
+        cpus = 12
+        memory = 24.GB
+    }
 
     // Large multi-core processes
     withLabel: large {

--- a/modules/local/bbduk/main.nf
+++ b/modules/local/bbduk/main.nf
@@ -1,6 +1,6 @@
 // Streamed version (interleaved or single-end input and output)
 process BBDUK {
-    label "medium"
+    label "small"
     label "BBTools"
     input:
         tuple val(sample), path(reads) // Interleaved or single-end
@@ -44,7 +44,7 @@ process BBDUK_HITS_INTERLEAVE {
         tuple val(sample), path("${sample}_${params_map.suffix}_bbduk.stats.txt"), emit: log
     script:
         // Reserve CPUs for the streaming pipeline (2x zcat, paste/tr) to avoid thrashing
-        def threads = Math.max(1, task.cpus - 3)
+        def threads = Math.max(1, task.cpus - 4)
         def extractCmd = reads.toString().endsWith(".gz") ? "zcat" : "cat"
         def in1 = "${reads[0]}"
         def in2 = "${reads[1]}"

--- a/modules/local/bbduk/main.nf
+++ b/modules/local/bbduk/main.nf
@@ -1,6 +1,6 @@
 // Streamed version (interleaved or single-end input and output)
 process BBDUK {
-    label "small"
+    label "medium"
     label "BBTools"
     input:
         tuple val(sample), path(reads) // Interleaved or single-end
@@ -12,6 +12,8 @@ process BBDUK {
         tuple val(sample), path("${sample}_${params_map.suffix}_bbduk.stats.txt"), emit: log
         tuple val(sample), path("input_${reads}"), emit: input
     script:
+        // Reserve CPUs for the streaming pipeline (zcat) to avoid thrashing
+        def threads = Math.max(1, task.cpus - 2)
         def extractCmd = reads.toString().endsWith(".gz") ? "zcat" : "cat"
         def op = "${sample}_${params_map.suffix}_bbduk_nomatch.fastq.gz"
         def of = "${sample}_${params_map.suffix}_bbduk_match.fastq.gz"
@@ -19,7 +21,7 @@ process BBDUK {
         def ref = "${contaminant_ref}"
         def il = params_map.interleaved ? 't' : 'f'
         def io = "in=stdin.fastq ref=${ref} out=${op} outm=${of} stats=${stats} interleaved=${il}"
-        def par = "minkmerfraction=${params_map.min_kmer_fraction} k=${params_map.k} t=${task.cpus} -Xmx${task.memory.toGiga()}g"
+        def par = "minkmerfraction=${params_map.min_kmer_fraction} k=${params_map.k} t=${threads} -Xmx${task.memory.toGiga()}g"
         """
         ${extractCmd} ${reads} | bbduk.sh ${io} ${par}
         ln -s ${reads} input_${reads}
@@ -29,7 +31,7 @@ process BBDUK {
 // Streamed version of BBDUK_HITS that returns an interleaved file
 // Uses minkmerhits instead of minkmerfraction
 process BBDUK_HITS_INTERLEAVE {
-    label "small"
+    label "medium"
     label "BBTools"
     input:
         tuple val(sample), path(reads)
@@ -41,6 +43,8 @@ process BBDUK_HITS_INTERLEAVE {
         tuple val(sample), path("${sample}_${params_map.suffix}_bbduk_fail.fastq.gz"), emit: fail
         tuple val(sample), path("${sample}_${params_map.suffix}_bbduk.stats.txt"), emit: log
     script:
+        // Reserve CPUs for the streaming pipeline (2x zcat, paste/tr) to avoid thrashing
+        def threads = Math.max(1, task.cpus - 3)
         def extractCmd = reads.toString().endsWith(".gz") ? "zcat" : "cat"
         def in1 = "${reads[0]}"
         def in2 = "${reads[1]}"
@@ -49,7 +53,7 @@ process BBDUK_HITS_INTERLEAVE {
         def stats = "${sample}_${params_map.suffix}_bbduk.stats.txt"
         def ref = "${contaminant_ref}"
         def io = "in=stdin.fastq ref=${ref} out=${op} outm=${of} stats=${stats}"
-        def par = "minkmerhits=${params_map.min_kmer_hits} k=${params_map.k} interleaved=t t=${task.cpus} -Xmx${task.memory.toGiga()}g"
+        def par = "minkmerhits=${params_map.min_kmer_hits} k=${params_map.k} interleaved=t t=${threads} -Xmx${task.memory.toGiga()}g"
         """
         # Execute
         paste <(${extractCmd} ${in1} | paste - - - - ) <(${extractCmd} ${in2} | paste - - - -) | tr "\t" "\n" | bbduk.sh ${io} ${par}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mgs-workflow"
-version = "3.2.1.4"
+version = "3.2.1.5-dev"
 requires-python = ">=3.12"
 dependencies = [
     "biopython>=1.85",


### PR DESCRIPTION
* Adds a "medium" resource label with 12 CPUs and bumps the interleaved BBDuk processes from small (8 CPU) to medium;
* Tweaks BBDuk command line invocation to reserve threads for data pipelines and JVM overhead, reducing starvation and thrashing

In recent benchmarking experiments I found that overall throughput of the zcat -> paste -> BBDuk pipeline was degraded when BBDuk had `t=<number of CPUs on the machine>`, likely due to mild thrashing: no full cores left for zcat, paste, BBDuk parsing, and JVM overhead. Reducing the cores allocated to BBDuk actually improved overall throughput somewhat.

Rather than just reduce the cores, I've also added a new medium resource level and used that for the BBDuk process. This should approximately max out the data throughput of two single threaded zcat processes. In simple benchmarks, this change increases throughput 1.5x, so a pure wall time win without additional cost.

Asterisks on the above: (A) most EC2 families don't have a 12-core size, so if Batch isn't nicely packing 12-core containers onto a larger instance, this could end up being a modest cost increase; (B) this is assuming streaming data via Fusion isn't already a bottleneck. I think (B) is true; I mimicked by testing the streaming speed from a mounted S3 bucket (same region) which was very fast.