### PR TITLE
Scale MARK_ALIGNMENT_DUPLICATES and VSEARCH_CLUSTER memory by input size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v3.2.2.0-dev
 
-- Scale `MARK_ALIGNMENT_DUPLICATES` and `VSEARCH_CLUSTER` memory by input size via per-label tier closures (mirroring `bbmask_resources`), replacing their fixed `large` (32 GB) label. Large viral-hit groups previously OOM-killed both processes at 32 GB; tiers now allocate 32/64/128 GB based on the grouped_hits TSV size (MARK) and the largest per-species merged-reads FASTQ (VSEARCH), leaving normal groups at 32 GB.
+- Scale `MARK_ALIGNMENT_DUPLICATES` and `VSEARCH_CLUSTER` memory by input size via per-label tier closures to address OOM issues on large samples.
 - Exclude five viral genome records with rRNA contamination from the genome reference via `ref/hv_patterns_exclude.txt`.
 - Add `set -euo pipefail` to `BLASTN` module.
 - Add `pigz` to the `python` container so Python processes can use parallel (de)compression.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v3.2.2.0-dev
 
+- Scale `MARK_ALIGNMENT_DUPLICATES` and `VSEARCH_CLUSTER` memory by input size via per-label tier closures (mirroring `bbmask_resources`), replacing their fixed `large` (32 GB) label. Large viral-hit groups previously OOM-killed both processes at 32 GB; tiers now allocate 32/64/128 GB based on the grouped_hits TSV size (MARK) and the largest per-species merged-reads FASTQ (VSEARCH), leaving normal groups at 32 GB.
 - Exclude five viral genome records with rRNA contamination from the genome reference via `ref/hv_patterns_exclude.txt`.
 - Add `set -euo pipefail` to `BLASTN` module.
 - Add `pigz` to the `python` container so Python processes can use parallel (de)compression.

--- a/configs/resources.config
+++ b/configs/resources.config
@@ -73,8 +73,8 @@ process {
     }
 
     // Input-size-aware tiering for MARK_ALIGNMENT_DUPLICATES on the grouped_hits TSV.
-    // Peak memory scales ~5x the compressed grouped_hits size (measured 0.03-8.4 GB);
-    // tier thresholds are the grouped_hits byte size.
+    // Peak memory scales ~5x with the compressed grouped_hits size; tier thresholds are
+    // are the grouped_hits byte size.
     withLabel: mark_alignment_duplicates_resources {
         cpus = 16
         memory = {
@@ -87,8 +87,8 @@ process {
     }
 
     // Input-size-aware tiering for VSEARCH_CLUSTER on the merged-reads FASTQ. Species are
-    // clustered serially, so peak memory scales ~8x the largest per-species input
-    // (measured 0.4-4.3 GB); tier thresholds are that largest single-species byte size.
+    // clustered serially, so peak memory scales with ~8x the largest per-species input;
+    // tier thresholds are that largest single-species byte size.
     withLabel: vsearch_resources {
         cpus = 16
         memory = {

--- a/configs/resources.config
+++ b/configs/resources.config
@@ -71,4 +71,32 @@ process {
             return nextflow.util.MemoryUnit.of(idx >= 0 ? memories[idx] : memories.last())
         }
     }
+
+    // Input-size-aware tiering for MARK_ALIGNMENT_DUPLICATES on the grouped_hits TSV.
+    // Peak memory scales ~5x the compressed grouped_hits size (measured 0.03-8.4 GB);
+    // tier thresholds are the grouped_hits byte size.
+    withLabel: mark_alignment_duplicates_resources {
+        cpus = 16
+        memory = {
+            def thresholds = ['2 GB', '6 GB']
+            def memories = ['32 GB', '64 GB', '128 GB']
+            long bytes = (tsv instanceof List) ? tsv.sum { f -> f.size() } : tsv.size()
+            def idx = thresholds.findIndexOf { t -> bytes <= nextflow.util.MemoryUnit.of(t).toBytes() }
+            return nextflow.util.MemoryUnit.of(idx >= 0 ? memories[idx] : memories.last())
+        }
+    }
+
+    // Input-size-aware tiering for VSEARCH_CLUSTER on the merged-reads FASTQ. Species are
+    // clustered serially, so peak memory scales ~8x the largest per-species input
+    // (measured 0.4-4.3 GB); tier thresholds are that largest single-species byte size.
+    withLabel: vsearch_resources {
+        cpus = 16
+        memory = {
+            def thresholds = ['2 GB', '4 GB']
+            def memories = ['32 GB', '64 GB', '128 GB']
+            long bytes = (reads instanceof List) ? reads.max { r -> r.size() }.size() : reads.size()
+            def idx = thresholds.findIndexOf { t -> bytes <= nextflow.util.MemoryUnit.of(t).toBytes() }
+            return nextflow.util.MemoryUnit.of(idx >= 0 ? memories[idx] : memories.last())
+        }
+    }
 }

--- a/modules/local/markAlignmentDuplicates/main.nf
+++ b/modules/local/markAlignmentDuplicates/main.nf
@@ -1,6 +1,6 @@
 // Tool source: rust-tools/mark_duplicates/
 process MARK_ALIGNMENT_DUPLICATES {
-    label "large"
+    label "mark_alignment_duplicates_resources"
     label "rust_tools"
     tag "id=${sample}"
     input:

--- a/modules/local/vsearch/main.nf
+++ b/modules/local/vsearch/main.nf
@@ -1,6 +1,6 @@
 // Cluster merged FASTQ sequences with VSEARCH
 process VSEARCH_CLUSTER_LIST {
-    label "large"
+    label "vsearch_resources"
     label "vsearch"
     tag "id=${sample}"
     input:


### PR DESCRIPTION
`MARK_ALIGNMENT_DUPLICATES` and `VSEARCH_CLUSTER` both ran under a fixed `large` (32 GB) label. On deliveries with an unusually high viral-hit volume, this OOM-killed both processes. This replaces the fixed label with input-size-aware tier closures, mirroring the existing `bbmask_resources` pattern, so memory tracks the per-group data volume while normal groups stay at 32 GB.

## Changes
- Add `mark_alignment_duplicates_resources` and `vsearch_resources` tier labels to `configs/resources.config` (inline `memory = { ... }` closures, same shape as `bbmask_resources`).
- Switch `MARK_ALIGNMENT_DUPLICATES` and `VSEARCH_CLUSTER_LIST` from `large` to the new labels.
- VSEARCH tiers on the **largest single per-species** input (`reads.max{...}`), not the sum: species are clustered serially in a loop, so peak RSS is driven by the biggest single species, not the combined input.

## Justification
**Cutoff justification** (peak_rss measured from `.command.trace` across recent deliveries):

`MARK_ALIGNMENT_DUPLICATES` — peak ≈ **5× grouped_hits size** (clean across 0.03–8.4 GB):

| grouped_hits input | measured peak_rss | tier |
|---|---|---|
| 0.03–0.9 GB (normal) | 0.14–4.5 GB | 32 GB (existing) |
| 6.5 GB | 31 GB | 128 GB |
| 8.4 GB | 40 GB | 128 GB |

→ thresholds `2 GB / 6 GB` → `32 / 64 / 128 GB`. (32 GB OOM-killed the 6.5 & 8.4 GB groups.)

`VSEARCH_CLUSTER` — peak ≈ **8× largest per-species FASTQ** (for inputs ≥ ~0.4 GB):

| largest species input | measured peak_rss | tier |
|---|---|---|
| ≤ 0.5 GB (normal) | ≤ 4.2 GB | 32 GB (existing) |
| 3.4 GB | 28 GB | 64 GB |
| 4.3 GB | 37 GB | 128 GB |

→ thresholds `2 GB / 4 GB` → `32 / 64 / 128 GB`.

Both ratios were validated against full deliveries (BCL-CASPER/PHC-2026-06-12-a) and the GUAH outliers; tiers keep ≥2× headroom at every boundary, and every routine group stays in the 32 GB tier.

Generated with [Claude Code](https://claude.com/claude-code)