### PR TITLE
Disable Tower run-monitoring observer in test_run profile (fix benchmark CI hang)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Make `DOWNLOAD_VIRAL_GENOMES` retry the dehydrated `datasets download` step with exponential backoff, so a transient NCBI stream error there no longer aborts the task. (#828)
 - Fix the `Show version info` step in the manual-reset workflow, which failed on non-checked-out branch refs. (#805)
 - Add `set -euo pipefail` to the `BLASTN` module. (#838)
-- Disable the Seqera Platform (Tower) run-monitoring observer in the `test_run` profile (`tower.enabled = false`). It was auto-enabled by `TOWER_ACCESS_TOKEN` (present for Wave container auth), but on the pinned Nextflow `25.10.4` its `onFlowComplete()` PUT lacks an HTTP read timeout and intermittently hangs JVM exit after the workflow completes, timing out `benchmark-illumina-100M` CI ([nextflow-io/nextflow#6885](https://github.com/nextflow-io/nextflow/issues/6885)). Wave still authenticates from the environment token independently. (#PRNUM)
+- Disable the Seqera Platform (Tower) run-monitoring observer in the `test_run` profile (`tower.enabled = false`). It was auto-enabled by `TOWER_ACCESS_TOKEN` (present for Wave container auth), but on the pinned Nextflow `25.10.4` its `onFlowComplete()` PUT lacks an HTTP read timeout and intermittently hangs JVM exit after the workflow completes, timing out `benchmark-illumina-100M` CI ([nextflow-io/nextflow#6885](https://github.com/nextflow-io/nextflow/issues/6885)). Wave still authenticates from the environment token independently. (#876)
 
 ## Cleanup and best practice
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Make `DOWNLOAD_VIRAL_GENOMES` retry the dehydrated `datasets download` step with exponential backoff, so a transient NCBI stream error there no longer aborts the task. (#828)
 - Fix the `Show version info` step in the manual-reset workflow, which failed on non-checked-out branch refs. (#805)
 - Add `set -euo pipefail` to the `BLASTN` module. (#838)
+- Disable the Seqera Platform (Tower) run-monitoring observer in the `test_run` profile (`tower.enabled = false`). It was auto-enabled by `TOWER_ACCESS_TOKEN` (present for Wave container auth), but on the pinned Nextflow `25.10.4` its `onFlowComplete()` PUT lacks an HTTP read timeout and intermittently hangs JVM exit after the workflow completes, timing out `benchmark-illumina-100M` CI ([nextflow-io/nextflow#6885](https://github.com/nextflow-io/nextflow/issues/6885)). Wave still authenticates from the environment token independently. (#PRNUM)
 
 ## Cleanup and best practice
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Make `DOWNLOAD_VIRAL_GENOMES` retry the dehydrated `datasets download` step with exponential backoff, so a transient NCBI stream error there no longer aborts the task. (#828)
 - Fix the `Show version info` step in the manual-reset workflow, which failed on non-checked-out branch refs. (#805)
 - Add `set -euo pipefail` to the `BLASTN` module. (#838)
-- Disable the Seqera Platform (Tower) run-monitoring observer in the `test_run` profile (`tower.enabled = false`). It was auto-enabled by `TOWER_ACCESS_TOKEN` (present for Wave container auth), but on the pinned Nextflow `25.10.4` its `onFlowComplete()` PUT lacks an HTTP read timeout and intermittently hangs JVM exit after the workflow completes, timing out `benchmark-illumina-100M` CI ([nextflow-io/nextflow#6885](https://github.com/nextflow-io/nextflow/issues/6885)). Wave still authenticates from the environment token independently. (#876)
+- Disable the Tower run-monitoring observer in the `test_run` profile (`tower.enabled = false`) to stop benchmark CI hangs caused by Nextflow 25.10.4's timeout-less `onFlowComplete()` PUT ([nextflow-io/nextflow#6885](https://github.com/nextflow-io/nextflow/issues/6885)); Wave still uses the env token. (#876)
 
 ## Cleanup and best practice
 

--- a/configs/profiles.config
+++ b/configs/profiles.config
@@ -55,6 +55,14 @@ profiles {
         process { withLabel: 'use_scratch' { scratch = true } }
     }
     test_run { // Testing only
+        // Disable the Seqera Platform (Tower) run-monitoring observer. It is
+        // auto-enabled whenever TOWER_ACCESS_TOKEN is in the environment (which CI
+        // sets for Wave container auth / API rate limits), but on the pinned
+        // Nextflow 25.10.4 its onFlowComplete() PUT has no HTTP read timeout and
+        // intermittently hangs JVM exit after the workflow completes, timing out
+        // benchmark CI (nextflow-io/nextflow#6885). Wave still reads the token from
+        // the environment independently of this observer.
+        tower.enabled = false
         fusion.enabled = true
         fusion.exportStorageCredentials = false
         aws.batch.jobRole = params.batch_job_role ?: null

--- a/configs/profiles.config
+++ b/configs/profiles.config
@@ -55,13 +55,8 @@ profiles {
         process { withLabel: 'use_scratch' { scratch = true } }
     }
     test_run { // Testing only
-        // Disable the Seqera Platform (Tower) run-monitoring observer. It is
-        // auto-enabled whenever TOWER_ACCESS_TOKEN is in the environment (which CI
-        // sets for Wave container auth / API rate limits), but on the pinned
-        // Nextflow 25.10.4 its onFlowComplete() PUT has no HTTP read timeout and
-        // intermittently hangs JVM exit after the workflow completes, timing out
-        // benchmark CI (nextflow-io/nextflow#6885). Wave still reads the token from
-        // the environment independently of this observer.
+        // Disable Platform (Tower) run-monitoring: on Nextflow 25.10.4 its onFlowComplete()
+        // PUT can hang JVM exit (nextflow-io/nextflow#6885). Wave still uses the env token.
         tower.enabled = false
         fusion.enabled = true
         fusion.exportStorageCredentials = false


### PR DESCRIPTION
Standard-branch replacement for #876 (which was on a `release/…` branch). **Deferred: not part of 3.2.2.0** — since #874's CI went green, this is saved for after the dev→main merge.

**Root cause.** The benchmark/chain runs under `-profile test_run` with `TOWER_ACCESS_TOKEN` in the env (for Wave container auth + rate limits). That token alone auto-enables Nextflow's Seqera Platform (Tower) run-monitoring observer. On the pinned Nextflow **25.10.4**, `TowerClient.onFlowComplete()` does an HTTP PUT with **no read timeout**; on a stale connection it blocks the main thread forever, so the JVM never exits after the workflow completes and the benchmark job hangs to its 2h timeout. Upstream: **[nextflow-io/nextflow#6885](https://github.com/nextflow-io/nextflow/issues/6885)** (intermittent / timing-dependent; fixed in a later Nextflow).

**Fix.** `tower.enabled = false` in the `test_run` profile — the observer is never created, so `onFlowComplete()` can't hang. Wave still reads the token from the env independently.

**Scope.** `test_run` only (benchmarks / chained test). If the hang ever appears on a non-benchmark tokened run, the real fix is upgrading Nextflow past 25.10.4.

**Before merging (post-3.2.2.0):** rebase onto the reset `dev` and bump to the next `-dev` version (e.g. `3.2.2.1-dev`), moving the CHANGELOG entry under that heading. Until then this is a held draft and `check-version` will be red (non-release branch + non-`-dev` version) — expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)