### PR TITLE
Fix CONCATENATE_GENOME_FASTA SIGPIPE on large genome directories (COMP-1680)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -23,9 +23,10 @@ CVE-2025-6020 exp:2026-06-30
 # GnuPG gpgv: information disclosure / potential code execution (no Debian fix available as of 2026-03-14)
 CVE-2025-68973 exp:2026-06-30
 
-# ── Go stdlib v1.23.4 in ncbi-datasets-cli (ncbi_datasets container) ──
+# ── Go stdlib v1.23.4 in ncbi-datasets-cli 18.21.0 (ncbi_datasets container) ──
 # The NCBI datasets/dataformat binaries are pre-compiled Go executables distributed
-# via conda-forge. They ship Go stdlib v1.23.4; fixes require Go >= 1.25.10+.
+# via conda-forge. They ship Go stdlib v1.23.4.
+# Go ~= 1.25.10 or ~= 1.26.3 is required to address all vulnerabilities.
 # We cannot rebuild these — only NCBI can, by updating their Go toolchain.
 #
 # Risk assessment: these binaries run in an isolated container that only downloads
@@ -34,8 +35,7 @@ CVE-2025-68973 exp:2026-06-30
 # surface for these CVEs is minimal in our pipeline context.
 #
 # TODO: Remove these ignores when a newer ncbi-datasets-cli is available on
-# conda-forge built with Go >= 1.25.10 (or >= 1.26.3 from the 1.26.x line,
-# which also contains fixes for these CVEs). Check with:
+# conda-forge built with Go ~= 1.25.10 or ~= 1.26.3. Check with:
 #   conda search -c conda-forge ncbi-datasets-cli
 #   strings $(conda run -n <env> which datasets) | grep '^go1\.'
 # As of 2026-05-11, 18.25.1 still ships Go 1.23.4.

--- a/.trivyignore
+++ b/.trivyignore
@@ -35,10 +35,10 @@ CVE-2025-68973 exp:2026-06-30
 # surface for these CVEs is minimal in our pipeline context.
 #
 # TODO: Remove these ignores when a newer ncbi-datasets-cli is available on
-# conda-forge built with Go >= 1.25.9. Check with:
+# conda-forge built with Go >= 1.25.10 (or 1.26.3). Check with:
 #   conda search -c conda-forge ncbi-datasets-cli
 #   strings $(conda run -n <env> which datasets) | grep '^go1\.'
-# As of 2026-04-14, 18.23.0 still ships Go 1.23.4.
+# As of 2026-05-11, 18.25.1 still ships Go 1.23.4.
 #
 # crypto/tls: unexpected session resumption (CRITICAL)
 CVE-2025-68121 exp:2026-06-30
@@ -62,6 +62,16 @@ CVE-2026-32282 exp:2026-06-30
 CVE-2026-32281 exp:2026-06-30
 # crypto/tls: TLS 1.3 post-handshake key-update deadlock DoS (HIGH)
 CVE-2026-32283 exp:2026-06-30
+# net (cgo resolver): LookupCNAME mishandling of overlong CNAME responses (HIGH)
+CVE-2026-33811 exp:2026-06-30
+# net/http: HTTP/2 transport infinite loop on crafted SETTINGS frames (HIGH)
+CVE-2026-33814 exp:2026-06-30
+# net/mail: DoS via crafted ParseAddress/ParseAddressList/ParseDate inputs (HIGH)
+CVE-2026-39820 exp:2026-06-30
+# net: panic in Dial/LookupPort when handling NUL byte (HIGH)
+CVE-2026-39836 exp:2026-06-30
+# net/mail: DoS via pathological consumePhrase inputs (HIGH)
+CVE-2026-42499 exp:2026-06-30
 
 # ── Pillow in multiqc container (transitive dependency via matplotlib) ──
 # multiqc 1.33 (latest on bioconda) pulls Pillow 12.1.1; fix requires >= 12.2.0.

--- a/.trivyignore
+++ b/.trivyignore
@@ -25,9 +25,8 @@ CVE-2025-68973 exp:2026-06-30
 
 # ── Go stdlib v1.23.4 in ncbi-datasets-cli (ncbi_datasets container) ──
 # The NCBI datasets/dataformat binaries are pre-compiled Go executables distributed
-# via conda-forge. They ship Go stdlib v1.23.4; fixes require Go >= 1.24.6+.
+# via conda-forge. They ship Go stdlib v1.23.4; fixes require Go >= 1.25.10+.
 # We cannot rebuild these — only NCBI can, by updating their Go toolchain.
-# As of 2026-03-25, conda-forge ncbi-datasets-cli 18.21.0 is the latest version.
 #
 # Risk assessment: these binaries run in an isolated container that only downloads
 # genome metadata from NCBI's API and writes local files. They do not serve TLS,

--- a/.trivyignore
+++ b/.trivyignore
@@ -23,7 +23,7 @@ CVE-2025-6020 exp:2026-06-30
 # GnuPG gpgv: information disclosure / potential code execution (no Debian fix available as of 2026-03-14)
 CVE-2025-68973 exp:2026-06-30
 
-# ── Go stdlib v1.23.4 in ncbi-datasets-cli 18.21.0 (ncbi_datasets container) ──
+# ── Go stdlib v1.23.4 in ncbi-datasets-cli (ncbi_datasets container) ──
 # The NCBI datasets/dataformat binaries are pre-compiled Go executables distributed
 # via conda-forge. They ship Go stdlib v1.23.4; fixes require Go >= 1.24.6+.
 # We cannot rebuild these — only NCBI can, by updating their Go toolchain.

--- a/.trivyignore
+++ b/.trivyignore
@@ -34,7 +34,8 @@ CVE-2025-68973 exp:2026-06-30
 # surface for these CVEs is minimal in our pipeline context.
 #
 # TODO: Remove these ignores when a newer ncbi-datasets-cli is available on
-# conda-forge built with Go >= 1.25.10 (or 1.26.3). Check with:
+# conda-forge built with Go >= 1.25.10 (or >= 1.26.3 from the 1.26.x line,
+# which also contains fixes for these CVEs). Check with:
 #   conda search -c conda-forge ncbi-datasets-cli
 #   strings $(conda run -n <env> which datasets) | grep '^go1\.'
 # As of 2026-05-11, 18.25.1 still ships Go 1.23.4.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v3.2.1.5-dev
 
-- Add 5 Go stdlib v1.23.4 CVEs (CVE-2026-33811, -33814, -39820, -39836, -42499) in `ncbi_datasets` container to `.trivyignore`. No fix until NCBI rebuilds with Go >= 1.25.10.
+- Add 5 Go stdlib v1.23.4 CVEs (CVE-2026-33811, -33814, -39820, -39836, -42499) in `ncbi_datasets` container to `.trivyignore`. No fix until NCBI rebuilds with Go ~= 1.25.10 or ~= 1.26.3.
 - Combine `SUBSET_READS_PAIRED_TARGET` with the previously-separate `INTERLEAVE_FASTQ` step into a single FIFO-based process that reads each input once and emits interleaved output via `seqtk mergepe`; plumb in the upstream `COUNT_READS` TSV so the in-process read-counting pass is eliminated; use pigz for parallel (de)compression and bump `SUBSET_READS_*` from `single` to `xsmall`. Adds `pigz=2.8` to the `seqtk` container.
 - Replace single-threaded gzip/zcat with pigz across `EXTRACT_VIRAL_READS_SHORT` modules (`BBDUK`, `BBDUK_HITS_INTERLEAVE`, `BOWTIE2`, `FASTP`, `SORT_FASTQ`, `SORT_FILE`); adds `pigz=2.8` to `bbtools`, `bowtie2_samtools`, `fastp`, and `coreutils` containers.
 - Add CVE-2026-42010 and CVE-2026-42011 (libgnutls30 TLS-PSK vulnerabilities) to `.trivyignore`. No Debian fix available as of 2026-05-10; our containers don't negotiate TLS-PSK so the practical exposure is nil.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v3.2.1.5-dev
 
+- Add 5 Go stdlib v1.23.4 CVEs (CVE-2026-33811, -33814, -39820, -39836, -42499) in `ncbi_datasets` container to `.trivyignore`. No fix until NCBI rebuilds with Go >= 1.25.10.
 - Combine `SUBSET_READS_PAIRED_TARGET` with the previously-separate `INTERLEAVE_FASTQ` step into a single FIFO-based process that reads each input once and emits interleaved output via `seqtk mergepe`; plumb in the upstream `COUNT_READS` TSV so the in-process read-counting pass is eliminated; use pigz for parallel (de)compression and bump `SUBSET_READS_*` from `single` to `xsmall`. Adds `pigz=2.8` to the `seqtk` container.
 - Replace single-threaded gzip/zcat with pigz across `EXTRACT_VIRAL_READS_SHORT` modules (`BBDUK`, `BBDUK_HITS_INTERLEAVE`, `BOWTIE2`, `FASTP`, `SORT_FASTQ`, `SORT_FILE`); adds `pigz=2.8` to `bbtools`, `bowtie2_samtools`, `fastp`, and `coreutils` containers.
 - Add CVE-2026-42010 and CVE-2026-42011 (libgnutls30 TLS-PSK vulnerabilities) to `.trivyignore`. No Debian fix available as of 2026-05-10; our containers don't negotiate TLS-PSK so the practical exposure is nil.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v3.2.1.5-dev
 
+- Fix `CONCATENATE_GENOME_FASTA` `SIGPIPE` on large genome directories.
 - Add 5 Go stdlib v1.23.4 CVEs (CVE-2026-33811, -33814, -39820, -39836, -42499) in `ncbi_datasets` container to `.trivyignore`. No fix until NCBI rebuilds with Go ~= 1.25.10 or ~= 1.26.3.
 - Combine `SUBSET_READS_PAIRED_TARGET` with the previously-separate `INTERLEAVE_FASTQ` step into a single FIFO-based process that reads each input once and emits interleaved output via `seqtk mergepe`; plumb in the upstream `COUNT_READS` TSV so the in-process read-counting pass is eliminated; use pigz for parallel (de)compression and bump `SUBSET_READS_*` from `single` to `xsmall`. Adds `pigz=2.8` to the `seqtk` container.
 - Replace single-threaded gzip/zcat with pigz across `EXTRACT_VIRAL_READS_SHORT` modules (`BBDUK`, `BBDUK_HITS_INTERLEAVE`, `BOWTIE2`, `FASTP`, `SORT_FASTQ`, `SORT_FILE`); adds `pigz=2.8` to `bbtools`, `bowtie2_samtools`, `fastp`, and `coreutils` containers.

--- a/modules/local/concatenateGenomeFasta/main.nf
+++ b/modules/local/concatenateGenomeFasta/main.nf
@@ -12,7 +12,8 @@ process CONCATENATE_GENOME_FASTA {
         set -euo pipefail
         # Diagnostics
         echo "Genome directory contains" \$(ls ${genome_dir} | wc -l) "files, beginning with:"
-        ls -1 ${genome_dir} | head
+        # `|| true` prevents SIGPIPE in cases where directory size exceeds kernel pipe buffer
+        ls -1 ${genome_dir} | head || true
         if [[ ! -s ${path_file} ]]; then
             echo "No matching files found!"
             exit 1


### PR DESCRIPTION
The addition of `set -euo pipefail` in #758 to `CONCATENATE_GENOME_FASTA` fails with a `SIGPIPE` when run on large input directories, which are not represented by our current tests. Add `|| true` to handle the pipe error in the diagnostic printout.

Chained #778 --> **#779** --> #780 --> #781

🤖 Generated with [Claude Code](https://claude.com/claude-code)