### PR TITLE
Fix BBDUK interleaved flag stored as unresolved dataflow channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add a `.github/actions/trivy-scan` composite action and a PR-less invocation mode for the `triage-trivy` skill (developer/CI tooling; no pipeline change).
 - Publish a `rust-tools:stable` container image by adding `stable` to the `rust-tools.yml` push triggers and deriving the ECR image tag from the branch name (CI only; no pipeline change).
 - Gate the Trivy container vulnerability scan (`scan-containers`) behind a paths-filter so it only runs when `containers/**` or `configs/containers.config` change.
+- Fix the ribosomal `BBDUK` step in `PROFILE` storing the `interleaved` flag as an unresolved dataflow channel inside its params map. The stored `DataflowVariable` was always truthy inside the process (so single-end reads were incorrectly treated as interleaved) and could not be Kryo-serialized, which disabled `-resume` for the process. It now resolves to a plain boolean by mapping over the `single_end` value channel. Changes ribosomal separation results for single-end short-read runs; paired-end results are unaffected.
 
 # v3.2.2.0
 

--- a/subworkflows/local/profile/main.nf
+++ b/subworkflows/local/profile/main.nf
@@ -37,7 +37,13 @@ workflow PROFILE {
             noribo_in = ribo_ch.reads_unmapped
         } else {
             ribo_path = "${params_map.ref_dir}/results/ribo-ref-concat.fasta.gz"
-            ribo_bbduk_params = params_map + [interleaved: single_end.map { v -> !v }]
+            // Build the params map by mapping over the single_end value channel so
+            // interleaved resolves to a plain boolean inside the map. Adding the
+            // channel directly (params_map + [interleaved: single_end.map{...}])
+            // stores a DataflowVariable in the map, which is always truthy inside
+            // the process (so single-end reads were wrongly treated as interleaved)
+            // and cannot be Kryo-serialized (breaking -resume for BBDUK).
+            ribo_bbduk_params = single_end.map { se -> params_map + [interleaved: !se] }
             ribo_ch = BBDUK(reads_ch, ribo_path, ribo_bbduk_params)
             ribo_in = ribo_ch.match
             noribo_in = ribo_ch.nomatch


### PR DESCRIPTION
   In `PROFILE`, the ribosomal `BBDUK` params map was built as
  `params_map + [interleaved: single_end.map { v -> !v }]`. Because
  `single_end` is a value channel, `.map { }` returns another channel, so the
  map ends up holding a `DataflowVariable` object rather than a boolean. That
  object is never unwrapped when the map is passed as a `val` process input,
  which causes two problems: inside the process a non-null `DataflowVariable`
  is always truthy, so `interleaved` was effectively hard-coded to `true`
  (single-end reads were treated as interleaved); and the object holds a
  `ReferenceQueue` that Kryo cannot serialize, so the task context failed to
  serialize and `-resume` was silently disabled for every `BBDUK` task.

  The fix keeps `interleaved` in the params map — as requested — by mapping
  *over* the `single_end` value channel so the map itself becomes the channel
  unwraps the singleton to the plain map, so `interleaved` is a real boolean:
  serializable (resume works) and correct per run endedness. No change to the
  `BBDUK` module was needed.

  **Changes:**
  - `subworkflows/local/profile/main.nf`: build `ribo_bbduk_params` as `single_end.map { se -> params_map +

  **Changes:**
  - `subworkflows/local/profile/main.nf`: build `ribo_bbduk_params` as `single_end.map { se -> params_map + [interleaved: !se] }` instead of embedding `single_end.map { }` as a map value, so the flag resolves to a
  boolean rather than a `DataflowVariable`.
  - `CHANGELOG.md`: add an entry under the existing `v3.2.3.0-dev` heading. No version bump — dev is already at a Results-level `-dev` version, and this change is at most Results-level (it changes ribosomal
  separation for single-end short-read runs; paired-end runs are unaffected).

  Generated with [Claude Code](https://claude.com/claude-code)