### PR TITLE
Disable Tower run-monitoring observer in test_run profile (fix benchmark CI hang)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Make `DOWNLOAD_VIRAL_GENOMES` retry the dehydrated `datasets download` step with exponential backoff, so a transient NCBI stream error there no longer aborts the task. (#828)
 - Fix the `Show version info` step in the manual-reset workflow, which failed on non-checked-out branch refs. (#805)
 - Add `set -euo pipefail` to the `BLASTN` module. (#838)
-- Disable the Seqera Platform (Tower) run-monitoring observer in the `test_run` profile (`tower.enabled = false`). It was auto-enabled by `TOWER_ACCESS_TOKEN` (present for Wave container auth), but on the pinned Nextflow `25.10.4` its `onFlowComplete()` PUT lacks an HTTP read timeout and intermittently hangs JVM exit after the workflow completes, timing out `benchmark-illumina-100M` CI ([nextflow-io/nextflow#6885](https://github.com/nextflow-io/nextflow/issues/6885)). Wave still authenticates from the environment token independently. (#PRNUM)
+- Disable the Seqera Platform (Tower) run-monitoring observer in the `test_run` profile (`tower.enabled = false`). It was auto-enabled by `TOWER_ACCESS_TOKEN` (present for Wave container auth), but on the pinned Nextflow `25.10.4` its `onFlowComplete()` PUT lacks an HTTP read timeout and intermittently hangs JVM exit after the workflow completes, timing out `benchmark-illumina-100M` CI ([nextflow-io/nextflow#6885](https://github.com/nextflow-io/nextflow/issues/6885)). Wave still authenticates from the environment token independently. (#876)
 
 ## Cleanup and best practice
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Make `DOWNLOAD_VIRAL_GENOMES` retry the dehydrated `datasets download` step with exponential backoff, so a transient NCBI stream error there no longer aborts the task. (#828)
 - Fix the `Show version info` step in the manual-reset workflow, which failed on non-checked-out branch refs. (#805)
 - Add `set -euo pipefail` to the `BLASTN` module. (#838)
+- Disable the Seqera Platform (Tower) run-monitoring observer in the `test_run` profile (`tower.enabled = false`). It was auto-enabled by `TOWER_ACCESS_TOKEN` (present for Wave container auth), but on the pinned Nextflow `25.10.4` its `onFlowComplete()` PUT lacks an HTTP read timeout and intermittently hangs JVM exit after the workflow completes, timing out `benchmark-illumina-100M` CI ([nextflow-io/nextflow#6885](https://github.com/nextflow-io/nextflow/issues/6885)). Wave still authenticates from the environment token independently. (#PRNUM)
 
 ## Cleanup and best practice
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Make `DOWNLOAD_VIRAL_GENOMES` retry the dehydrated `datasets download` step with exponential backoff, so a transient NCBI stream error there no longer aborts the task. (#828)
 - Fix the `Show version info` step in the manual-reset workflow, which failed on non-checked-out branch refs. (#805)
 - Add `set -euo pipefail` to the `BLASTN` module. (#838)
-- Disable the Seqera Platform (Tower) run-monitoring observer in the `test_run` profile (`tower.enabled = false`). It was auto-enabled by `TOWER_ACCESS_TOKEN` (present for Wave container auth), but on the pinned Nextflow `25.10.4` its `onFlowComplete()` PUT lacks an HTTP read timeout and intermittently hangs JVM exit after the workflow completes, timing out `benchmark-illumina-100M` CI ([nextflow-io/nextflow#6885](https://github.com/nextflow-io/nextflow/issues/6885)). Wave still authenticates from the environment token independently. (#876)
+- Disable the Tower run-monitoring observer in the `test_run` profile (`tower.enabled = false`) to stop benchmark CI hangs caused by Nextflow 25.10.4's timeout-less `onFlowComplete()` PUT ([nextflow-io/nextflow#6885](https://github.com/nextflow-io/nextflow/issues/6885)); Wave still uses the env token. (#876)
 
 ## Cleanup and best practice
 

--- a/configs/profiles.config
+++ b/configs/profiles.config
@@ -55,6 +55,14 @@ profiles {
         process { withLabel: 'use_scratch' { scratch = true } }
     }
     test_run { // Testing only
+        // Disable the Seqera Platform (Tower) run-monitoring observer. It is
+        // auto-enabled whenever TOWER_ACCESS_TOKEN is in the environment (which CI
+        // sets for Wave container auth / API rate limits), but on the pinned
+        // Nextflow 25.10.4 its onFlowComplete() PUT has no HTTP read timeout and
+        // intermittently hangs JVM exit after the workflow completes, timing out
+        // benchmark CI (nextflow-io/nextflow#6885). Wave still reads the token from
+        // the environment independently of this observer.
+        tower.enabled = false
         fusion.enabled = true
         fusion.exportStorageCredentials = false
         aws.batch.jobRole = params.batch_job_role ?: null

--- a/configs/profiles.config
+++ b/configs/profiles.config
@@ -55,13 +55,8 @@ profiles {
         process { withLabel: 'use_scratch' { scratch = true } }
     }
     test_run { // Testing only
-        // Disable the Seqera Platform (Tower) run-monitoring observer. It is
-        // auto-enabled whenever TOWER_ACCESS_TOKEN is in the environment (which CI
-        // sets for Wave container auth / API rate limits), but on the pinned
-        // Nextflow 25.10.4 its onFlowComplete() PUT has no HTTP read timeout and
-        // intermittently hangs JVM exit after the workflow completes, timing out
-        // benchmark CI (nextflow-io/nextflow#6885). Wave still reads the token from
-        // the environment independently of this observer.
+        // Disable Platform (Tower) run-monitoring: on Nextflow 25.10.4 its onFlowComplete()
+        // PUT can hang JVM exit (nextflow-io/nextflow#6885). Wave still uses the env token.
         tower.enabled = false
         fusion.enabled = true
         fusion.exportStorageCredentials = false


### PR DESCRIPTION
Release fix for the intermittent `benchmark-illumina-100M` CI hang seen on the 3.2.2.0 release PR (#874). No version bump — part of the in-flight 3.2.2.0 release, so it lands under the existing `v3.2.2.0` CHANGELOG heading (this is a `release/…` branch, so `check-version` accepts the non-`-dev` version).

**Root cause.** The benchmark/chain runs under `-profile test_run` with `TOWER_ACCESS_TOKEN` set in the CI environment (needed for Wave container auth + API rate limits). Merely having that token in the env auto-enables Nextflow's Seqera Platform (Tower) run-monitoring observer — nothing here requests run monitoring. On the pinned Nextflow **25.10.4**, `TowerClient.onFlowComplete()` issues an HTTP PUT to the Tower API with **no read timeout**; when that connection goes stale it blocks the main thread forever, so the JVM never exits after the workflow completes. The benchmark work finishes, then the head node hangs until the 120-min job timeout cancels it. This is upstream bug **[nextflow-io/nextflow#6885](https://github.com/nextflow-io/nextflow/issues/6885)** (fixed in a later Nextflow; the read-timeout config doesn't exist on 25.10.4).

**Fix.** `tower.enabled = false` in the `test_run` profile. With the observer off, `onFlowComplete()` is never called, so the stale-connection PUT can't hang. Wave keeps working — it reads `TOWER_ACCESS_TOKEN` from the environment independently of the run-monitoring observer. The only loss is the (unneeded-for-CI) Seqera Platform watch URL.

**Scope.** Limited to `test_run` (benchmarks / chained integration test). Production/other profiles are untouched; if the same hang ever appears on a non-benchmark tokened run, the fix would be upgrading Nextflow past 25.10.4.

**Changes:**
- `configs/profiles.config`: add `tower.enabled = false` to the `test_run` profile (with an explanatory comment).
- `CHANGELOG.md`: note under `v3.2.2.0` Bugfixes.

Verification plan to run before un-drafting: a `benchmark-on-demand` run confirming (a) `tower.enabled = false` overrides the env-var auto-enable (no "Creating Seqera Platform observer" in the log), (b) Wave/Fusion still authenticate and pull containers, and (c) the job exits cleanly after downstream completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)