### PR TITLE
ci(rust-tools): publish stable-tagged container image

### DIFF
--- a/.github/workflows/rust-tools.yml
+++ b/.github/workflows/rust-tools.yml
@@ -2,7 +2,7 @@ name: Rust Tools CI
 
 on:
   push:
-    branches: [dev, main]
+    branches: [dev, main, stable]
   pull_request:
 
 permissions:
@@ -107,12 +107,13 @@ jobs:
           aws-region: us-east-1
 
       - name: Push to ECR
+        env:
+          BRANCH_TAG: ${{ github.ref_name }}
         run: |
           aws ecr-public get-login-password --region us-east-1 | \
             docker login --username AWS --password-stdin public.ecr.aws
 
-          BRANCH_TAG=${{ github.ref == 'refs/heads/main' && 'main' || 'dev' }}
           REPO=public.ecr.aws/q0n1c7g8/nao-mgs-workflow/rust-tools
 
-          docker tag nao-rust-tools:local $REPO:$BRANCH_TAG
-          docker push $REPO:$BRANCH_TAG
+          docker tag nao-rust-tools:local "$REPO:$BRANCH_TAG"
+          docker push "$REPO:$BRANCH_TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add `bin/compare_downstream_runs.py` / `bin/downstream_metrics.py` and the paired `benchmark-downstream` agent skill for comparing two DOWNSTREAM runs (e.g. across a pipeline change) from their existing output files. Developer/agent tooling only: reads existing DOWNSTREAM outputs and adds no new pipeline outputs, behavior, or schema changes.
 - Pass `-t ${task.cpus}` to minimap2 in the `MINIMAP2` and `MINIMAP2_NON_STREAMED` modules.
 - Add a `.github/actions/trivy-scan` composite action and a PR-less invocation mode for the `triage-trivy` skill (developer/CI tooling; no pipeline change).
+- Publish a `rust-tools:stable` container image by adding `stable` to the `rust-tools.yml` push triggers and deriving the ECR image tag from the branch name (CI only; no pipeline change).
 
 # v3.2.2.0
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -104,7 +104,7 @@ docker push public.ecr.aws/q0n1c7g8/nao-mgs-workflow/rust-tools:dev-$(whoami)
 nextflow run main.nf --rust_tools_version dev-$(whoami) -profile batch ...
 ```
 
-**Note:** The container is automatically rebuilt by GitHub Actions when Rust source files change on `dev` or `main`. Use `--rust_tools_version dev` to test against the dev branch build.
+**Note:** The container is automatically rebuilt by GitHub Actions when Rust source files change on `dev`, `main`, or `stable`, and is published to ECR under a tag matching the branch name (`rust-tools:dev`, `rust-tools:main`, `rust-tools:stable`). Use `--rust_tools_version dev` to test against the dev branch build.
 
 ## Containers
 


### PR DESCRIPTION
CI that builds and pushes the Rust-tools container to public ECR only ever produced `:main` and `:dev` tags — never `:stable`. The nao-mgs-orchestrator E2E matrix runs a `stable` leg that pulls `rust-tools:stable` (via `--rust_tools_version stable`); because that tag never existed, the `rust_tools`-labelled `PROCESS_VSEARCH_CLUSTER_OUTPUT` step couldn't start and the stable leg failed. This closes that gap.

**Changes:**
- `.github/workflows/rust-tools.yml`: add `stable` to the push-trigger branches, and derive the ECR tag from `github.ref_name` (via an `env:` var, per the repo's no-`${{ }}`-in-`run:` rule) instead of a hardcoded main/dev ternary. Because the trigger is restricted to `{dev, main, stable}`, `github.ref_name` is exactly the tag to publish. Build/scan/paths-filter jobs are unchanged.
- `docs/developer.md`: note that `stable` also triggers a rebuild and that images are published under a branch-matching tag.
- CHANGELOG entry under the existing `v3.2.2.1-dev` heading (point-level, CI-only; no pipeline/index/schema change).

Note: merging this does **not** retroactively create `rust-tools:stable` — the image is published only on the next qualifying push/reset to `stable`. The tag was seeded manually (built from `stable`'s own source, which differs from `main`'s: nucleaze v1.4.2 vs v1.5.0-alpha, and no pigz) to unblock the E2E stable leg now. The pipeline default in `configs/containers.config` remains `main`; only the orchestrator's stable leg sets `--rust_tools_version stable`.

Generated with [Claude Code](https://claude.com/claude-code)