### PR TITLE
Temporarily ignore additional HIGH Trivy CVEs (libgnutls30, Pillow, rustls-webpki)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -13,6 +13,12 @@ CVE-2026-0861 exp:2026-06-30
 # No fix available until Polars releases a build with quinn-proto >= 0.11.14
 CVE-2026-31812 exp:2026-06-30
 
+# rustls-webpki Rust crate embedded in compiled Polars .so (multiqc dependency):
+# DoS via panic on malformed CRL BIT STRING. Multiqc does not perform CRL
+# validation against attacker-controlled inputs.
+# No fix available until Polars releases a build with rustls-webpki >= 0.103.13.
+GHSA-82j2-j2ch-gfr8 exp:2026-06-30
+
 # linux-pam: directory traversal (no Debian fix available as of 2026-03-14)
 CVE-2025-6020 exp:2026-06-30
 
@@ -62,9 +68,12 @@ CVE-2026-32283 exp:2026-06-30
 # ── Pillow in multiqc container (transitive dependency via matplotlib) ──
 # multiqc 1.33 (latest on bioconda) pulls Pillow 12.1.1; fix requires >= 12.2.0.
 # We cannot pin Pillow independently in the conda environment spec.
-# The vulnerability is a FITS GZIP decompression bomb — not a realistic attack
-# vector since multiqc only processes pipeline QC data, not untrusted FITS images.
+# Neither vulnerability is a realistic attack vector since multiqc only
+# processes pipeline QC data, not untrusted images.
+# FITS GZIP decompression bomb (HIGH)
 CVE-2026-40192 exp:2026-06-30
+# OOB write via integer overflow in PSD tile extents (HIGH)
+CVE-2026-42311 exp:2026-06-30
 
 # ── Debian bookworm base image: no fixes available ──
 # glibc: DoS via iconv() with specific character set conversions (fix_deferred)

--- a/.trivyignore
+++ b/.trivyignore
@@ -18,6 +18,7 @@ CVE-2026-31812 exp:2026-06-30
 # rustls-webpki: DoS via panic on malformed CRL BIT STRING. Multiqc does not
 # perform CRL validation against attacker-controlled inputs. No fix available
 # until Polars releases a build with rustls-webpki >= 0.103.13.
+# Identified by GHSA (no assigned CVE as of 2026-05-06).
 GHSA-82j2-j2ch-gfr8 exp:2026-06-30
 
 # linux-pam: directory traversal (no Debian fix available as of 2026-03-14)

--- a/.trivyignore
+++ b/.trivyignore
@@ -10,8 +10,10 @@ CVE-2023-45853 exp:2026-06-30
 CVE-2026-0861 exp:2026-06-30
 
 # ── Rust crates embedded in compiled Polars .so (multiqc dependency) ──
-# quinn-proto: no fix available until Polars releases a build with
-# quinn-proto >= 0.11.14
+# Multiqc invokes Polars only for reading local Parquet/CSV files; it does not
+# exercise the QUIC/TLS networking code paths that contain these vulnerabilities.
+# quinn-proto: QUIC protocol DoS. Multiqc does not open QUIC connections.
+# No fix available until Polars releases a build with quinn-proto >= 0.11.14.
 CVE-2026-31812 exp:2026-06-30
 # rustls-webpki: DoS via panic on malformed CRL BIT STRING. Multiqc does not
 # perform CRL validation against attacker-controlled inputs. No fix available

--- a/.trivyignore
+++ b/.trivyignore
@@ -101,3 +101,11 @@ CVE-2026-4878 exp:2026-06-30
 # Check for a Debian fix at:
 #   https://security-tracker.debian.org/tracker/CVE-2026-33845
 CVE-2026-33845 exp:2026-06-30
+
+# libgnutls30: heap buffer overflow / DoS in DTLS handshake fragment reassembly
+# via inconsistent message_length across fragments.
+# (No Debian fix available as of 2026-05-05.) Our pipeline containers do not
+# run DTLS, only HTTPS, so we do not call the affected code.
+# Check for a Debian fix at:
+#   https://security-tracker.debian.org/tracker/CVE-2026-33846
+CVE-2026-33846 exp:2026-06-30

--- a/.trivyignore
+++ b/.trivyignore
@@ -9,14 +9,13 @@ CVE-2023-45853 exp:2026-06-30
 # (minor issue, requires attacker control of size+alignment args)
 CVE-2026-0861 exp:2026-06-30
 
-# quinn-proto Rust crate embedded in compiled Polars .so (multiqc dependency)
-# No fix available until Polars releases a build with quinn-proto >= 0.11.14
+# ── Rust crates embedded in compiled Polars .so (multiqc dependency) ──
+# quinn-proto: no fix available until Polars releases a build with
+# quinn-proto >= 0.11.14
 CVE-2026-31812 exp:2026-06-30
-
-# rustls-webpki Rust crate embedded in compiled Polars .so (multiqc dependency):
-# DoS via panic on malformed CRL BIT STRING. Multiqc does not perform CRL
-# validation against attacker-controlled inputs.
-# No fix available until Polars releases a build with rustls-webpki >= 0.103.13.
+# rustls-webpki: DoS via panic on malformed CRL BIT STRING. Multiqc does not
+# perform CRL validation against attacker-controlled inputs. No fix available
+# until Polars releases a build with rustls-webpki >= 0.103.13.
 GHSA-82j2-j2ch-gfr8 exp:2026-06-30
 
 # linux-pam: directory traversal (no Debian fix available as of 2026-03-14)
@@ -68,11 +67,13 @@ CVE-2026-32283 exp:2026-06-30
 # ── Pillow in multiqc container (transitive dependency via matplotlib) ──
 # multiqc 1.33 (latest on bioconda) pulls Pillow 12.1.1; fix requires >= 12.2.0.
 # We cannot pin Pillow independently in the conda environment spec.
-# Neither vulnerability is a realistic attack vector since multiqc only
-# processes pipeline QC data, not untrusted images.
-# FITS GZIP decompression bomb (HIGH)
+# multiqc only processes pipeline-generated QC outputs, not untrusted images,
+# so neither attack vector below is reachable in our usage.
+# FITS GZIP decompression bomb (HIGH): pipeline does not generate or process
+# FITS-format images.
 CVE-2026-40192 exp:2026-06-30
-# OOB write via integer overflow in PSD tile extents (HIGH)
+# OOB write via integer overflow in PSD tile extents (HIGH): pipeline does not
+# generate or process PSD-format images.
 CVE-2026-42311 exp:2026-06-30
 
 # ── Debian bookworm base image: no fixes available ──

--- a/.trivyignore
+++ b/.trivyignore
@@ -10,15 +10,11 @@ CVE-2023-45853 exp:2026-06-30
 CVE-2026-0861 exp:2026-06-30
 
 # ── Rust crates embedded in compiled Polars .so (multiqc dependency) ──
-# Multiqc invokes Polars only for reading local Parquet/CSV files; it does not
-# exercise the QUIC/TLS networking code paths that contain these vulnerabilities.
-# quinn-proto: QUIC protocol DoS. Multiqc does not open QUIC connections.
-# No fix available until Polars releases a build with quinn-proto >= 0.11.14.
+# quinn-proto: QUIC protocol DoS
+# No fix available until Polars releases a build with quinn-proto >= 0.11.14
 CVE-2026-31812 exp:2026-06-30
-# rustls-webpki: DoS via panic on malformed CRL BIT STRING. Multiqc does not
-# perform CRL validation against attacker-controlled inputs. No fix available
-# until Polars releases a build with rustls-webpki >= 0.103.13.
-# Identified by GHSA (no assigned CVE as of 2026-05-06).
+# rustls-webpki: DoS via panic on malformed CRL BIT STRING.
+# No fix available until Polars releases a build with rustls-webpki >= 0.103.13.
 GHSA-82j2-j2ch-gfr8 exp:2026-06-30
 
 # linux-pam: directory traversal (no Debian fix available as of 2026-03-14)
@@ -70,10 +66,8 @@ CVE-2026-32283 exp:2026-06-30
 # ── Pillow in multiqc container (transitive dependency via matplotlib) ──
 # multiqc 1.33 (latest on bioconda) pulls Pillow 12.1.1; fix requires >= 12.2.0.
 # We cannot pin Pillow independently in the conda environment spec.
-# multiqc only processes pipeline-generated QC outputs, not untrusted images,
-# so neither attack vector below is reachable in our usage.
-# FITS GZIP decompression bomb (HIGH): pipeline does not generate or process
-# FITS-format images.
+# The vulnerability is a FITS GZIP decompression bomb — not a realistic attack
+# vector since multiqc only processes pipeline QC data, not untrusted FITS images.
 CVE-2026-40192 exp:2026-06-30
 # OOB write via integer overflow in PSD tile extents (HIGH): pipeline does not
 # generate or process PSD-format images.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v3.2.1.5-dev
 
-- Add CVE-2026-4878 (libcap2) and CVE-2026-33845 (libgnutls30) to `.trivyignore`; no Debian fix available for either, and neither is exercised by our pipeline.
+- Add CVE-2026-4878 (libcap2), CVE-2026-33845 (libgnutls30), and CVE-2026-33846 (libgnutls30) to `.trivyignore`; no Debian fix available for any, and none is exercised by our pipeline.
 
 # v3.2.1.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v3.2.1.5-dev
 
-- Add CVE-2026-4878 (libcap2), CVE-2026-33845 (libgnutls30), and CVE-2026-33846 (libgnutls30) to `.trivyignore`; no Debian fix available for any, and none is exercised by our pipeline.
+- Add CVE-2026-4878 (libcap2), CVE-2026-33845 (libgnutls30), CVE-2026-33846 (libgnutls30), CVE-2026-42311 (Pillow in multiqc), and GHSA-82j2-j2ch-gfr8 (rustls-webpki embedded in Polars in multiqc) to `.trivyignore`; no fix currently available for any, and none is exercised by our pipeline.
 
 # v3.2.1.4
 


### PR DESCRIPTION
Several new HIGH-severity Trivy findings are failing CI with no upstream fix available. This PR adds them to `.trivyignore` with `exp:2026-06-30` to be reviewed alongside the existing batch.

**Changes:**
- [CVE-2026-33846](https://security-tracker.debian.org/tracker/CVE-2026-33846) (libgnutls30): affects the same package as the already-ignored CVE-2026-33845 from #755.
  - Not relevant since our containers do not run DTLS, only HTTPS.
  - No Debian fix available as of 2026-05-05.
- [CVE-2026-42311](https://nvd.nist.gov/vuln/detail/CVE-2026-42311) (Pillow 12.1.1, multiqc container): same package as the already-ignored CVE-2026-40192
  - multiqc only processes pipeline QC data, not untrusted images.
  - Fix requires Pillow >= 12.2.0, which we cannot pin independently of the multiqc conda environment.
- [GHSA-82j2-j2ch-gfr8](https://github.com/advisories/GHSA-82j2-j2ch-gfr8) (rustls-webpki, multiqc container): issue in Polars Rust crate, same as already-ignored CVE-2026-31812
  - No fix available until Polars releases a new version with bumped rustls-webpki
Generated with [Claude Code](https://claude.com/claude-code)