### PR TITLE
Fix NUCLEAZE deadlock when given an incompatible index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@
     - INDEX: new `NUCLEAZE_INDEX` process builds `virus-genomes-masked.nucleaze.bin` once, alongside the existing bowtie2/minimap2 viral indexes.
     - RUN reads `nucleaze_k` from the index's `input/index-params.json` so the screen-time `k` always matches the index it screens against.
     - `NUCLEAZE` exposes `keep_match` / `keep_nomatch` flags (default true); the viral path passes `keep_nomatch: false` to skip compressing the discarded majority.
-    - `NUCLEAZE` pipes gzipped inputs through pigz FIFOs instead of letting needletail decompress them single-threaded internally; ~22 % wall reduction on the process (Illumina-100M samples, 8-core sandbox). Input-side pigz is capped at 2 threads since pigz cannot extract more parallelism from an ordinary single-stream gz. Module test covers the gz-input FIFO path.
+    - `NUCLEAZE` pipes gzipped inputs through pigz FIFOs instead of letting needletail decompress them single-threaded internally; ~22% wall reduction on the process (Illumina-100M samples, 8-core sandbox). Input-side pigz is capped at 2 threads since pigz cannot extract more parallelism from an ordinary single-stream gz. Module test covers the gz-input FIFO path.
     - Removes the unused `BBDUK_HITS_INTERLEAVE` process and its test.
     - Internal channel/param renames: `bbduk_match`/`bbduk_trimmed`/`min_kmer_hits`/`bbduk_suffix` → `kmer_match`/`kmer_trimmed`/`minhits`/`kmer_suffix`.
 - Add `triage-trivy` skill (`.claude/skills/triage-trivy/`) for per-CVE triage of `scan-containers` CI failures, structured to make `.trivyignore` the harder path. `CLAUDE.md`'s CI-status section points at it.

--- a/modules/local/nucleaze/main.nf
+++ b/modules/local/nucleaze/main.nf
@@ -79,22 +79,28 @@ process NUCLEAZE {
                 pigz -p ${task.cpus} -1 < "\${tmpdir}/nomatch.fifo" > ${nomatch_out} & PIDS+=(\$!)
                 outu="\${tmpdir}/nomatch.fifo"
             fi
-            status=0
-            nucleaze --in "\${in1}" --in2 "\${in2}" --outm "\${outm}" --outu "\${outu}" ${nucleaze_args} 2>&1 | tee ${stats} || status=\${PIPESTATUS[0]}
-            if [[ "\${status}" -eq 0 ]]; then
-                # Drain the pigz feeders and let the output compressors flush
-                # their gzip trailers before exiting; otherwise the .gz outputs
-                # truncate. A failing helper trips errexit and fails the task.
-                for pid in "\${PIDS[@]}"; do wait "\${pid}"; done
-            else
+            # Capture both pipe stages separately: nucleaze failure and tee
+            # (stats-log write) failure need different handling.
+            pipestatus=(0 0)
+            nucleaze --in "\${in1}" --in2 "\${in2}" --outm "\${outm}" --outu "\${outu}" ${nucleaze_args} 2>&1 | tee ${stats} || pipestatus=("\${PIPESTATUS[@]}")
+            nucleaze_status=\${pipestatus[0]}
+            tee_status=\${pipestatus[1]}
+            if [[ "\${nucleaze_status}" -ne 0 ]]; then
                 # nucleaze exited before opening its FIFOs (e.g. an incompatible
                 # --binref index dies during indexing). The pigz helpers are then
                 # blocked in open() forever; tear them down so the task fails fast
                 # instead of stalling. kill on an already-dead pid is harmless.
                 kill "\${PIDS[@]}" 2>/dev/null || true
                 wait "\${PIDS[@]}" 2>/dev/null || true
-                exit "\${status}"
+                exit "\${nucleaze_status}"
             fi
+            # nucleaze succeeded: drain the pigz feeders and let the output
+            # compressors flush their gzip trailers before exiting (otherwise
+            # the .gz outputs truncate). A failing helper trips errexit.
+            for pid in "\${PIDS[@]}"; do wait "\${pid}"; done
+            # A failed tee means the stats log is incomplete; fail the task
+            # rather than silently reporting success.
+            [[ "\${tee_status}" -eq 0 ]] || exit "\${tee_status}"
         fi
         ln -s ${r1} input_${r1}
         ln -s ${r2} input_${r2}

--- a/modules/local/nucleaze/main.nf
+++ b/modules/local/nucleaze/main.nf
@@ -79,8 +79,22 @@ process NUCLEAZE {
                 pigz -p ${task.cpus} -1 < "\${tmpdir}/nomatch.fifo" > ${nomatch_out} & PIDS+=(\$!)
                 outu="\${tmpdir}/nomatch.fifo"
             fi
-            nucleaze --in "\${in1}" --in2 "\${in2}" --outm "\${outm}" --outu "\${outu}" ${nucleaze_args} 2>&1 | tee ${stats}
-            for pid in "\${PIDS[@]}"; do wait "\${pid}"; done
+            status=0
+            nucleaze --in "\${in1}" --in2 "\${in2}" --outm "\${outm}" --outu "\${outu}" ${nucleaze_args} 2>&1 | tee ${stats} || status=\${PIPESTATUS[0]}
+            if [[ "\${status}" -eq 0 ]]; then
+                # Drain the pigz feeders and let the output compressors flush
+                # their gzip trailers before exiting; otherwise the .gz outputs
+                # truncate. A failing helper trips errexit and fails the task.
+                for pid in "\${PIDS[@]}"; do wait "\${pid}"; done
+            else
+                # nucleaze exited before opening its FIFOs (e.g. an incompatible
+                # --binref index dies during indexing). The pigz helpers are then
+                # blocked in open() forever; tear them down so the task fails fast
+                # instead of stalling. kill on an already-dead pid is harmless.
+                kill "\${PIDS[@]}" 2>/dev/null || true
+                wait "\${PIDS[@]}" 2>/dev/null || true
+                exit "\${status}"
+            fi
         fi
         ln -s ${r1} input_${r1}
         ln -s ${r2} input_${r2}

--- a/tests/modules/local/nucleaze/main.nf.test
+++ b/tests/modules/local/nucleaze/main.nf.test
@@ -272,12 +272,13 @@ nextflow_process {
         tag "expect_failure"
         tag "paired_end"
         tag "gz_input"
-        // Regression test for the FIFO deadlock: an incompatible --binref index
-        // makes nucleaze exit during indexing, before it opens the pigz FIFOs,
-        // so the pigz helpers block in open() forever unless the module tears
-        // them down. R1.fastq is passed as the "index" — it is not a serialized
-        // nucleaze index, so nucleaze fails during indexing and the process must
-        // fail promptly rather than stalling.
+        // Regression test for the FIFO deadlock: when nucleaze is given an
+        // incompatible --binref index it exits during indexing, before it opens
+        // the pigz FIFOs, so the pigz helpers block in open() forever unless the
+        // module tears them down. Here we trigger that failure by passing R1.fastq
+        // as the index — it is a raw reads file, not a serialized nucleaze index —
+        // so nucleaze fails during indexing and the process must fail promptly
+        // rather than stalling.
         setup {
             run("GZIP_FILE", alias: "GZIP_R1") {
                 script "modules/local/gzipFile/main.nf"
@@ -309,6 +310,7 @@ nextflow_process {
                 input[0] = GZIP_R1.out.map { s, f -> [s, f] }
                     .join(GZIP_R2.out.map { s, f -> [s, f] })
                     .map { s, f1, f2 -> [s, [f1, f2]] }
+                // A raw reads file, not a real nucleaze index — this triggers the failure.
                 input[1] = "${projectDir}/test-data/tiny-index/reads/R1.fastq"
                 input[2] = params.params_map
                 '''

--- a/tests/modules/local/nucleaze/main.nf.test
+++ b/tests/modules/local/nucleaze/main.nf.test
@@ -268,6 +268,57 @@ nextflow_process {
         }
     }
 
+    test("Should fail fast (not hang) on an incompatible index with gzipped input") {
+        tag "expect_failure"
+        tag "paired_end"
+        tag "gz_input"
+        // Regression test for the FIFO deadlock: an incompatible --binref index
+        // makes nucleaze exit during indexing, before it opens the pigz FIFOs,
+        // so the pigz helpers block in open() forever unless the module tears
+        // them down. R1.fastq is passed as the "index" — it is not a serialized
+        // nucleaze index, so nucleaze fails during indexing and the process must
+        // fail promptly rather than stalling.
+        setup {
+            run("GZIP_FILE", alias: "GZIP_R1") {
+                script "modules/local/gzipFile/main.nf"
+                process {
+                    '''
+                    input[0] = Channel.of(["test", "${projectDir}/test-data/tiny-index/reads/R1.fastq"])
+                    '''
+                }
+            }
+            run("GZIP_FILE", alias: "GZIP_R2") {
+                script "modules/local/gzipFile/main.nf"
+                process {
+                    '''
+                    input[0] = Channel.of(["test", "${projectDir}/test-data/tiny-index/reads/R2.fastq"])
+                    '''
+                }
+            }
+        }
+        when {
+            params {
+                params_map = [
+                    k: "24",
+                    minhits: "1",
+                    suffix: "viral"
+                ]
+            }
+            process {
+                '''
+                input[0] = GZIP_R1.out.map { s, f -> [s, f] }
+                    .join(GZIP_R2.out.map { s, f -> [s, f] })
+                    .map { s, f1, f2 -> [s, [f1, f2]] }
+                input[1] = "${projectDir}/test-data/tiny-index/reads/R1.fastq"
+                input[2] = params.params_map
+                '''
+            }
+        }
+        then {
+            assert process.failed
+        }
+    }
+
     test("Should fail when both keep_match and keep_nomatch are false") {
         tag "expect_failure"
         tag "paired_end"


### PR DESCRIPTION
An incompatible --binref index makes nucleaze terminate during indexing, before it opens its input/output FIFOs. The background pigz helpers are then left blocked forever in open(), so the task never finishes — it stalls until killed by hand.

Capture nucleaze's exit status; on failure, kill the helpers before exiting so the task fails fast with nucleaze's error. The success path still waits on the helpers, preserving output gzip trailer flushing and decoder-error propagation.

Note that the Claude reviewer's D1 is intentional, for now: depending when this lands relative to the dev->main merge that introduces Nucleaze to main, we might not need a new CHANGELOG.md entry.