### PR TITLE
Docs: warn that rust_tools_version defaults to :main for dev builds/runs

### DIFF
--- a/.claude/skills/benchmark-index/SKILL.md
+++ b/.claude/skills/benchmark-index/SKILL.md
@@ -131,6 +131,7 @@ Two reminders that are not obvious from the template alone:
 
 - Trust the script's annotations. If a row has `covered_by_hard_exclude = 2169574`, the script verified the lineage; do not manually re-classify. The "Categorization buckets" glossary below explains what each script-emitted label means.
 - Err on the side of inclusion in §Recommendations. Every plausible candidate change should appear, even at `low` confidence. In particular: any stale reference in §1, every uncovered promotion in §4, and every override policy gap in §4 should each appear as a candidate change.
+- Sanity-check `rust_tools_version` in `params_changes.tsv`. It selects the Rust-tools container used to build the index and defaults to `main`, so a value of `main` on an index built from a `dev` checkout means the index was built with main's (older) Rust tools by accident — flag it in §5, and note that RUN must later use a matching version.
 
 ### Step 6 - Hand off
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -110,6 +110,9 @@ nextflow run REPO_DIR \
 
 Replace `<BASE_DIR>` with the directory (likely on S3) where you want to store your index files, and `<BATCH_QUEUE_NAME>` with your AWS Batch job queue name. (You shouldn't need to modify anything else at this stage. However, if you'd like to, you can [learn more about what each parameter does here](./config.md).)
 
+> [!NOTE]
+> The Rust-tools container version defaults to `main`. When building an index from an unmerged `dev` checkout (or any branch not yet on `main`), pass `--rust_tools_version dev` (or set `export RUST_TOOLS_VERSION=dev`) so the index is built with dev's Rust tools rather than the older versions pinned on `main`. Use the same version when you later run the pipeline against this index.
+
 > [!TIP]
 > You don't need to point `nextflow run` at `main.nf` any other workflow file; pointing to the directory will cause Nextflow to automatically run `main.nf` from that directory.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -91,6 +91,9 @@ nextflow run <PATH/TO/PIPELINE/DIR> \
 
 where `<PATH/TO/PIPELINE/DIR>` specifies the path to the directory containing this repository's `main.nf` file. Any `params.*` value in the config file can be overridden with `--<param>` on the command line. If you copied the config file into the launch directory as `nextflow.config`, you can omit the `-c` flag.
 
+> [!NOTE]
+> The Rust-tools container version defaults to `main`. If you're running an unmerged `dev` checkout (or a branch not yet on `main`), add `--rust_tools_version dev` (or set `export RUST_TOOLS_VERSION=dev`) so the pipeline uses dev's Rust tools. This must match the version used to build the index you point `--ref_dir` at.
+
 > [!TIP]
 > To use a non-default profile, add `-profile <PROFILE_NAME>` to the command.
 


### PR DESCRIPTION
The Rust-tools container version resolves to `System.getenv("RUST_TOOLS_VERSION") ?: "main"`, so building an index or running the pipeline from an unmerged `dev` checkout silently uses main's *older* Rust tools rather than dev's. The only existing mention of the knob is in `docs/developer.md` (framed around local Rust development), so a user following the standard index-build / run instructions has no signal that they need to set it. This closes that docs gap; the complementary runtime fail-fast guard is tracked separately (#873 / COMP-2734).

**Changes:**
- `docs/installation.md` §7 (index build): add a `[!NOTE]` that the Rust-tools version defaults to `main`, and to pass `--rust_tools_version dev` (or `export RUST_TOOLS_VERSION=dev`) when building from an unmerged `dev` checkout — reusing the same version at run time.
- `docs/usage.md` §3 (running the pipeline): matching run-side `[!NOTE]`, noting the version must match the one used to build the index at `--ref_dir`.
- `.claude/skills/benchmark-index/SKILL.md`: add a Step 5 reviewer reminder to sanity-check `rust_tools_version` in `params_changes.tsv` — a `main` value on a dev-built index means it accidentally used main's older Rust tools.

Docs-only change: all three files are Markdown, so `check-changelog.yml`'s docs-only filter exempts it and no CHANGELOG entry / version bump is required (verified via pr-preflight).

Closes #872.

Generated with [Claude Code](https://claude.com/claude-code)