### PR TITLE
Fix CONCATENATE_GENOME_FASTA exit 141 + bump memory

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -35,10 +35,10 @@ CVE-2025-68973 exp:2026-06-30
 # surface for these CVEs is minimal in our pipeline context.
 #
 # TODO: Remove these ignores when a newer ncbi-datasets-cli is available on
-# conda-forge built with Go >= 1.25.9. Check with:
+# conda-forge built with Go >= 1.25.10 (or 1.26.3). Check with:
 #   conda search -c conda-forge ncbi-datasets-cli
 #   strings $(conda run -n <env> which datasets) | grep '^go1\.'
-# As of 2026-04-14, 18.23.0 still ships Go 1.23.4.
+# As of 2026-05-11, 18.25.1 still ships Go 1.23.4.
 #
 # crypto/tls: unexpected session resumption (CRITICAL)
 CVE-2025-68121 exp:2026-06-30
@@ -62,6 +62,16 @@ CVE-2026-32282 exp:2026-06-30
 CVE-2026-32281 exp:2026-06-30
 # crypto/tls: TLS 1.3 post-handshake key-update deadlock DoS (HIGH)
 CVE-2026-32283 exp:2026-06-30
+# net (cgo resolver): LookupCNAME mishandling of overlong CNAME responses (HIGH)
+CVE-2026-33811 exp:2026-06-30
+# net/http: HTTP/2 transport infinite loop on crafted SETTINGS frames (HIGH)
+CVE-2026-33814 exp:2026-06-30
+# net/mail: DoS via crafted ParseAddress/ParseAddressList/ParseDate inputs (HIGH)
+CVE-2026-39820 exp:2026-06-30
+# net: panic in Dial/LookupPort when handling NUL byte (HIGH)
+CVE-2026-39836 exp:2026-06-30
+# net/mail: DoS via pathological consumePhrase inputs (HIGH)
+CVE-2026-42499 exp:2026-06-30
 
 # ── Pillow in multiqc container (transitive dependency via matplotlib) ──
 # multiqc 1.33 (latest on bioconda) pulls Pillow 12.1.1; fix requires >= 12.2.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v3.2.1.5-dev
 
+- Add 5 Go stdlib v1.23.4 CVEs (CVE-2026-33811, -33814, -39820, -39836, -42499) in `ncbi_datasets` container to `.trivyignore`. No fix until NCBI rebuilds with Go >= 1.25.10.
 - Combine `SUBSET_READS_PAIRED_TARGET` with the previously-separate `INTERLEAVE_FASTQ` step into a single FIFO-based process that reads each input once and emits interleaved output via `seqtk mergepe`; plumb in the upstream `COUNT_READS` TSV so the in-process read-counting pass is eliminated; use pigz for parallel (de)compression and bump `SUBSET_READS_*` from `single` to `xsmall`. Adds `pigz=2.8` to the `seqtk` container.
 - Replace single-threaded gzip/zcat with pigz across `EXTRACT_VIRAL_READS_SHORT` modules (`BBDUK`, `BBDUK_HITS_INTERLEAVE`, `BOWTIE2`, `FASTP`, `SORT_FASTQ`, `SORT_FILE`); adds `pigz=2.8` to `bbtools`, `bowtie2_samtools`, `fastp`, and `coreutils` containers.
 - Add CVE-2026-42010 and CVE-2026-42011 (libgnutls30 TLS-PSK vulnerabilities) to `.trivyignore`. No Debian fix available as of 2026-05-10; our containers don't negotiate TLS-PSK so the practical exposure is nil.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Bump pinned Nextflow version from `25.10.4` to `25.10.5`.
 - Fix `samtools view` failure on duplicate sequence IDs in the concatenated viral genome FASTA produced by `CONCATENATE_GENOME_FASTA`. NCBI `datasets` sometimes returns superseded ("previous") assembly versions alongside current ones, causing duplicate accessions.
     - `DOWNLOAD_VIRAL_GENOMES` now emits an `assembly_status` column in the per-taxid metadata TSV (via `dataformat tsv genome --fields ...assminfo-status`), which `PREPARE_VIRAL_METADATA` flows through to `FILTER_VIRAL_GENBANK_METADATA`, which keeps only rows with `assembly_status == 'current'` (dropping `previous`, `replaced`, `suppressed`, etc.).
-    - `CONCATENATE_GENOME_FASTA` now runs `seqkit rmdup --by-name` after concatenation as a defense-in-depth check. Switched the process from the `seqtk` container to the existing `seqkit` container (no `seqtk` invocation in the script).
+    - `CONCATENATE_GENOME_FASTA` now runs `seqkit rmdup --by-name` after concatenation as a defense-in-depth check. Switched the process from the `seqtk` container to the existing `seqkit` container (no `seqtk` invocation in the script). Also bumped the memory tier to `single_cpu_16GB_memory`.
 - Add CVE-2026-4878 (libcap2), CVE-2026-33845 (libgnutls30), CVE-2026-33846 (libgnutls30), CVE-2026-3833 (libgnutls30), CVE-2026-42311 (Pillow in multiqc), and GHSA-82j2-j2ch-gfr8 (rustls-webpki embedded in Polars in multiqc) to `.trivyignore`; no fix currently available for any, and none is exercised by our pipeline.
 
 # v3.2.1.4

--- a/modules/local/concatenateGenomeFasta/main.nf
+++ b/modules/local/concatenateGenomeFasta/main.nf
@@ -10,7 +10,7 @@ process CONCATENATE_GENOME_FASTA {
     script:
         """
         set -euo pipefail
-        # Diagnostics.
+        # Diagnostics
         # `|| true` prevents SIGPIPE in cases where directory size exceeds kernel pipe buffer
         ls -1 ${genome_dir} | head || true
         if [[ ! -s ${path_file} ]]; then

--- a/modules/local/concatenateGenomeFasta/main.nf
+++ b/modules/local/concatenateGenomeFasta/main.nf
@@ -1,6 +1,6 @@
 // Concatenate downloaded genomes from ncbi-genome-download according to a file of genome IDs
 process CONCATENATE_GENOME_FASTA {
-    label "single"
+    label "single_cpu_16GB_memory"
     label "seqkit"
     input:
         path(genome_dir)
@@ -10,9 +10,9 @@ process CONCATENATE_GENOME_FASTA {
     script:
         """
         set -euo pipefail
-        # Diagnostics
-        echo "Genome directory contains" \$(ls ${genome_dir} | wc -l) "files, beginning with:"
-        ls -1 ${genome_dir} | head
+        # Diagnostics.
+        # `|| true` prevents SIGPIPE in cases where directory size exceeds kernel pipe buffer
+        ls -1 ${genome_dir} | head || true
         if [[ ! -s ${path_file} ]]; then
             echo "No matching files found!"
             exit 1


### PR DESCRIPTION
- The addition of `set -euo pipefail` in #758 to `CONCATENATE_GENOME_FASTA` fails with a `SIGPIPE` when run on large input directories, which are not represented by our current tests.
  - Added `|| true` to handle the pipe error in the diagnostic printout.
- Separately, this process also hit an OOM when trying to build a new production index, with and without the `seqkit rmdup` command.
  - Bumped resources to `single_cpu_16GB_memory` and confirmed it resolved the issue.
  - I think this is caused by the pending #763 change to emit downloaded directories instead of individual files, which seems to increase the Fusion memory overhead.

Generated with [Claude Code](https://claude.com/claude-code)