### PR TITLE
Default fusion.exportStorageCredentials to false in Batch profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v3.2.1.5-dev
 
+- Default `fusion.exportStorageCredentials = false` in the `standard`, `batch`, and `test_run` profiles. Users who pass `--batch_job_role <ARN>` see no change. Users running on AWS Batch without a job role now rely on the EC2 instance role for S3 access. The `ec2_s3` profile is unchanged.
 - Fix `samtools view` failure on duplicate sequence IDs in the concatenated viral genome FASTA produced by `CONCATENATE_GENOME_FASTA`. NCBI `datasets` sometimes returns superseded ("previous") assembly versions alongside current ones, causing duplicate accessions.
     - `DOWNLOAD_VIRAL_GENOMES` now emits an `assembly_status` column in the per-taxid metadata TSV (via `dataformat tsv genome --fields ...assminfo-status`), which `PREPARE_VIRAL_METADATA` flows through to `FILTER_VIRAL_GENBANK_METADATA`, which keeps only rows with `assembly_status == 'current'` (dropping `previous`, `replaced`, `suppressed`, etc.).
     - `CONCATENATE_GENOME_FASTA` now runs `seqkit rmdup --by-name` after concatenation as a defense-in-depth check. Switched the process from the `seqtk` container to the existing `seqkit` container (no `seqtk` invocation in the script).

--- a/configs/profiles.config
+++ b/configs/profiles.config
@@ -22,7 +22,7 @@ params {
 profiles {
     standard { // Run on AWS Batch
         fusion.enabled = true
-        fusion.exportStorageCredentials = !params.batch_job_role
+        fusion.exportStorageCredentials = false
         aws.batch.jobRole = params.batch_job_role ?: null
         process.executor = "awsbatch"
         process.errorStrategy = "retry"
@@ -31,7 +31,7 @@ profiles {
     }
     batch { // Run on AWS Batch
         fusion.enabled = true
-        fusion.exportStorageCredentials = !params.batch_job_role
+        fusion.exportStorageCredentials = false
         aws.batch.jobRole = params.batch_job_role ?: null
         process.executor = "awsbatch"
         process.errorStrategy = "retry"
@@ -52,7 +52,7 @@ profiles {
     }
     test_run { // Testing only
         fusion.enabled = true
-        fusion.exportStorageCredentials = !params.batch_job_role
+        fusion.exportStorageCredentials = false
         aws.batch.jobRole = params.batch_job_role ?: null
         process.executor = "awsbatch"
         aws.batch.volumes = ['/scratch:/scratch'] // Shared directory for large reference files

--- a/docs/batch.md
+++ b/docs/batch.md
@@ -110,11 +110,9 @@ Note: Nextflow cannot distinguish Spot reclamation from other failures (both sur
 
 Finally, you need to use all the infrastructure you've just set up to actually run a Nextflow workflow! We recommend using our [test dataset](https://github.com/naobservatory/mgs-workflow/blob/will-merge-master/docs/installation.md#6-run-the-pipeline-on-test-data) to get started.
 
-### Optional: use a Batch job role
+### Container credentials on Batch
 
-By default, the `standard`, `batch`, and `test_run` profiles enable `fusion.exportStorageCredentials`, so Nextflow propagates the caller's AWS credentials to Batch containers as environment variables. If your AWS environment provides an IAM role that Batch jobs can assume — with the S3 read/write permissions needed for your sample sheet, index, and base directories — you can pass its ARN at run time with `--batch_job_role <ARN>`. When set:
+In the `standard`, `batch`, and `test_run` profiles, Batch containers obtain AWS credentials via one of two mechanisms:
 
-- The role is attached to Batch jobs via `aws.batch.jobRole`.
-- `fusion.exportStorageCredentials` is automatically disabled for that run, so containers obtain credentials from the role rather than from environment variables.
-
-The role's trust policy must allow `ecs-tasks.amazonaws.com` to assume it, and the IAM principal launching Nextflow must have `iam:PassRole` for the role. When `--batch_job_role` is omitted, profile behavior is unchanged.
+- **EC2 instance role** (default): containers inherit credentials from the instance profile on the Batch compute environment. Step 3 above configures this with `AmazonS3FullAccess`, which is sufficient.
+- **Job role** (optional): pass `--batch_job_role <ARN>` to attach a specific IAM role to each Batch job via `aws.batch.jobRole`. The role's trust policy must allow `ecs-tasks.amazonaws.com` to assume it, and the IAM principal launching Nextflow must have `iam:PassRole` for the role. Use this when you want to scope container permissions narrower than the instance role provides.

--- a/docs/batch.md
+++ b/docs/batch.md
@@ -114,5 +114,5 @@ Finally, you need to use all the infrastructure you've just set up to actually r
 
 In the `standard`, `batch`, and `test_run` profiles, Batch containers obtain AWS credentials via one of two mechanisms:
 
-- **EC2 instance role** (default): containers inherit credentials from the instance profile on the Batch compute environment. Step 3 above configures this with `AmazonS3FullAccess`, which is sufficient.
+- **EC2 instance role** (default): containers inherit credentials from the instance profile on the Batch compute environment. Step 1 above requires `AmazonS3FullAccess` on this role, which is sufficient.
 - **Job role** (optional): pass `--batch_job_role <ARN>` to attach a specific IAM role to each Batch job via `aws.batch.jobRole`. The role's trust policy must allow `ecs-tasks.amazonaws.com` to assume it, and the IAM principal launching Nextflow must have `iam:PassRole` for the role. Use this when you want to scope container permissions narrower than the instance role provides.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -84,9 +84,10 @@ If possible, we recommend validating the pipeline's basic functionality in your 
 > [!TIP]
 > We recommend running the test suite on an `m5.xlarge`, to most closely match the conditions under which our CI/CD tests run with Github Actions. However, any Linux machine with sufficient resources should work.
 
-To run the tests, clone this repository onto your machine, navigate to the repo directory, and run
+To run the tests, clone this repository onto your machine, navigate to the repo directory, export your AWS credentials so the tests can read S3-hosted test data, and run `nf-test test`:
 
 ```bash
+eval "$(aws configure export-credentials --format env)"
 nf-test test
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,11 +37,6 @@ aws_access_key_id = <ACCESS_KEY_ID>
 aws_secret_access_key = <SECRET_ACCESS_KEY>
 ```
 
-Then, export the keys as environment variables before running nextflow:
-```
-eval "$(aws configure export-credentials --format env)"
-```
-
 Next, you need to make sure your user is configured to use Docker. To do this, create the `docker` user group and add your current user to it:
 
 ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -99,7 +99,7 @@ In order to cut down on the time it takes to run our test suite, we have switche
 To run the tests locally, you need to make sure that you have a powerful enough compute instance (at least 4 cores, 14GB of RAM, and 32GB of storage). On AWS EC2, we recommend the `m5.2xlarge`. Note that you may want a more powerful instance when running tests in parallel (as described below).
 
 > [!NOTE]
-> Before running tests, to allow access to testing datasets/indexes on AWS, you will need to set up AWS credentials as described in [installation.md](installation.md), and then export them as described in the installation doc:
+> Before running tests, to allow access to testing datasets/indexes on AWS, you will need to set up AWS credentials as described in [installation.md](installation.md) and export them as environment variables:
 >
 > ```
 > eval "$(aws configure export-credentials --format env)"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,12 +4,6 @@
 
 When attempting to run a released version of the pipeline, the most common sources of errors are AWS permission issues. Before debugging a persistent error in-depth, make sure you have all the permissions required. When running the pipeline on AWS Batch, the necessary permissions are specified in [our Batch tutorial](./batch.md#step-0-set-up-your-aws-credentials).
 
-Once you've verified you have the required permissions, make sure Nextflow has access to your AWS credentials (if not you may get `AccessDenied` errors):
-
-```
-eval "$(aws configure export-credentials --format env)"
-```
-
 ## Docker image failures
 
 Another common issue is for processes to fail with some variation of the following Docker-related error:


### PR DESCRIPTION
## Summary

In the `standard`, `batch`, and `test_run` profiles, `fusion.exportStorageCredentials` is now `false`. Containers obtain AWS credentials from the EC2 instance role by default, or from a job role attached via `--batch_job_role <ARN>` when one is provided. The `ec2_s3` profile is unchanged.

This returns mgs-workflow to Nextflow's framework default for this setting; the explicit `true` was a workflow-side override.

I've tested that this doesn't break the CI (by changing target branch to ci-test) and that I can run nextflow in batch mode targeting `nao-mgs-staging-test`.

## Mechanics

- The conditional `fusion.exportStorageCredentials = !params.batch_job_role` becomes the constant `false`. The `aws.batch.jobRole = params.batch_job_role ?: null` line is unchanged, so passing `--batch_job_role <ARN>` continues to work exactly as before.
- Containers without a job role rely on the EC2 instance role via IMDS. `docs/batch.md` Step 1 already requires `AmazonS3FullAccess` on the instance role for this to be sufficient.

## Compat

- **No change** for users who pass `--batch_job_role <ARN>` (already gets `false`).
- **No change** for users running on AWS Batch with the documented instance-role setup (`AmazonS3FullAccess`).
- **Breaking** for users on AWS Batch with a hardened instance role lacking S3 access who don't pass `--batch_job_role`. Such users either need to grant S3 to the instance role or pass a job role. CHANGELOG flags this.
- `ec2_s3` (single-EC2 fusion runs, not Batch) is intentionally untouched.

## Test plan

- [x] Target this PR (or a successor) at `ci-test` to exercise `test-chained.yml` end-to-end and confirm the chained run completes.
- [x] Verified locally: a routine-orchestrator run with this setting completes via the EC2 instance role.