### PR TITLE
Add weekly scheduled Trivy scan + auto-triage workflow

### DIFF
--- a/.github/workflows/scheduled-trivy-triage.yml
+++ b/.github/workflows/scheduled-trivy-triage.yml
@@ -5,6 +5,9 @@
 #   - secrets.CI_AGENT_ANTHROPIC_API_KEY               (Claude API key; ORGANIZATION secret, visible to this repo)
 #   - vars.DETECTION_ROUTINE_SCANNER_APP_ID            (GitHub App id for the triage bot)
 #   - secrets.DETECTION_ROUTINE_SCANNER_PRIVATE_KEY    (GitHub App private key)
+#
+# The triage-bot GitHub App needs contents:write, pull-requests:write, and
+# issues:write: it pushes a branch, opens the triage PR, and files tracking issues.
 
 name: Scheduled Trivy scan and triage
 
@@ -65,10 +68,20 @@ jobs:
             the `trivy_results` directory in the workspace. Pass that directory to
             the skill as the scan results directory and do NOT re-run the scan.
 
-            Follow the skill to triage the HIGH/CRITICAL findings and open a single
-            DRAFT triage pull request against `dev` with the appropriate remediation
-            per finding (apply a patch, add a `.trivyignore` entry, or escalate the
-            finding as an issue), exactly as the skill specifies.
+            Follow the skill to triage the HIGH/CRITICAL findings, applying the
+            appropriate remediation per finding (apply a patch, add a `.trivyignore`
+            entry, or escalate) exactly as the skill specifies.
+
+            Then route the results so a human notices them:
+
+            - If any finding was patched or ignored (i.e. there are file changes),
+              open a single DRAFT triage PR against `dev` with those changes.
+            - Always open one GitHub tracking issue summarizing every finding and
+              its outcome. Link the triage PR from the issue when one was opened,
+              and record any escalated findings in the issue. This issue is the
+              entry point for our triage queue, so open it even when there is a PR.
+            - If every finding was escalated (no file changes), open the tracking
+              issue only and do NOT open an empty PR.
 
             This is a scheduled run with no associated pull request or issue, so do
             not look for or reference any PR/issue event context.

--- a/.github/workflows/scheduled-trivy-triage.yml
+++ b/.github/workflows/scheduled-trivy-triage.yml
@@ -1,0 +1,72 @@
+# Weekly scheduled Trivy container scan + auto-triage of HIGH/CRITICAL findings.
+#
+# Required configuration:
+#   - secrets.AWS_OIDC_ROLE_ARN                        (OIDC role for ECR Public, used by trivy-scan)
+#   - secrets.CI_AGENT_ANTHROPIC_API_KEY               (Claude API key; ORGANIZATION secret, visible to this repo)
+#   - vars.DETECTION_ROUTINE_SCANNER_APP_ID            (GitHub App id for the triage bot)
+#   - secrets.DETECTION_ROUTINE_SCANNER_PRIVATE_KEY    (GitHub App private key)
+
+name: Scheduled Trivy scan and triage
+
+# Every Monday (06:00 UTC)
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch: {}
+
+# The triage PR is created with the GitHub App token; workflow-level permissions
+# stay minimal. `id-token: write` is for the trivy-scan action's OIDC AWS auth.
+permissions:
+  contents: read
+  id-token: write
+
+# Schedule and manual dispatch can otherwise overlap and race to open duplicate
+# triage PRs; serialize and cancel any in-progress run.
+concurrency:
+  group: scheduled-trivy-triage
+  cancel-in-progress: true
+
+jobs:
+  scan-and-triage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout dev
+        uses: actions/checkout@v4
+        with:
+          ref: dev
+
+      - name: Run Trivy scan
+        id: scan
+        uses: ./.github/actions/trivy-scan
+        with:
+          aws-role-arn: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+
+      - name: Generate triage-bot app token
+        id: app-token
+        if: steps.scan.outputs.found == 'true'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.DETECTION_ROUTINE_SCANNER_APP_ID }}
+          private-key: ${{ secrets.DETECTION_ROUTINE_SCANNER_PRIVATE_KEY }}
+
+      - name: Triage HIGH/CRITICAL findings
+        if: steps.scan.outputs.found == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          github_token: ${{ steps.app-token.outputs.token }}
+          anthropic_api_key: ${{ secrets.CI_AGENT_ANTHROPIC_API_KEY }}
+          prompt: |
+            Run the `triage-trivy` skill in SCHEDULED MODE against the `dev` branch.
+
+            The Trivy scan has already run for this workflow: its results are in
+            the `trivy_results` directory in the workspace. Pass that directory to
+            the skill as the scan results directory and do NOT re-run the scan.
+
+            Follow the skill to triage the HIGH/CRITICAL findings and open a single
+            DRAFT triage pull request against `dev` with the appropriate remediation
+            per finding (apply a patch, add a `.trivyignore` entry, or escalate the
+            finding as an issue), exactly as the skill specifies.
+
+            This is a scheduled run with no associated pull request or issue, so do
+            not look for or reference any PR/issue event context.

--- a/.github/workflows/scheduled-trivy-triage.yml
+++ b/.github/workflows/scheduled-trivy-triage.yml
@@ -21,10 +21,12 @@ permissions:
   id-token: write
 
 # Schedule and manual dispatch can otherwise overlap and race to open duplicate
-# triage PRs; serialize and cancel any in-progress run.
+# triage PRs. cancel-in-progress is false so a second run queues behind the active
+# one rather than cancelling it mid-triage, after it has pushed a branch or opened
+# a PR but before it finishes.
 concurrency:
   group: scheduled-trivy-triage
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   scan-and-triage:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add a `.github/actions/trivy-scan` composite action and a PR-less invocation mode for the `triage-trivy` skill (developer/CI tooling; no pipeline change).
 - Publish a `rust-tools:stable` container image by adding `stable` to the `rust-tools.yml` push triggers and deriving the ECR image tag from the branch name (CI only; no pipeline change).
 - Gate the Trivy container vulnerability scan (`scan-containers`) behind a paths-filter so it only runs when `containers/**` or `configs/containers.config` change.
+- Add a weekly scheduled Trivy container scan (`.github/workflows/scheduled-trivy-triage.yml`) that invokes the `triage-trivy` skill via `claude-code-action` to open a draft triage PR against `dev` when HIGH/CRITICAL findings are present (CI tooling only; no pipeline change).
 
 # v3.2.2.0
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -81,6 +81,10 @@ Runs Rust unit tests and builds the `nao-rust-tools` container when Rust source 
 
 Scans all containers defined in `configs/containers.config` for security vulnerabilities using [Trivy](https://trivy.dev/).
 
+### Scheduled Trivy scan and triage (`scheduled-trivy-triage.yml`)
+
+Runs the same Trivy scan on a weekly schedule (Mondays 06:00 UTC) rather than per-PR, so HIGH/CRITICAL container CVEs are caught even in weeks with no container-touching PR. The job checks out and scans `dev`; when the scan reports HIGH/CRITICAL findings, it invokes the `triage-trivy` skill (in its PR-less scheduled mode) via `anthropics/claude-code-action` to open a draft triage PR against `dev`.
+
 ### Version and changelog checks
 
 These checks run unconditionally (no path filtering) to ensure version consistency across the codebase.


### PR DESCRIPTION
Adds a scheduled counterpart to the existing PR-triggered `scan-containers` job so that HIGH/CRITICAL container CVEs are caught even on weeks with no container-touching PRs. When the weekly scan finds actionable findings, it invokes the `triage-trivy` skill (in its scheduled/PR-less mode) via `claude-code-action` to open a draft triage PR against `dev`, rather than just surfacing a red check.

**Changes:**
- New `.github/workflows/scheduled-trivy-triage.yml`: Monday 06:00 UTC cron + `workflow_dispatch`; reuses the `./.github/actions/trivy-scan` composite action and gates the triage step on its `found` output.
- The triage run always opens a GitHub tracking issue summarizing the findings (so it enters our issue→Linear triage queue and gets noticed) and opens a draft PR only when a finding is patched or ignored; an escalate-only run files the issue and no empty PR.
- Triage PR is opened with a GitHub App token, so workflow-level `permissions` stay minimal (`contents: read`, `id-token: write` for the trivy-scan OIDC AWS auth).
- Added a `concurrency` group with `cancel-in-progress: false` so a second run queues behind the active one (rather than cancelling it mid-triage) and schedule/dispatch can't race to open duplicate triage PRs, plus a 30-minute job timeout.
- CHANGELOG entry under the existing `v3.2.3.0-dev` heading; no version increment (CI-tooling-only, point-level, and `-dev` already reflects the next point release).

**Deployment notes for reviewers:**
- Neither trigger is usable until a copy of this file reaches the **default branch (`main`)**: the `schedule` cron only ever runs `main`'s copy, and `workflow_dispatch` only becomes available once the workflow exists on `main` (after which it can target any branch). In practice, nothing runs until `dev`→`main` promotion at the next release.
- Requires new config before the triage step can run: `secrets.CI_AGENT_ANTHROPIC_API_KEY` (org secret), `vars.DETECTION_ROUTINE_SCANNER_APP_ID`, `secrets.DETECTION_ROUTINE_SCANNER_PRIVATE_KEY`. The App needs `contents: write`, `pull-requests: write`, and `issues: write` (for the tracking issue). `AWS_OIDC_ROLE_ARN` already exists.

Generated with [Claude Code](https://claude.com/claude-code)
