### PR TITLE
Update check-release workflow to verify latest index does not have -dev version

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -22,7 +22,11 @@ jobs:
 
       - name: Check benchmark index is not a -dev build
         run: |
-          version=$(aws s3 cp s3://nao-testing/mgs-workflow-test/index-latest/output/logging/pyproject.toml - | grep -m1 '^version = ' | cut -d'"' -f2)
+          if ! pyproject=$(aws s3 cp s3://nao-testing/mgs-workflow-test/index-latest/output/logging/pyproject.toml -); then
+            echo "::error::could not read index-latest pyproject.toml from s3://nao-testing/mgs-workflow-test/index-latest/output/logging/; ensure the benchmark index exists and OIDC credentials are available"
+            exit 1
+          fi
+          version=$(echo "$pyproject" | grep -m1 '^version = ' | cut -d'"' -f2 || true)
           echo "Benchmark index version: $version"
           if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::index-latest version '$version' is not a 4-part release version (dev-built or malformed); rebuild from a tagged release before merging to main"

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -4,11 +4,30 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   check-release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Check benchmark index is not a -dev build
+        run: |
+          version=$(aws s3 cp s3://nao-testing/mgs-workflow-test/index-latest/output/logging/pyproject.toml - | grep -m1 '^version = ' | cut -d'"' -f2)
+          echo "Benchmark index version: $version"
+          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::index-latest version '$version' is not a 4-part release version (dev-built or malformed); rebuild from a tagged release before merging to main"
+            exit 1
+          fi
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v3.2.2.1-dev
 
 - Add `bin/compare_downstream_runs.py` / `bin/downstream_metrics.py` and the paired `benchmark-downstream` agent skill for comparing two DOWNSTREAM runs (e.g. across a pipeline change) from their existing output files. Developer/agent tooling only: reads existing DOWNSTREAM outputs and adds no new pipeline outputs, behavior, or schema changes.
+- Add check to `check-release` workflow that index published to `s3://nao-testing/mgs-workflow-test/index-latest/` does not include `-dev` suffix.
 
 # v3.2.2.0
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -135,8 +135,9 @@ Runs on PRs to `main` and `stable`. Checks the age of the benchmark index at `s3
 ### Release readiness check (`check-release.yml`)
 
 Runs only on PRs to `main`. Verifies that:
-1. The version in `pyproject.toml` has a corresponding changelog section
-2. The version has not already been released on GitHub
+1. The benchmark index at `s3://nao-testing/mgs-workflow-test/index-latest/` was built from a tagged release (its `pyproject.toml` version is a 4-part release version, not a `-dev` build)
+2. The version in `pyproject.toml` has a corresponding changelog section
+3. The version has not already been released on GitHub
 
 This check runs unconditionally (no path filtering).
 


### PR DESCRIPTION
Previously, it was possible to publish a new index to `s3://nao-testing/mgs-workflow-test/index-latest/` built from an unreleased `-dev` pipeline version. Now, we require this index - which is used in the long-running pre-release integration tests - to have been built using a strict 4-point semantic version of the pipeline code.

## Validation

- I validated this bash code against some `-dev` and non`-dev` indexes in the private SB bucket to confirm it passes and fails as expected.

## Design decisions

- It felt like overkill to write testable Python functions given the simple behavior here, but if a review requests it I would be happy to do so.
- I did not support legacy indexes with no `pyproject.toml` files since we do not publish those anymore.

## Infrastructure dependency

- This adds a new dependency to `check-release.yml`: it now assumes an AWS OIDC role (`AWS_OIDC_ROLE_ARN`, the same role `check-index-age.yml` uses) and reads from `s3://nao-testing/` on every PR to `main`. If AWS/OIDC is unavailable or the `index-latest` object is missing, release PRs to `main` will be blocked. Under the default `bash -eo pipefail`, a missing object aborts the step with a raw `aws` 404 rather than the friendly `::error::` message; impact is limited since `check-release` runs only on maintainer-driven PRs to `main`.