### PR TITLE
Add set -euo pipefail to BLASTN module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v3.2.2.0-dev
 
+- Add `set -euo pipefail` to `BLASTN` module.
 - Publish BLAST database under a fixed `results/blast-db/` directory with a constant `blast-db` alias regardless of database name.
     - Update `DOWNLOAD_BLAST_DB` to handle both the production named database and test tarball-URL paths.
     - Remove the redundant `blast_db_prefix` parameter from `configs/downstream*.config` to avoid drift.

--- a/modules/local/blast/main.nf
+++ b/modules/local/blast/main.nf
@@ -14,6 +14,7 @@ process BLASTN {
         def extractCmd = fasta.toString().endsWith(".gz") ? "zcat" : "cat"
         def inputCmd = fasta.toString().endsWith(".gz") ? "ln -s ${fasta} ${sample}_in.fasta.gz" : "gzip -c ${fasta} > ${sample}_in.fasta.gz"
         """
+        set -euo pipefail
         # Download BLAST database if not already present
         db_local_path=\$(download_db.py "${blast_db_dir}" "${params_map.db_download_timeout}")
         # Set up command

--- a/tests/modules/local/blast/main.nf.test
+++ b/tests/modules/local/blast/main.nf.test
@@ -44,4 +44,29 @@ nextflow_process {
         }
     }
 
+    test("Should fail when the blast-db alias is missing rather than emit empty output") {
+        tag "expect_failed"
+        when {
+            params {
+            }
+            process {
+                '''
+                def blast_params = [
+                    blast_perc_id: params.blast_perc_id,
+                    blast_qcov_hsp_perc: params.blast_qcov_hsp_perc,
+                    db_download_timeout: params.db_download_timeout
+                ]
+                input[0] = Channel.of("test")
+                    | combine(Channel.of("${projectDir}/test-data/tiny-index/reads/R1.fasta"))
+                input[1] = "${params.ref_dir}/results/bt2-virus-index"
+                input[2] = blast_params
+                '''
+            }
+        }
+        then {
+            assert process.failed
+            assert process.errorReport =~ /No alias or index file found/
+        }
+    }
+
 }

--- a/tests/modules/local/blast/main.nf.test
+++ b/tests/modules/local/blast/main.nf.test
@@ -65,7 +65,7 @@ nextflow_process {
         }
         then {
             assert process.failed
-            assert process.errorReport =~ /No alias or index file found/
+            assert process.errorReport =~ /BLAST Database error/
         }
     }
 


### PR DESCRIPTION
`BLASTN` runs `zcat | blastn | gzip`. Without `pipefail`, a `blastn` failure (e.g. a missing/mismatched BLAST DB) is masked by `gzip`'s exit 0, so the task "succeeds" with an empty output file and downstream validation silently goes all-NA. Add `set -euo pipefail` (matching the other modules) plus a regression test.

**Changes:**
- `modules/local/blast/main.nf`: add `set -euo pipefail`.
- `tests/modules/local/blast/main.nf.test`: regression test pointing `BLASTN` at a directory without the `blast-db` alias; asserts the task fails. Verified it fails without the fix and passes with it.

**Reproduction of the swallowed failure (before the fix):**
```bash
DIR=~/src/nao-mgs-workflow/test-data/tiny-index/output/results/blast-db
READS=~/src/nao-mgs-workflow/test-data/tiny-index/reads
IMG=public.ecr.aws/q0n1c7g8/nao-mgs-workflow/blast:2c02155ffc7b2c18
docker run --rm -v "$DIR":/db:ro -v "$READS":/q:ro -v /tmp:/out "$IMG" \
  bash -ue -c 'zcat -f /q/R1.fasta | blastn -db /db/core_nt -outfmt 6 | gzip > /out/hits.gz'
echo "exit=$? bytes=$(stat -c%s /tmp/hits.gz)"
# BLAST Database error: No alias or index file found
# exit=0 bytes=20 (empty gzip)
```

Stacked on #832.

Generated with [Claude Code](https://claude.com/claude-code)